### PR TITLE
Gateway: set WithDeveloperRole on /platform .../schema/tables (followup to #43)

### DIFF
--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -238,8 +238,13 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			r.Get("/schema/rls-audit", query.HandleRLSAudit(pool))
 			// DDL on tenant schemas runs against the developer pool so
 			// CREATE/ALTER/REFERENCES on migrator-owned tables works.
-			r.Mount("/schema/tables", query.HandleDDL(developerPool))
-			r.Mount("/schema/functions", query.HandleFunctions(developerPool))
+			// withDeveloperRole adds the flag the DDL helpers read inside
+			// runDDL to elevate `SET LOCAL ROLE eurobase_migrator` — without
+			// it, tables would be developer-owned and cross-tool DDL would
+			// fail with "must be owner". (PlatformTenantContext also sets
+			// this flag, but it's only mounted on /data/sql and below.)
+			r.With(withDeveloperRole).Mount("/schema/tables", query.HandleDDL(developerPool))
+			r.With(withDeveloperRole).Mount("/schema/functions", query.HandleFunctions(developerPool))
 			r.Mount("/webhooks", webhook.Routes(pool, limitsSvc))
 			cronSvc := cron.NewCronService(pool)
 			r.Mount("/cron", cron.Routes(cronSvc))
@@ -570,6 +575,17 @@ func superadminMiddleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// withDeveloperRole flags the request context for eurobase_migrator role
+// elevation inside DDL transactions (see internal/query/engine.go
+// applyDeveloperRole). Apply to platform-authenticated DDL routes that
+// don't already go through tenant.PlatformTenantContext (which sets the
+// same flag).
+func withDeveloperRole(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(query.WithDeveloperRole(r.Context())))
+	})
 }
 
 // requireSecretKeyForDDL gates SDK DDL routes to secret API keys only.


### PR DESCRIPTION
## Followup to PR #43

Post-deploy verification on \`newtek2\` showed an MCP-created table was still owned by \`eurobase_developer\` rather than \`eurobase_migrator\`. PR #43 made the DDL helpers honour \`DeveloperRoleFromContext\` via \`runDDL\`, but the platform DDL route at \`/platform/projects/{id}/schema/tables\` (and \`.../schema/functions\`) is mounted directly under \`/projects/{id}\` — \`tenant.PlatformTenantContext\` (which sets the dev-role flag) is only applied on the \`/data/sql\` subroute, not on the schema mounts. So the flag never reached the DDL handlers and \`applyDeveloperRole\` was a silent no-op.

## Fix

Add a tiny \`withDeveloperRole\` middleware that wraps the request context with \`query.WithDeveloperRole\`, applied to the two platform schema mounts.

Both paths now flow uniformly:

\`\`\`
Platform DDL: withDeveloperRole → CreateTable → runDDL → SET LOCAL ROLE migrator
SDK DDL:      sdkDDLAdapter (already sets the flag) → CreateTable → runDDL → SET LOCAL ROLE migrator
\`\`\`

## Live evidence (pre-fix)

\`\`\`
mcp createTable(name=verify_pr43)
  → status: created
runSQL: SELECT tableowner FROM pg_tables WHERE tablename = 'verify_pr43'
  → eurobase_developer  ❌ should be eurobase_migrator
runSQL: SELECT current_user
  → eurobase_migrator   ✓ runSQL elevation works
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [ ] Post-deploy: re-run the same verification, expect \`tableowner = eurobase_migrator\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)