### PR TITLE
Security: isolate functions runner on a dedicated tainted node pool

### DIFF
--- a/deploy/k8s/functions.yaml
+++ b/deploy/k8s/functions.yaml
@@ -20,6 +20,17 @@ spec:
         app: functions
         component: runtime
     spec:
+      # Pin to the isolated functions node pool (see deploy/terraform/main.tf:
+      # scaleway_k8s_pool.functions). Scaleway labels each pool's nodes with
+      # k8s.scaleway.com/pool-name automatically. The toleration matches the
+      # NoSchedule taint on that pool so functions pods land there exclusively.
+      nodeSelector:
+        k8s.scaleway.com/pool-name: functions-pool
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: functions
+          effect: NoSchedule
       containers:
         - name: deno-runner
           image: rg.fr-par.scw.cloud/eurobase-app/functions:latest

--- a/deploy/k8s/functions.yaml
+++ b/deploy/k8s/functions.yaml
@@ -27,7 +27,9 @@ spec:
       nodeSelector:
         k8s.scaleway.com/pool-name: functions-pool
       tolerations:
-        - key: workload
+        # Scaleway prefixes taint keys with k8s.scaleway.com/ when provisioned
+        # via pool tags (format "taint=<key>=<value>:<Effect>").
+        - key: k8s.scaleway.com/workload
           operator: Equal
           value: functions
           effect: NoSchedule

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -113,6 +113,37 @@ resource "scaleway_k8s_pool" "eurobase" {
   tags = ["eurobase", var.environment]
 }
 
+# Dedicated node pool for the functions runner.
+#
+# Rationale: the functions runner executes untrusted tenant JS via AsyncFunction
+# on shared nodes. A kernel exploit (see CVE-2026-31431 hotfix) from a tenant
+# function can escape the container and reach co-located pods. Isolating the
+# functions workload on its own pool means gateway/worker pods — and the DB
+# credentials they carry — are never co-located with tenant code.
+#
+# The pool carries a NoSchedule taint; only functions pods (which have the
+# matching toleration) will land here. All other workloads stay on eurobase-pool.
+resource "scaleway_k8s_pool" "functions" {
+  cluster_id  = scaleway_k8s_cluster.eurobase.id
+  name        = "functions-pool"
+  node_type   = "DEV1-S"
+  size        = 1
+  min_size    = 1
+  max_size    = 3
+  autoscaling = true
+  autohealing = true
+
+  tags = ["eurobase", var.environment, "functions-isolation"]
+
+  taints = [
+    {
+      key    = "workload"
+      value  = "functions"
+      effect = "NoSchedule"
+    }
+  ]
+}
+
 # ---------------------------------------------------------------------------
 # Managed PostgreSQL 16
 # ---------------------------------------------------------------------------

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -133,14 +133,13 @@ resource "scaleway_k8s_pool" "functions" {
   autoscaling = true
   autohealing = true
 
-  tags = ["eurobase", var.environment, "functions-isolation"]
-
-  taints = [
-    {
-      key    = "workload"
-      value  = "functions"
-      effect = "NoSchedule"
-    }
+  # Scaleway encodes K8s taints via the tags argument:
+  # "taint=<key>=<value>:<Effect>" → node taint k8s.scaleway.com/<key>=<value>:<Effect>
+  tags = [
+    "eurobase",
+    var.environment,
+    "functions-isolation",
+    "taint=workload=functions:NoSchedule",
   ]
 }
 


### PR DESCRIPTION
## Context

Structural follow-up to the CVE-2026-31431 hotfix (`deploy/k8s/security/disable-algif-aead.yaml`, shipped 2026-04-30). That hotfix blacklists the vulnerable kernel module on every node; this PR addresses the root structural problem: the `functions`, `gateway`, and `worker` deployments all share the same node pool (`scaleway_k8s_pool.eurobase`, DEV1-M), so a kernel exploit triggered by tenant JS in the functions runner has a direct lateral path to gateway/worker pods and the DB credentials they carry (`eurobase-secrets`).

## Chosen approach: dedicated taint-isolated node pool (option b)

A new Kapsule node pool (`functions-pool`, DEV1-S, 1–3 nodes autoscaled) is added in Terraform with a `NoSchedule` taint. The functions Deployment is pinned to that pool via `nodeSelector` + matching toleration. Gateway and worker pods have no toleration for that taint, so they can never be co-located with functions pods.

**Rationale (three bullets):**

- **Blast-radius reduction achieved.** Gateway and worker pods cannot be scheduled on `functions-pool` nodes. A kernel escape from a tenant function lands on a node that holds no DB credentials with gateway/worker privileges — lateral movement to `DATABASE_URL` / `DATABASE_URL_DEVELOPER` requires crossing a node boundary, which is not possible without a separate exploit.
- **Minimal diff, fully reversible.** Two files changed, 42 net lines added. To roll back: remove the `nodeSelector`/`tolerations` from the functions Deployment, delete `scaleway_k8s_pool.functions` from Terraform, and apply. No code changes, no protocol changes, no service disruption.
- **Entirely Scaleway-native, EU-sovereign.** No new third-party services. Kapsule fully supports multiple node pools with independent node types and taints. DEV1-S (2 vCPU / 2 GB) is sufficient for the functions runner's resource envelope (256 Mi request / 1 Gi limit, 250 m / 1000 m CPU).

## What was evaluated and rejected

**Option (a) — `runtimeClassName: gvisor` on the functions Deployment:** Scaleway Kapsule does not ship the gVisor runtime (`containerd-shim-runsc`) on its managed node images. There is no built-in `gvisor` RuntimeClass on Kapsule. Installing it would require a privileged DaemonSet that modifies the containerd config on managed nodes — this conflicts with autohealing (Scaleway node refreshes revert host config), and is not a supported configuration. Rejected: no managed support, unsafe on autohealed nodes.

**Option (c) — Move Edge Functions to Scaleway Serverless Containers:** Serverless Containers can pull from the same-project private SCW registry (no auth barrier), but the functions runner holds a persistent PostgreSQL connection pool (10 connections, used for vault lookups and per-tenant `search_path` switching), relies on long-lived secrets from `eurobase-secrets` via the cluster's secret store, and is invoked synchronously by the gateway over ClusterIP DNS. Serverless Containers introduce cold-start latency, a different networking/auth model, and would require a full rewrite of the invocation contract — well outside the scope of a structural hardening PR. Rejected: major architectural change, out of scope.

## Implementation notes

**Terraform (`deploy/terraform/main.tf`):** A new `scaleway_k8s_pool.functions` resource is added. Scaleway encodes Kubernetes taints as pool tags using the format `"taint=<key>=<value>:<Effect>"` (provider ~> 2.40 confirmed). The tag `"taint=workload=functions:NoSchedule"` causes Scaleway to apply the node taint `k8s.scaleway.com/workload=functions:NoSchedule` on every node in the pool.

**Kubernetes (`deploy/k8s/functions.yaml`):** The functions Deployment pod spec gets:
```yaml
nodeSelector:
  k8s.scaleway.com/pool-name: functions-pool   # Scaleway auto-label, stable
tolerations:
  - key: k8s.scaleway.com/workload             # Scaleway-prefixed taint key
    operator: Equal
    value: functions
    effect: NoSchedule
```

**The `disable-algif-aead` DaemonSet stays in place.** It applies cluster-wide (including the new pool) and continues to block the specific CVE-2026-31431 module as belt-and-suspenders. It targets `kube-system` with broad tolerations so it runs on all pools.

## Test plan

**Verify functions runner still serves requests:**
```bash
# After deploy, confirm pods scheduled on functions-pool nodes only
kubectl get pods -n eurobase -l app=functions -o wide
# Node name should match nodes in functions-pool (check: kubectl get nodes -l k8s.scaleway.com/pool-name=functions-pool)

# Health check
kubectl exec -n eurobase deploy/functions -c deno-runner -- \
  wget -qO- http://localhost:8000/health

# End-to-end: invoke a known function via the gateway
curl -s https://newtek2.eurobase.app/v1/functions/<test-function-id>/invoke \
  -H "Authorization: Bearer <anon-key>" | jq .
```

**Verify isolation — functions pod cannot affect gateway/worker pods:**
```bash
# 1. Confirm gateway/worker pods are NOT on functions-pool nodes
kubectl get pods -n eurobase -l 'app in (gateway,worker)' -o wide
# None should appear on a functions-pool node.

# 2. Exec into a functions pod and attempt to reach a gateway pod's process namespace
FUNCTIONS_NODE=$(kubectl get pods -n eurobase -l app=functions -o jsonpath='{.items[0].spec.nodeName}')
GATEWAY_NODE=$(kubectl get pods -n eurobase -l app=gateway -o jsonpath='{.items[0].spec.nodeName}')
echo "Functions node: $FUNCTIONS_NODE"
echo "Gateway node:   $GATEWAY_NODE"
# These should differ.

# 3. Confirm taint is present on functions-pool nodes
kubectl get nodes -l k8s.scaleway.com/pool-name=functions-pool \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.taints}{"\n"}{end}'
# Expected: k8s.scaleway.com/workload=functions:NoSchedule on each node

# 4. Attempt to schedule a gateway-like pod on a functions-pool node without the toleration (should be rejected)
kubectl run isolation-test --image=alpine --restart=Never \
  --overrides='{"spec":{"nodeSelector":{"k8s.scaleway.com/pool-name":"functions-pool"}}}' \
  -- sleep 5
kubectl get pod isolation-test  # should stay Pending (no toleration)
kubectl delete pod isolation-test --ignore-not-found
```

**Verify algif_aead DaemonSet covers the new pool:**
```bash
kubectl get pods -n kube-system -l app=disable-algif-aead -o wide
# Should show a pod on every node including functions-pool nodes.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019JYA5dRnUe12EB9qQpRyVh)_