### PR TITLE
SDK: declare package as ESM and run dist-import fixer on every build

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -4,18 +4,18 @@
   "description": "Eurobase TypeScript SDK — EU-sovereign Backend-as-a-Service. Auth, database, storage, realtime, functions, vault, and schema DDL.",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js"
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node test/fix-dist-imports.mjs",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node test/fix-dist-imports.mjs && node test/token-propagation.mjs"
+    "test": "npm run build && node test/token-propagation.mjs"
   },
   "keywords": [
     "eurobase",


### PR DESCRIPTION
## Summary

The published \`@eurobase/sdk@0.2.1\` artifact loaded fine from bundlers but failed under Node's strict ESM resolver. During the live verification of #38 we had to patch the installed copy in \`/tmp\` to make it work — that workaround belongs in the build, not in the consumer.

Two-line cause:

1. The package had no \`"type"\` field, so Node defaulted to CommonJS and only fell back to ESM via syntax detection. The resolver then ran in a half-state with inconsistent rules for nested imports.
2. The compiled dist contained extensionless relative imports (\`from './client'\`), which Node's strict ESM rules reject.

The dist-import fixer that solves (2) had been written for the 0.2.1 verification test (\`test/fix-dist-imports.mjs\`) but only ran inside \`npm test\`, not on publish. Consumers got the unpatched artifact.

## Changes

- \`"type": "module"\` — every .js in the package is unambiguously ESM.
- \`"build": "tsc && node test/fix-dist-imports.mjs"\` — the fixer now runs as part of the build, which means it runs on \`prepublishOnly\`.
- Drop the redundant \`"require": "./dist/index.js"\` export — once the package is ESM-only, advertising CJS support is misleading and won't actually work.
- \`"test"\` no longer calls the fixer separately (build does it).

## Verification

\`\`\`
$ npm test
> @eurobase/sdk@0.2.1 build
> tsc && node test/fix-dist-imports.mjs

token-propagation.mjs: PASS    # no MODULE_TYPELESS_PACKAGE_JSON warning

$ node --input-type=module -e "import('./dist/index.js').then(m => console.log(Object.keys(m).join(', ')))"
AuthClient, DatabaseClient, FunctionsClient, QueryBuilder, RealtimeClient, SchemaClient, StorageClient, VaultClient, createClient
\`\`\`

## Release plan

After merge: bump to 0.2.2 on main and republish, same flow as 0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)