### PR TITLE
Tenant DDL: route all schema mutations through eurobase_migrator (fixes #40 #41 #42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Eurobase Project: 
 
 ## API
-- Base URL: https://newtek2-njyf.eurobase.app
-- Project ID: 16a1a87c-6c7e-43b7-a9d5-03e6a46e9555
+- Base URL: https://newtek2.eurobase.app
+- Project ID: b24e9fa8-463f-452d-be4e-ee5127c3e8f7
 
 ## Database
 - Connection: see .env for DATABASE_URL

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -444,10 +444,17 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			// since DDL is destructive. The handlers inside HandleDDL expect
 			// chi URL param "id" to be the project ID — sdkDDLAdapter injects
 			// it from the API-key-authenticated ProjectContext.
+			//
+			// Routed through developerPool (not the runtime gateway pool) +
+			// the developer-role flag so all SDK DDL elevates to
+			// eurobase_migrator inside its tx, producing migrator-owned
+			// tables identical to the platform/MCP DDL path. Without this,
+			// SDK-created tables are gateway-owned and cannot be ALTER/DROP'd
+			// from the platform path (and vice versa). See issues #40/#41/#42.
 			r.Route("/schema/tables", func(r chi.Router) {
 				r.Use(requireSecretKeyForDDL)
 				r.Use(sdkDDLAdapter)
-				r.Mount("/", query.HandleDDL(pool))
+				r.Mount("/", query.HandleDDL(developerPool))
 			})
 
 			r.Get("/{table}", query.HandleTableGet(queryEngine))
@@ -584,10 +591,16 @@ func requireSecretKeyForDDL(next http.Handler) http.Handler {
 }
 
 // sdkDDLAdapter injects the authenticated ProjectContext.ProjectID as the
-// chi URL param "id" that HandleDDL's handlers expect. This lets the same
-// handlers serve both the platform path (/platform/projects/{id}/schema/...)
-// where {id} comes from the URL and the SDK path (/v1/db/schema/...) where
-// the project is resolved by the API key middleware.
+// chi URL param "id" that HandleDDL's handlers expect, and flags the
+// request context for eurobase_migrator role elevation inside the DDL
+// transactions (see internal/query/engine.go applyDeveloperRole).
+//
+// This lets the same handlers serve both the platform path
+// (/platform/projects/{id}/schema/...) where {id} comes from the URL and
+// the developer-role flag is set by tenant.PlatformTenantContext, and the
+// SDK path (/v1/db/schema/...) where the project is resolved by the API
+// key middleware and the dev-role flag is set here. Both paths therefore
+// produce uniformly migrator-owned tables.
 func sdkDDLAdapter(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
@@ -598,7 +611,8 @@ func sdkDDLAdapter(next http.Handler) http.Handler {
 		if rctx := chi.RouteContext(r.Context()); rctx != nil {
 			rctx.URLParams.Add("id", pc.ProjectID)
 		}
-		next.ServeHTTP(w, r)
+		ctx := query.WithDeveloperRole(r.Context())
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/query/ddl.go
+++ b/internal/query/ddl.go
@@ -7,8 +7,36 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// runDDL executes fn inside a fresh transaction with eurobase_migrator role
+// elevation applied (when DeveloperRoleFromContext is set on ctx). Every
+// mutating DDL helper in this file routes through here so all tenant DDL
+// — whether triggered by the SDK or the platform/MCP path — runs as
+// migrator and produces uniformly migrator-owned objects.
+//
+// Without this, SDK DDL ran as eurobase_gateway (gateway-owned tables) and
+// MCP DDL ran as eurobase_developer (developer-owned tables). Cross-tool
+// ALTER/DROP failed with "must be owner" and gateway-pool introspection
+// queries returned empty column lists for developer-owned tables. See
+// issues #40, #41, #42.
+func runDDL(ctx context.Context, pool *pgxpool.Pool, fn func(tx pgx.Tx) error) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if err := applyDeveloperRole(ctx, tx); err != nil {
+		return err
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
 
 // validIdentRe matches safe SQL identifiers (letters, digits, underscores).
 var validIdentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
@@ -182,26 +210,20 @@ func CreateTable(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName 
 
 	createSQL := fmt.Sprintf("CREATE TABLE %s (\n  %s\n)", qt, strings.Join(colDefs, ",\n  "))
 
-	// Execute in a transaction: CREATE TABLE + enable RLS + create policy.
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, createSQL); err != nil {
+			return fmt.Errorf("create table: %w", err)
+		}
 
-	if _, err := tx.Exec(ctx, createSQL); err != nil {
-		return fmt.Errorf("create table: %w", err)
-	}
+		rlsSQL := fmt.Sprintf("ALTER TABLE %s ENABLE ROW LEVEL SECURITY", qt)
+		if _, err := tx.Exec(ctx, rlsSQL); err != nil {
+			return fmt.Errorf("enable RLS: %w", err)
+		}
 
-	// Enable RLS (no default policy — table is locked down until policies are added).
-	rlsSQL := fmt.Sprintf("ALTER TABLE %s ENABLE ROW LEVEL SECURITY", qt)
-	if _, err := tx.Exec(ctx, rlsSQL); err != nil {
-		return fmt.Errorf("enable RLS: %w", err)
-	}
-
-	// Add foreign key constraints.
-	for _, col := range columns {
-		if col.ForeignKey != nil {
+		for _, col := range columns {
+			if col.ForeignKey == nil {
+				continue
+			}
 			fk := col.ForeignKey
 			onDelete := "NO ACTION"
 			if fk.OnDelete != "" {
@@ -220,13 +242,8 @@ func CreateTable(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName 
 				return fmt.Errorf("add foreign key on %s: %w", col.Name, err)
 			}
 		}
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // DropTable drops a table from the tenant's schema.
@@ -246,11 +263,12 @@ func DropTable(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName st
 
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("DROP TABLE %s", qt)
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop table: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop table: %w", err)
+		}
+		return nil
+	})
 }
 
 // AddColumn adds a column to an existing table.
@@ -283,11 +301,12 @@ func AddColumn(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName st
 	}
 
 	sql := strings.Join(parts, " ")
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("add column: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("add column: %w", err)
+		}
+		return nil
+	})
 }
 
 // DropColumn removes a column from a table.
@@ -309,11 +328,12 @@ func DropColumn(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName, 
 
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", qt, quoteIdent(columnName))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop column: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop column: %w", err)
+		}
+		return nil
+	})
 }
 
 // RenameTable renames a table and its RLS policy.
@@ -350,37 +370,28 @@ func RenameTable(ctx context.Context, pool *pgxpool.Pool, schemaName, oldName, n
 		return fmt.Errorf("table %s already exists", newName)
 	}
 
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck
-
-	qt := qualifiedTable(schemaName, oldName)
-	renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", qt, quoteIdent(newName))
-	if _, err := tx.Exec(ctx, renameSQL); err != nil {
-		return fmt.Errorf("rename table: %w", err)
-	}
-
-	// Rename the RLS policy (best-effort via savepoint so failure doesn't abort the tx).
-	oldPolicy := fmt.Sprintf("tenant_isolation_%s", oldName)
-	newPolicy := fmt.Sprintf("tenant_isolation_%s", newName)
-	newQt := qualifiedTable(schemaName, newName)
-	if _, err := tx.Exec(ctx, "SAVEPOINT rename_policy"); err == nil {
-		policySQL := fmt.Sprintf("ALTER POLICY %s ON %s RENAME TO %s", quoteIdent(oldPolicy), newQt, quoteIdent(newPolicy))
-		if _, err := tx.Exec(ctx, policySQL); err != nil {
-			slog.Warn("failed to rename RLS policy (non-fatal)", "error", err)
-			tx.Exec(ctx, "ROLLBACK TO SAVEPOINT rename_policy") //nolint:errcheck
-		} else {
-			tx.Exec(ctx, "RELEASE SAVEPOINT rename_policy") //nolint:errcheck
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		qt := qualifiedTable(schemaName, oldName)
+		renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", qt, quoteIdent(newName))
+		if _, err := tx.Exec(ctx, renameSQL); err != nil {
+			return fmt.Errorf("rename table: %w", err)
 		}
-	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
-	return nil
+		// Rename the RLS policy (best-effort via savepoint so failure doesn't abort the tx).
+		oldPolicy := fmt.Sprintf("tenant_isolation_%s", oldName)
+		newPolicy := fmt.Sprintf("tenant_isolation_%s", newName)
+		newQt := qualifiedTable(schemaName, newName)
+		if _, err := tx.Exec(ctx, "SAVEPOINT rename_policy"); err == nil {
+			policySQL := fmt.Sprintf("ALTER POLICY %s ON %s RENAME TO %s", quoteIdent(oldPolicy), newQt, quoteIdent(newPolicy))
+			if _, err := tx.Exec(ctx, policySQL); err != nil {
+				slog.Warn("failed to rename RLS policy (non-fatal)", "error", err)
+				tx.Exec(ctx, "ROLLBACK TO SAVEPOINT rename_policy") //nolint:errcheck
+			} else {
+				tx.Exec(ctx, "RELEASE SAVEPOINT rename_policy") //nolint:errcheck
+			}
+		}
+		return nil
+	})
 }
 
 // RenameColumn renames a column in a table.
@@ -407,11 +418,12 @@ func RenameColumn(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName
 
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s", qt, quoteIdent(oldCol), quoteIdent(newCol))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("rename column: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("rename column: %w", err)
+		}
+		return nil
+	})
 }
 
 // AlterColumnType changes the data type of a column.
@@ -436,11 +448,12 @@ func AlterColumnType(ctx context.Context, pool *pgxpool.Pool, schemaName, tableN
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s USING %s::%s",
 		qt, quoteIdent(col), strings.ToUpper(newType), quoteIdent(col), strings.ToUpper(newType))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("alter column type: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("alter column type: %w", err)
+		}
+		return nil
+	})
 }
 
 // AlterColumnNullable sets or drops the NOT NULL constraint on a column.
@@ -465,11 +478,12 @@ func AlterColumnNullable(ctx context.Context, pool *pgxpool.Pool, schemaName, ta
 		action = "DROP NOT NULL"
 	}
 	sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s %s", qt, quoteIdent(col), action)
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("alter column nullable: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("alter column nullable: %w", err)
+		}
+		return nil
+	})
 }
 
 // validOnDelete lists the allowed ON DELETE actions for FK constraints.
@@ -524,11 +538,12 @@ func AddForeignKey(ctx context.Context, pool *pgxpool.Pool, schemaName, tableNam
 		quoteIdent(schemaName), quoteIdent(fk.ReferencedTable), quoteIdent(fk.ReferencedColumn),
 		onDelete,
 	)
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("add foreign key: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("add foreign key: %w", err)
+		}
+		return nil
+	})
 }
 
 // DropConstraint drops a named constraint from a table (works for FK and UNIQUE).
@@ -542,11 +557,12 @@ func DropConstraint(ctx context.Context, pool *pgxpool.Pool, schemaName, tableNa
 
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", qt, quoteIdent(constraintName))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop constraint: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop constraint: %w", err)
+		}
+		return nil
+	})
 }
 
 // AddUniqueConstraint adds a UNIQUE constraint to a column.
@@ -567,11 +583,12 @@ func AddUniqueConstraint(ctx context.Context, pool *pgxpool.Pool, schemaName, ta
 	qt := qualifiedTable(schemaName, tableName)
 	constraintName := fmt.Sprintf("uq_%s_%s", tableName, column)
 	sql := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)", qt, quoteIdent(constraintName), quoteIdent(column))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("add unique constraint: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("add unique constraint: %w", err)
+		}
+		return nil
+	})
 }
 
 // CreateIndex creates an index on a column. If unique is true, creates a UNIQUE index.
@@ -596,21 +613,23 @@ func CreateIndex(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName,
 		uniqueKw = "UNIQUE "
 	}
 	sql := fmt.Sprintf("CREATE %sINDEX %s ON %s (%s)", uniqueKw, quoteIdent(indexName), qt, quoteIdent(column))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("create index: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("create index: %w", err)
+		}
+		return nil
+	})
 }
 
 // DropIndex drops an index from the schema.
 func DropIndex(ctx context.Context, pool *pgxpool.Pool, schemaName, indexName string) error {
 	sql := fmt.Sprintf("DROP INDEX %s.%s", quoteIdent(schemaName), quoteIdent(indexName))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop index: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop index: %w", err)
+		}
+		return nil
+	})
 }
 
 // DBTrigger describes a row- or statement-level trigger attached to a table.
@@ -831,10 +850,13 @@ func CreateTrigger(ctx context.Context, pool *pgxpool.Pool, schemaName string, r
 	fmt.Fprintf(&b, " EXECUTE FUNCTION %s.%s()",
 		quoteIdent(schemaName), quoteIdent(req.FunctionName))
 
-	if _, err := pool.Exec(ctx, b.String()); err != nil {
-		return fmt.Errorf("create trigger: %w", err)
-	}
-	return nil
+	stmt := b.String()
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("create trigger: %w", err)
+		}
+		return nil
+	})
 }
 
 // DropTrigger removes a trigger from a table. Both identifiers are
@@ -848,10 +870,12 @@ func DropTrigger(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName,
 	}
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("DROP TRIGGER %s ON %s", quoteIdent(triggerName), qt)
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop trigger: %w", err)
-	}
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop trigger: %w", err)
+		}
+		return nil
+	})
 }
 
 // DBFunction represents a PostgreSQL function in a schema.
@@ -992,19 +1016,15 @@ func CreateFunction(ctx context.Context, pool *pgxpool.Pool, schemaName string, 
 	// Set search_path to the tenant schema so unqualified table references
 	// in the function body (e.g. "SELECT * FROM categories") resolve
 	// correctly. Use a transaction so the search_path resets automatically.
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck
-
-	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", quoteIdent(schemaName))); err != nil {
-		return fmt.Errorf("set search_path: %w", err)
-	}
-	if _, err := tx.Exec(ctx, createSQL); err != nil {
-		return fmt.Errorf("create function: %w", err)
-	}
-	return tx.Commit(ctx)
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", quoteIdent(schemaName))); err != nil {
+			return fmt.Errorf("set search_path: %w", err)
+		}
+		if _, err := tx.Exec(ctx, createSQL); err != nil {
+			return fmt.Errorf("create function: %w", err)
+		}
+		return nil
+	})
 }
 
 // DropFunction drops a zero-argument function from the schema.
@@ -1014,11 +1034,12 @@ func DropFunction(ctx context.Context, pool *pgxpool.Pool, schemaName, funcName 
 	}
 
 	sql := fmt.Sprintf("DROP FUNCTION IF EXISTS %s.%s()", quoteIdent(schemaName), quoteIdent(funcName))
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop function: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop function: %w", err)
+		}
+		return nil
+	})
 }
 
 // AlterColumnDefault sets or drops the default value of a column.
@@ -1047,11 +1068,12 @@ func AlterColumnDefault(ctx context.Context, pool *pgxpool.Pool, schemaName, tab
 		}
 		sql = fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s", qt, quoteIdent(col), *defaultVal)
 	}
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("alter column default: %w", err)
-	}
-
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("alter column default: %w", err)
+		}
+		return nil
+	})
 }
 
 // RLSPolicy represents a PostgreSQL RLS policy.
@@ -1200,23 +1222,11 @@ func ApplyPolicyPreset(ctx context.Context, pool *pgxpool.Pool, schemaName, tabl
 	if err != nil {
 		return err
 	}
-	for _, p := range existing {
-		dropSQL := fmt.Sprintf("DROP POLICY %s ON %s", quoteIdent(p.Name), qt)
-		if _, err := pool.Exec(ctx, dropSQL); err != nil {
-			slog.Warn("failed to drop policy", "policy", p.Name, "error", err)
-		}
-	}
 
 	if userIDColumn == "" {
 		userIDColumn = "user_id"
 	}
 	col := quoteIdent(userIDColumn)
-
-	// Set search_path so auth_uid() / auth_role() are found in the tenant schema.
-	if _, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", quoteIdent(schemaName))); err != nil {
-		return fmt.Errorf("set search_path: %w", err)
-	}
-	defer pool.Exec(ctx, "SET search_path TO public") //nolint:errcheck
 
 	// Every restrictive preset includes a `public.is_service_role() OR ...`
 	// branch so platform-admin paths and pre-auth lookups (which legitimately
@@ -1259,10 +1269,26 @@ func ApplyPolicyPreset(ctx context.Context, pool *pgxpool.Pool, schemaName, tabl
 		return fmt.Errorf("unknown policy preset: %s", preset)
 	}
 
-	for _, sql := range sqls {
-		if _, err := pool.Exec(ctx, sql); err != nil {
-			return fmt.Errorf("apply policy: %w", err)
+	if err := runDDL(ctx, pool, func(tx pgx.Tx) error {
+		// Tenant-local search_path so auth_uid() / auth_role() resolve in
+		// the tenant schema. SET LOCAL auto-resets on commit.
+		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", quoteIdent(schemaName))); err != nil {
+			return fmt.Errorf("set search_path: %w", err)
 		}
+		for _, p := range existing {
+			dropSQL := fmt.Sprintf("DROP POLICY %s ON %s", quoteIdent(p.Name), qt)
+			if _, err := tx.Exec(ctx, dropSQL); err != nil {
+				slog.Warn("failed to drop policy", "policy", p.Name, "error", err)
+			}
+		}
+		for _, sql := range sqls {
+			if _, err := tx.Exec(ctx, sql); err != nil {
+				return fmt.Errorf("apply policy: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	slog.Info("RLS policy preset applied", "schema", schemaName, "table", tableName, "preset", preset)
@@ -1283,12 +1309,6 @@ func CreateCustomPolicy(ctx context.Context, pool *pgxpool.Pool, schemaName, tab
 		return fmt.Errorf("command must be SELECT, INSERT, UPDATE, DELETE, or ALL")
 	}
 
-	// Set search_path so auth_uid() / auth_role() are found in the tenant schema.
-	if _, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", quoteIdent(schemaName))); err != nil {
-		return fmt.Errorf("set search_path: %w", err)
-	}
-	defer pool.Exec(ctx, "SET search_path TO public") //nolint:errcheck
-
 	sql := fmt.Sprintf("CREATE POLICY %s ON %s FOR %s", quoteIdent(policyName), qt, command)
 	if usingExpr != "" {
 		sql += fmt.Sprintf(" USING (%s)", usingExpr)
@@ -1297,8 +1317,17 @@ func CreateCustomPolicy(ctx context.Context, pool *pgxpool.Pool, schemaName, tab
 		sql += fmt.Sprintf(" WITH CHECK (%s)", withCheckExpr)
 	}
 
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("create policy: %w", err)
+	if err := runDDL(ctx, pool, func(tx pgx.Tx) error {
+		// Tenant-local search_path so auth_uid() / auth_role() resolve.
+		if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", quoteIdent(schemaName))); err != nil {
+			return fmt.Errorf("set search_path: %w", err)
+		}
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("create policy: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	slog.Info("custom RLS policy created", "schema", schemaName, "table", tableName, "policy", policyName)
 	return nil
@@ -1308,8 +1337,10 @@ func CreateCustomPolicy(ctx context.Context, pool *pgxpool.Pool, schemaName, tab
 func DropPolicy(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName, policyName string) error {
 	qt := qualifiedTable(schemaName, tableName)
 	sql := fmt.Sprintf("DROP POLICY IF EXISTS %s ON %s", quoteIdent(policyName), qt)
-	if _, err := pool.Exec(ctx, sql); err != nil {
-		return fmt.Errorf("drop policy: %w", err)
-	}
-	return nil
+	return runDDL(ctx, pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("drop policy: %w", err)
+		}
+		return nil
+	})
 }

--- a/internal/query/ddl_handler.go
+++ b/internal/query/ddl_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eurobase/euroback/internal/audit"
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -348,7 +349,11 @@ func handleCreateTable(pool *pgxpool.Pool) http.HandlerFunc {
 		var warning string
 		if req.DisableRLS {
 			qt := qualifiedTable(schemaName, req.Name)
-			if _, err := pool.Exec(r.Context(), fmt.Sprintf("ALTER TABLE %s DISABLE ROW LEVEL SECURITY", qt)); err != nil {
+			err := runDDL(r.Context(), pool, func(tx pgx.Tx) error {
+				_, err := tx.Exec(r.Context(), fmt.Sprintf("ALTER TABLE %s DISABLE ROW LEVEL SECURITY", qt))
+				return err
+			})
+			if err != nil {
 				slog.Error("disable rls failed", "error", err, "table", req.Name)
 				jsonError(w, "failed to disable rls: "+err.Error(), http.StatusInternalServerError)
 				return
@@ -1151,7 +1156,11 @@ func handleToggleRLS(pool *pgxpool.Pool) http.HandlerFunc {
 		}
 
 		sql := fmt.Sprintf("ALTER TABLE %s %s ROW LEVEL SECURITY", qt, action)
-		if _, err := pool.Exec(r.Context(), sql); err != nil {
+		err = runDDL(r.Context(), pool, func(tx pgx.Tx) error {
+			_, err := tx.Exec(r.Context(), sql)
+			return err
+		})
+		if err != nil {
 			slog.Error("toggle RLS failed", "error", err, "table", tableName, "action", action)
 			jsonError(w, "failed to toggle RLS: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/query/devrole_test.go
+++ b/internal/query/devrole_test.go
@@ -245,6 +245,60 @@ func TestExecuteSQLTransaction_DeveloperRole_AppliesMigratorOwnership(t *testing
 	_, _ = pool.Exec(context.Background(), "ALTER TABLE "+pgIdent(schema)+".users DROP COLUMN IF EXISTS mig_demo_marker")
 }
 
+// TestDDLHelpers_DeveloperRole_AppliesMigratorOwnership covers the
+// regression behind issues #40, #41, #42: the per-helper DDL functions
+// in ddl.go must elevate to eurobase_migrator when the request context
+// carries the developer-role flag, so tables created via the SDK or MCP
+// path are uniformly migrator-owned. Without this elevation, SDK DDL
+// produces gateway-owned tables and MCP DDL produces developer-owned
+// tables — neither role can ALTER/DROP the other's objects, and
+// gateway-pool introspection returns columns:null on developer-owned
+// tables.
+func TestDDLHelpers_DeveloperRole_AppliesMigratorOwnership(t *testing.T) {
+	pool, schema, _ := setupTestDB(t)
+	ctx := WithDeveloperRole(context.Background())
+
+	tableName := "ddl_helper_owner_test"
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			"DROP TABLE IF EXISTS "+pgIdent(schema)+"."+pgIdent(tableName)+" CASCADE")
+	})
+
+	if err := CreateTable(ctx, pool, schema, tableName, []ColumnDefinition{
+		{Name: "id", Type: "uuid", IsPrimaryKey: true, DefaultValue: "public.uuid_generate_v4()"},
+		{Name: "title", Type: "text"},
+	}); err != nil {
+		t.Fatalf("CreateTable with developer-role flag: %v", err)
+	}
+
+	var owner string
+	err := pool.QueryRow(context.Background(),
+		`SELECT tableowner FROM pg_tables WHERE schemaname = $1 AND tablename = $2`,
+		schema, tableName,
+	).Scan(&owner)
+	if err != nil {
+		t.Fatalf("read tableowner: %v", err)
+	}
+	if owner != "eurobase_migrator" {
+		t.Errorf("CreateTable owner = %q, want %q (the SET LOCAL ROLE didn't take effect inside runDDL)", owner, "eurobase_migrator")
+	}
+
+	// Drop via DropTable — also goes through runDDL → applyDeveloperRole.
+	// Confirms the symmetric drop path works on a migrator-owned table.
+	if err := DropTable(ctx, pool, schema, tableName); err != nil {
+		t.Fatalf("DropTable with developer-role flag: %v", err)
+	}
+
+	var stillExists bool
+	_ = pool.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = $1 AND tablename = $2)`,
+		schema, tableName,
+	).Scan(&stillExists)
+	if stillExists {
+		t.Error("DropTable did not remove the table")
+	}
+}
+
 // pgIdent quotes a Postgres identifier for use in raw SQL. Mirrors the
 // engine's quoteIdent helper but available to tests in this file.
 func pgIdent(name string) string {

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eurobase/sdk",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eurobase/sdk",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@eurobase/sdk": "^0.1.0"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eurobase/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Eurobase TypeScript SDK — EU-sovereign Backend-as-a-Service. Auth, database, storage, realtime, functions, vault, and schema DDL.",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

Three reported MCP/SDK bugs (#40, #41, #42) collapse into one root cause: the per-helper DDL functions in \`internal/query/ddl.go\` open their own \`pool.Begin\` (or call \`pool.Exec\` directly) and never apply the \`SET LOCAL ROLE eurobase_migrator\` elevation that \`QueryEngine.WithTenantTx\`/\`ExecuteSQL\` already do for SQL execution.

| Path | Pool | Role at CREATE | Owner |
|---|---|---|---|
| SDK \`/v1/db/schema/tables\` | \`pool\` | \`eurobase_gateway\` | gateway |
| MCP \`/platform/projects/{id}/schema/tables\` | \`developerPool\` | \`eurobase_developer\` | developer |

Cross-tool ALTER/DROP failed with \"must be owner\" (#41), \`runSQL\` CREATE INDEX/ALTER on SDK tables failed for the same reason (#42), and gateway-pool \`HandleSchemaIntrospection\` returned \`columns:null\` on developer-owned tables because \`information_schema.columns\` is privilege-filtered (#40).

## Fix

- New \`runDDL(ctx, pool, fn)\` helper in \`ddl.go\` — wraps each mutation in a tx with \`applyDeveloperRole\` at the top. When the request context carries the developer-role flag, the tx elevates to \`eurobase_migrator\` and the resulting object is migrator-owned.
- Refactor every mutating DDL helper to route through \`runDDL\` (21 in total: CreateTable, DropTable, AddColumn, DropColumn, RenameTable, RenameColumn, AlterColumn{Type,Nullable,Default}, AddForeignKey, DropConstraint, AddUniqueConstraint, CreateIndex, DropIndex, CreateTrigger, DropTrigger, CreateFunction, DropFunction, ApplyPolicyPreset, CreateCustomPolicy, DropPolicy). Read-only helpers (Get*, List*, AuditRLS) are unchanged — SELECT works via the existing membership chain.
- Wrap the two direct \`pool.Exec\` calls in \`ddl_handler.go\` (DISABLE RLS in \`handleCreateTable\`, \`handleToggleRLS\`) in \`runDDL\`.
- \`gateway/router.go\`: SDK DDL mount changes from \`pool\` → \`developerPool\`, and \`sdkDDLAdapter\` now sets \`WithDeveloperRole\` on the request context. Both SDK and platform DDL travel through the same pool with the same elevation flag.

## Side fix bundled

\`ApplyPolicyPreset\` and \`CreateCustomPolicy\` previously did \`SET search_path\` on the pool then \`defer pool.Exec(\"SET search_path TO public\")\` — the defer ran on a different pooled connection so the temporary search_path leaked into other queries on the original connection. Now scoped to a single tx with \`SET LOCAL search_path\` which auto-resets on commit.

## Cleanup note (operational)

This fix only normalises ownership for **new** DDL. Pre-existing tables created on either side need a one-time \`ALTER TABLE … OWNER TO eurobase_migrator\` (run as a role that can act as both owners) or have to be dropped from the Scaleway console. Affected reporters had \`_probe\`, \`app_users\`, \`sessions\`, \`session_memories\` stuck this way.

## Bonus

Stale CLAUDE.md values updated: \`newtek2-njyf.eurobase.app\` → \`newtek2.eurobase.app\`, project ID \`16a1a87c-...\` → \`b24e9fa8-...\` (the old project no longer exists).

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/query/\` (existing tests pass)
- [x] New regression test \`TestDDLHelpers_DeveloperRole_AppliesMigratorOwnership\` in \`devrole_test.go\` asserts \`CreateTable\` + \`DropTable\` both produce migrator ownership when the dev-role flag is set
- [ ] Post-deploy E2E: from the SDK side, \`eb.db.schema.createTable(...)\`; verify the new table is migrator-owned via \`SELECT tableowner FROM pg_tables\`. Then from the MCP side, \`runSQL('DROP TABLE ...')\` succeeds.
- [ ] Post-deploy E2E: \`runSQL('CREATE INDEX ...')\` succeeds on a freshly-SDK-created table.

Fixes #40
Fixes #41
Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)