### PR TITLE
Fix #38: share HttpClient across auth/db/storage so RLS sees the user token

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "npm run build && node test/fix-dist-imports.mjs && node test/token-propagation.mjs"
   },
   "keywords": [
     "eurobase",

--- a/sdk/js/src/client.ts
+++ b/sdk/js/src/client.ts
@@ -130,9 +130,9 @@ export function createClient(configOrConnectionString: EurobaseConfig | string):
 
   return {
     auth: authClient,
-    db: new DatabaseClient(config),
+    db: new DatabaseClient(config, http),
     functions: new FunctionsClient(config, http),
-    storage: new StorageClient(config),
+    storage: new StorageClient(config, http),
     realtime: new RealtimeClient(config, http),
     vault: new VaultClient(config),
     async status() {

--- a/sdk/js/src/database.ts
+++ b/sdk/js/src/database.ts
@@ -273,8 +273,8 @@ export class DatabaseClient {
    */
   readonly schema: SchemaClient
 
-  constructor(config: EurobaseConfig) {
-    this.http = httpClient(config)
+  constructor(config: EurobaseConfig, http?: HttpClient) {
+    this.http = http ?? httpClient(config)
     this.schema = new SchemaClient(config)
   }
 

--- a/sdk/js/src/storage.ts
+++ b/sdk/js/src/storage.ts
@@ -81,8 +81,8 @@ export interface SignedUrlOptions {
 export class StorageClient {
   private http: HttpClient
 
-  constructor(config: EurobaseConfig) {
-    this.http = httpClient(config)
+  constructor(config: EurobaseConfig, http?: HttpClient) {
+    this.http = http ?? httpClient(config)
   }
 
   /**

--- a/sdk/js/test/fix-dist-imports.mjs
+++ b/sdk/js/test/fix-dist-imports.mjs
@@ -1,0 +1,20 @@
+// Adds `.js` extensions to relative imports inside dist/ so the test harness
+// can load the ESM build directly under Node's strict ESM resolver.
+// Build consumers (bundlers / TypeScript) tolerate extensionless imports;
+// raw Node does not.
+
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist')
+
+const RELATIVE_IMPORT = /(from\s+['"])(\.\/[A-Za-z0-9_\-]+)(['"])/g
+
+for (const entry of await readdir(distDir)) {
+  if (!entry.endsWith('.js')) continue
+  const path = join(distDir, entry)
+  const src = await readFile(path, 'utf8')
+  const out = src.replace(RELATIVE_IMPORT, '$1$2.js$3')
+  if (out !== src) await writeFile(path, out)
+}

--- a/sdk/js/test/token-propagation.mjs
+++ b/sdk/js/test/token-propagation.mjs
@@ -1,0 +1,76 @@
+// Regression test for issue #38: AuthClient must share its HttpClient with
+// DatabaseClient and StorageClient so that the Authorization: Bearer <token>
+// header reaches RLS-protected endpoints.
+//
+// Run via: npm run build && node test/token-propagation.mjs
+
+import { createClient } from '../dist/index.js'
+import assert from 'node:assert/strict'
+
+const FAKE_TOKEN = 'eyJ-fake-jwt-token'
+const FAKE_API_KEY = 'eb_pk_fake'
+const FAKE_URL = 'https://fake.eurobase.app'
+
+const calls = []
+
+globalThis.fetch = async (url, init = {}) => {
+  const headers = init.headers ?? {}
+  calls.push({ url: String(url), method: init.method ?? 'GET', headers: { ...headers } })
+
+  if (String(url).endsWith('/v1/auth/signin')) {
+    return new Response(
+      JSON.stringify({
+        access_token: FAKE_TOKEN,
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'rt-fake',
+        user: { id: 'u1', email: 'a@b.c', created_at: '', updated_at: '' },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )
+  }
+
+  return new Response(JSON.stringify({ data: [], count: 0 }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function authHeaderFor(predicate) {
+  const call = calls.find(predicate)
+  assert.ok(call, `expected request matching predicate; got: ${JSON.stringify(calls.map(c => c.url))}`)
+  return call.headers.Authorization
+}
+
+const eb = createClient({ url: FAKE_URL, apiKey: FAKE_API_KEY })
+
+// Pre-signIn: queries should NOT carry an Authorization header.
+await eb.db.from('todos').select('id')
+const preDbAuth = authHeaderFor(c => c.url.includes('/v1/db/todos'))
+assert.equal(preDbAuth, undefined, 'pre-signIn db request should not carry Authorization header')
+
+// Sign in — token enters AuthClient's http instance.
+const { error } = await eb.auth.signIn({ email: 'a@b.c', password: 'pw' })
+assert.equal(error, null, 'signIn should succeed against the fake gateway')
+
+// Reset call log so we only inspect post-signIn traffic.
+calls.length = 0
+
+// Post-signIn: db query must carry the bearer token.
+await eb.db.from('todos').select('id')
+const dbAuth = authHeaderFor(c => c.url.includes('/v1/db/todos'))
+assert.equal(dbAuth, `Bearer ${FAKE_TOKEN}`, 'db query must carry shared bearer token after signIn')
+
+// Post-signIn: storage list must also carry the bearer token.
+await eb.storage.list()
+const storageAuth = authHeaderFor(c => c.url.includes('/v1/storage') && !c.url.includes('/v1/storage/upload'))
+assert.equal(storageAuth, `Bearer ${FAKE_TOKEN}`, 'storage request must carry shared bearer token after signIn')
+
+// Sign out clears the token from the shared instance.
+await eb.auth.signOut()
+calls.length = 0
+await eb.db.from('todos').select('id')
+const postSignOutDbAuth = authHeaderFor(c => c.url.includes('/v1/db/todos'))
+assert.equal(postSignOutDbAuth, undefined, 'db request after signOut must not carry Authorization header')
+
+console.log('token-propagation.mjs: PASS')


### PR DESCRIPTION
## Summary
- `createClient()` built one shared `HttpClient` and handed it only to `AuthClient`, `FunctionsClient`, and `RealtimeClient`.
- `DatabaseClient` and `StorageClient` each constructed their own `httpClient(config)` — orphan instances that `AuthClient.setSession()` could never reach.
- After `signIn` or `restoreSession`, db/storage requests went out without an `Authorization` header, RLS evaluated `auth_uid()` as `NULL`, and queries silently returned empty rows.

This PR threads the shared `http` instance into both clients (matching the pattern already used for `FunctionsClient` / `RealtimeClient`).

## Scope
| Client | Before | After |
|---|---|---|
| auth | shared http (owner) | unchanged |
| functions | shared http | unchanged |
| realtime | shared http | unchanged |
| **db** | own http — bug | **shared http** |
| **storage** | own http — bug | **shared http** |
| schema (DDL) | raw fetch + secret key | unchanged (no end-user token needed) |
| vault | raw fetch + secret key | unchanged (no end-user token needed) |

Issue #38 only mentioned `db`, but `storage` had the identical bug (storage_objects is RLS-protected). `schema` and `vault` are secret-key-only and correctly unaffected.

## Changes
- `sdk/js/src/database.ts` — `DatabaseClient` accepts optional `http` (falls back to its own when omitted, so direct construction still works).
- `sdk/js/src/storage.ts` — same.
- `sdk/js/src/client.ts` — pass the shared `http` to both.
- `sdk/js/test/token-propagation.mjs` — new regression test: monkey-patches `fetch`, asserts the bearer token reaches `/v1/db` and `/v1/storage` after `signIn`, and is gone after `signOut`. Also asserts the pre-signIn case sends no `Authorization` header.
- `sdk/js/test/fix-dist-imports.mjs` — tiny post-build helper so the test can load the dist under Node's strict ESM resolver (the SDK ships extensionless imports, which bundlers tolerate but raw Node does not).
- `sdk/js/package.json` — `npm test` now runs the regression test.

## Test plan
- [x] `cd sdk/js && npm test` → `token-propagation.mjs: PASS`
- [ ] Manual: sign in in a browser app, hard-refresh, query an RLS-protected table, confirm rows return and `Authorization: Bearer <token>` is on the request.
- [ ] Manual: storage upload/list while signed in to confirm the same on `/v1/storage`.

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)