### PR TITLE
Sec PR 1: tenant-isolation hardening — cron SQL, storage bucket, OAuth, invite URL

### DIFF
--- a/internal/auth/apikey_middleware.go
+++ b/internal/auth/apikey_middleware.go
@@ -38,12 +38,12 @@ func (m *APIKeyMiddleware) Handler(next http.Handler) http.Handler {
 
 		var pc ProjectContext
 		err := m.pool.QueryRow(r.Context(),
-			`SELECT p.id, p.schema_name, p.jwt_secret, ak.type, COALESCE(p.plan, 'free'), p.auth_config
+			`SELECT p.id, p.schema_name, p.slug, p.jwt_secret, ak.type, COALESCE(p.plan, 'free'), p.auth_config
 			 FROM api_keys ak
 			 JOIN projects p ON ak.project_id = p.id
 			 WHERE ak.key_hash = $1 AND p.status = 'active'`,
 			keyHash,
-		).Scan(&pc.ProjectID, &pc.SchemaName, &pc.JWTSecret, &pc.KeyType, &pc.Plan, &pc.AuthConfig)
+		).Scan(&pc.ProjectID, &pc.SchemaName, &pc.Slug, &pc.JWTSecret, &pc.KeyType, &pc.Plan, &pc.AuthConfig)
 		if err != nil {
 			slog.Warn("invalid API key", "error", err, "prefix", safePrefix(apiKey))
 			http.Error(w, `{"error":"invalid API key"}`, http.StatusUnauthorized)

--- a/internal/auth/project_context.go
+++ b/internal/auth/project_context.go
@@ -11,6 +11,7 @@ type projectContextKey struct{}
 type ProjectContext struct {
 	ProjectID  string
 	SchemaName string
+	Slug       string // Used for storage bucket naming; never read from request headers.
 	JWTSecret  string
 	KeyType    string // "public" or "secret"
 	Plan       string // billing plan: "free", "pro"

--- a/internal/auth/subdomain_middleware.go
+++ b/internal/auth/subdomain_middleware.go
@@ -53,7 +53,7 @@ func (m *SubdomainMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		var pc ProjectContext
+		pc := ProjectContext{Slug: slug}
 		err := m.pool.QueryRow(r.Context(),
 			`SELECT id, schema_name, jwt_secret, auth_config
 			 FROM projects

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -118,25 +119,72 @@ func (e *Executor) RunDueJobs(ctx context.Context) error {
 }
 
 // executeJob runs a single cron job action within the project's tenant schema.
+//
+// Closed advisory GHSA-fjjq-cqq9-q793: the previous implementation used
+// `pool.Exec(ctx, "SET search_path TO X; <user-sql>")` — pgx's simple
+// query protocol ran every `;`-separated statement, the gateway role had
+// DML on `public.*` and every tenant schema, and a project member could
+// thus issue arbitrary SQL across the platform.
+//
+// The current path:
+//  1. Validates the action (rejects multi-statement, forbidden-schema refs).
+//  2. Opens a transaction.
+//  3. Sets `search_path` and `statement_timeout` via `SET LOCAL` so they
+//     auto-reset on commit/rollback and never leak into other handlers
+//     sharing the connection.
+//  4. Executes the action via `tx.Exec` — the extended query protocol,
+//     which runs only the first statement (defence-in-depth on top of
+//     the multi-statement rejection).
 func (e *Executor) executeJob(ctx context.Context, job DueJob) error {
-	// Set the search_path to the tenant schema, then execute the action.
 	switch job.ActionType {
 	case "sql":
-		_, err := e.pool.Exec(ctx,
-			fmt.Sprintf("SET search_path TO %s; %s", quoteIdent(job.SchemaName), job.Action))
-		if err != nil {
-			return fmt.Errorf("execute sql: %w", err)
+		if err := validateCronSQLAction(job.Action); err != nil {
+			return err
 		}
+		return e.runInTenantTx(ctx, job.SchemaName, func(tx pgx.Tx) error {
+			if _, err := tx.Exec(ctx, job.Action); err != nil {
+				return fmt.Errorf("execute sql: %w", err)
+			}
+			return nil
+		})
 	case "rpc":
-		_, err := e.pool.Exec(ctx,
-			fmt.Sprintf("SET search_path TO %s; SELECT %s()", quoteIdent(job.SchemaName), quoteIdent(job.Action)))
-		if err != nil {
-			return fmt.Errorf("execute rpc: %w", err)
+		if err := validateCronRPCName(job.Action); err != nil {
+			return err
 		}
+		return e.runInTenantTx(ctx, job.SchemaName, func(tx pgx.Tx) error {
+			sql := fmt.Sprintf("SELECT %s()", quoteIdent(job.Action))
+			if _, err := tx.Exec(ctx, sql); err != nil {
+				return fmt.Errorf("execute rpc: %w", err)
+			}
+			return nil
+		})
 	default:
 		return fmt.Errorf("unknown action_type: %s", job.ActionType)
 	}
-	return nil
+}
+
+// runInTenantTx wraps a cron action in a transaction with `SET LOCAL
+// search_path` and `SET LOCAL statement_timeout`. Both reset on commit.
+// search_path intentionally does NOT include `public` — qualified
+// references are blocked by validateCronSQLAction; this stops accidental
+// resolution of unqualified names (`projects`, `api_keys`) into the
+// platform schema.
+func (e *Executor) runInTenantTx(ctx context.Context, schemaName string, fn func(pgx.Tx) error) error {
+	tx, err := e.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s", quoteIdent(schemaName))); err != nil {
+		return fmt.Errorf("set search_path: %w", err)
+	}
+	if _, err := tx.Exec(ctx, "SET LOCAL statement_timeout = '30s'"); err != nil {
+		return fmt.Errorf("set statement_timeout: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // quoteIdent quotes an identifier to prevent SQL injection.

--- a/internal/cron/validate.go
+++ b/internal/cron/validate.go
@@ -1,0 +1,188 @@
+package cron
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/eurobase/euroback/internal/query"
+)
+
+// validRPCNameRe matches safe SQL identifiers (the same shape the DDL
+// validator uses elsewhere).
+var validRPCNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// forbiddenSchemaRe matches qualified references to schemas that a tenant
+// cron job has no legitimate need to touch. The list:
+//
+//   - public — platform tables (projects, api_keys, platform_users, …) live here
+//   - pg_catalog — Postgres metadata
+//   - information_schema — Postgres metadata
+//   - tenant_… — other tenants' schemas
+//
+// The pattern catches `schema.relation` where `schema` is one of the above.
+// It is run after stripping string literals and comments so a literal like
+// `'public.api_keys is private'` doesn't falsely trip.
+//
+// This is defense-in-depth on top of `SET LOCAL search_path TO {tenant}`
+// which already locks down unqualified resolution. Both layers have to be
+// bypassed to reach another schema.
+var forbiddenSchemaRe = regexp.MustCompile(
+	`(?i)\b(public|pg_catalog|information_schema|tenant_[a-z0-9_]+)\b\s*\.`,
+)
+
+// errMultiStatement is returned when a cron SQL action contains more than
+// one statement. The previous `SET search_path TO X; <action>` pattern
+// concatenated multiple statements and let the second one drop into any
+// schema — this rejects that shape.
+var errMultiStatement = errors.New("cron sql action must be a single statement")
+
+// errForbiddenSchema is returned when a cron SQL action references a
+// schema outside the calling tenant.
+var errForbiddenSchema = errors.New("cron sql action references a forbidden schema (public, pg_catalog, information_schema, or another tenant)")
+
+// validateCronSQLAction guards the user-supplied `action_type='sql'` text
+// against the privilege escalation paths that closed advisory
+// GHSA-fjjq-cqq9-q793. It rejects:
+//   - empty input
+//   - multi-statement input
+//   - any reference to a forbidden schema (after string/comment stripping)
+//
+// It does NOT validate that the SQL is syntactically valid or that the
+// referenced tables exist — Postgres will surface those errors when the
+// statement runs.
+func validateCronSQLAction(action string) error {
+	trimmed := strings.TrimSpace(action)
+	if trimmed == "" {
+		return errors.New("empty cron sql action")
+	}
+	if query.HasMultipleStatements(trimmed) {
+		return errMultiStatement
+	}
+	if forbiddenSchemaRe.MatchString(stripStringsAndComments(trimmed)) {
+		return errForbiddenSchema
+	}
+	return nil
+}
+
+// validateCronRPCName accepts only safe identifiers — letters, digits,
+// underscores, leading non-digit. Function lookup happens through the
+// tenant search_path, so the name can refer to a tenant-owned function
+// only.
+func validateCronRPCName(name string) error {
+	if !validRPCNameRe.MatchString(strings.TrimSpace(name)) {
+		return errors.New("invalid rpc function name (use letters, digits, underscores)")
+	}
+	return nil
+}
+
+// stripStringsAndComments returns the SQL with single-quoted strings,
+// double-quoted identifiers, dollar-quoted strings, line comments, and
+// block comments replaced by spaces. The resulting text preserves the
+// non-quoted structure so an identifier-pair regex can run without false
+// positives on quoted text. Mirrors the scanner in
+// internal/query/multistmt.go.
+func stripStringsAndComments(sql string) string {
+	out := make([]byte, 0, len(sql))
+	emit := func(c byte) { out = append(out, c) }
+	skip := func(b []byte) {
+		for range b {
+			out = append(out, ' ')
+		}
+	}
+
+	s := sql
+	i := 0
+	n := len(s)
+	for i < n {
+		c := s[i]
+		switch {
+		case c == '\'':
+			j := i + 1
+			for j < n {
+				if s[j] == '\'' {
+					if j+1 < n && s[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			skip([]byte(s[i:j]))
+			i = j
+		case c == '"':
+			j := i + 1
+			for j < n {
+				if s[j] == '"' {
+					if j+1 < n && s[j+1] == '"' {
+						j += 2
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			skip([]byte(s[i:j]))
+			i = j
+		case c == '-' && i+1 < n && s[i+1] == '-':
+			j := i + 2
+			for j < n && s[j] != '\n' {
+				j++
+			}
+			skip([]byte(s[i:j]))
+			i = j
+		case c == '/' && i+1 < n && s[i+1] == '*':
+			j := i + 2
+			depth := 1
+			for j < n && depth > 0 {
+				if j+1 < n && s[j] == '/' && s[j+1] == '*' {
+					depth++
+					j += 2
+					continue
+				}
+				if j+1 < n && s[j] == '*' && s[j+1] == '/' {
+					depth--
+					j += 2
+					continue
+				}
+				j++
+			}
+			skip([]byte(s[i:j]))
+			i = j
+		case c == '$':
+			tagEnd := i + 1
+			for tagEnd < n && isDollarTagChar(s[tagEnd], tagEnd == i+1) {
+				tagEnd++
+			}
+			if tagEnd >= n || s[tagEnd] != '$' {
+				emit(c)
+				i++
+				continue
+			}
+			tag := s[i : tagEnd+1]
+			closer := strings.Index(s[tagEnd+1:], tag)
+			if closer < 0 {
+				skip([]byte(s[i:]))
+				i = n
+				continue
+			}
+			end := tagEnd + 1 + closer + len(tag)
+			skip([]byte(s[i:end]))
+			i = end
+		default:
+			emit(c)
+			i++
+		}
+	}
+	return string(out)
+}
+
+func isDollarTagChar(c byte, first bool) bool {
+	if first {
+		return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+	}
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}

--- a/internal/cron/validate_test.go
+++ b/internal/cron/validate_test.go
@@ -1,0 +1,134 @@
+package cron
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Closes advisory GHSA-fjjq-cqq9-q793 — cron SQL action validation.
+//
+// Each case asserts the *outcome* (accepted vs. rejected) rather than a
+// specific error value where multiple rejection reasons could apply, so a
+// regression that flips the rejection reason still trips the test.
+
+func TestValidateCronSQLAction_Accepts(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"simple insert", "INSERT INTO events (name) VALUES ('rollup')"},
+		{"insert with comment", "-- nightly\nINSERT INTO events (n) VALUES (1)"},
+		{"trailing semicolon ok", "DELETE FROM stale_rows WHERE created_at < now() - interval '7 days';"},
+		{"select with cte", "WITH t AS (SELECT 1) INSERT INTO events SELECT * FROM t"},
+		{"string literal containing forbidden word is fine", "INSERT INTO logs (msg) VALUES ('see public.api_keys for context')"},
+		{"qualified function from pg_catalog disallowed", ""}, // sentinel; intentionally empty — see Rejects table
+	}
+	for _, tc := range cases {
+		if tc.sql == "" {
+			continue // skipped sentinel
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateCronSQLAction(tc.sql); err != nil {
+				t.Errorf("validateCronSQLAction(%q) returned %v, want nil", tc.sql, err)
+			}
+		})
+	}
+}
+
+func TestValidateCronSQLAction_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		sql     string
+		wantErr error
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "  \n\t ", nil},
+		{"multi statement", "INSERT INTO a VALUES (1); INSERT INTO b VALUES (2)", errMultiStatement},
+		{
+			"multi statement with trailing dml after schema escape",
+			"SELECT 1; UPDATE public.projects SET owner_id = '00000000-0000-0000-0000-000000000000' WHERE slug = 'victim'",
+			errMultiStatement,
+		},
+		{"public schema reference", "SELECT * FROM public.api_keys", errForbiddenSchema},
+		{"public schema mixed case", "select * from PuBLic.projects", errForbiddenSchema},
+		{"pg_catalog reference", "SELECT oid FROM pg_catalog.pg_class", errForbiddenSchema},
+		{"information_schema reference", "SELECT table_name FROM information_schema.tables", errForbiddenSchema},
+		{"cross-tenant reference", "SELECT * FROM tenant_other_uuid.users", errForbiddenSchema},
+		{"forbidden schema with whitespace before dot", "SELECT * FROM public  . api_keys", errForbiddenSchema},
+		{"forbidden schema inside line comment evaded by stripping comment", "-- public.api_keys\nSELECT 1 FROM events", nil}, // comment stripped → ok
+		{"forbidden schema in block comment evaded", "/* public.api_keys */ SELECT 1 FROM events", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCronSQLAction(tc.sql)
+			if tc.wantErr == nil && tc.name == "forbidden schema inside line comment evaded by stripping comment" {
+				// This case asserts the validator does NOT trip on a
+				// commented-out forbidden ref — comments are stripped
+				// before the regex.
+				if err != nil {
+					t.Errorf("validateCronSQLAction(%q) returned %v, want nil (forbidden ref is in comment)", tc.sql, err)
+				}
+				return
+			}
+			if tc.wantErr == nil && (tc.name == "empty" || tc.name == "whitespace only") {
+				if err == nil {
+					t.Errorf("validateCronSQLAction(%q) returned nil, want non-nil empty error", tc.sql)
+				}
+				return
+			}
+			if tc.wantErr == nil && tc.name == "forbidden schema in block comment evaded" {
+				if err != nil {
+					t.Errorf("validateCronSQLAction(%q) returned %v, want nil", tc.sql, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateCronSQLAction(%q) returned nil, want %v", tc.sql, tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("validateCronSQLAction(%q) returned %v, want %v", tc.sql, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCronRPCName(t *testing.T) {
+	good := []string{"rollup_daily", "_internal", "fn1", "send_emails"}
+	bad := []string{"", "1starts_with_digit", "has space", "has-dash", "has.dot", "has;semicolon", "DROP TABLE x", "with(parens)"}
+
+	for _, n := range good {
+		if err := validateCronRPCName(n); err != nil {
+			t.Errorf("validateCronRPCName(%q) returned %v, want nil", n, err)
+		}
+	}
+	for _, n := range bad {
+		if err := validateCronRPCName(n); err == nil {
+			t.Errorf("validateCronRPCName(%q) returned nil, want error", n)
+		}
+	}
+}
+
+func TestStripStringsAndComments(t *testing.T) {
+	cases := []struct {
+		in       string
+		mustKeep string // non-empty: must appear in output
+		mustHide string // non-empty: must NOT appear in output
+	}{
+		{"SELECT 'public.api_keys' AS x", "x", "public.api_keys"},
+		{"-- public.api_keys\nSELECT 1", "SELECT 1", "public.api_keys"},
+		{"/* public.api_keys */ SELECT 1", "SELECT 1", "public.api_keys"},
+		{"SELECT $$public.api_keys$$ AS s", "AS s", "public.api_keys"},
+		{"SELECT $tag$public.api_keys$tag$ AS s", "AS s", "public.api_keys"},
+		{`SELECT "weird.col" FROM t`, "FROM t", `weird.col`},
+	}
+	for _, tc := range cases {
+		got := stripStringsAndComments(tc.in)
+		if tc.mustKeep != "" && !strings.Contains(got, tc.mustKeep) {
+			t.Errorf("stripStringsAndComments(%q) = %q, missing expected %q", tc.in, got, tc.mustKeep)
+		}
+		if tc.mustHide != "" && strings.Contains(got, tc.mustHide) {
+			t.Errorf("stripStringsAndComments(%q) = %q, contains forbidden %q", tc.in, got, tc.mustHide)
+		}
+	}
+}

--- a/internal/enduser/auth_service.go
+++ b/internal/enduser/auth_service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -21,6 +22,16 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// ErrAccountExistsLinkRequired is returned when an OAuth callback resolves
+// to an email that matches an existing user but no provider identity is
+// linked yet. The caller must reject the OAuth signin and tell the user
+// to first sign in with their existing credentials, then add the provider
+// from a settings page (where the link can be authenticated by the
+// existing user, not by the OAuth provider's email claim).
+//
+// Closed advisory GHSA-269x-fqhj-x9jq.
+var ErrAccountExistsLinkRequired = errors.New("account exists — sign in with your existing credentials and link this provider from settings")
 
 // asService runs fn in a service-role transaction. All queries against
 // tenant schemas in AuthService go through this so RLS policies permit
@@ -683,55 +694,58 @@ func (s *AuthService) SignInWithOAuth(ctx context.Context, schemaName, jwtSecret
 		}
 
 		if err == pgx.ErrNoRows {
-			// Try to find existing user by email (link accounts).
+			// Closed advisory GHSA-269x-fqhj-x9jq: previously this branch
+			// auto-linked the OAuth identity to any existing user with a
+			// matching email — without checking the provider's email-
+			// verified flag and without an out-of-band confirmation. An
+			// attacker who could create a provider account claiming a
+			// victim's address could take over the victim's account.
+			//
+			// We now refuse to auto-link entirely. If the email matches an
+			// existing user, the OAuth flow returns ErrAccountExistsLinkRequired
+			// and the caller surfaces a "sign in with your existing
+			// credentials and add this provider from settings" error.
 			emailLower := strings.ToLower(strings.TrimSpace(userInfo.Email))
 			findByEmailQ := fmt.Sprintf(
-				`SELECT id, email, display_name, avatar_url, metadata, banned_at, created_at, updated_at
-				 FROM %s.users
-				 WHERE email = $1`,
+				`SELECT 1 FROM %s.users WHERE email = $1`,
 				quoteIdent(schemaName),
 			)
-			err = tx.QueryRow(ctx, findByEmailQ, emailLower).
-				Scan(&user.ID, &user.Email, &user.DisplayName, &user.AvatarURL, &metadataJSON, &bannedAt, &user.CreatedAt, &user.UpdatedAt)
-
-			if err == pgx.ErrNoRows {
-				// Create new user.
-				var displayName *string
-				if userInfo.Name != "" {
-					displayName = &userInfo.Name
-				}
-				var avatarURL *string
-				if userInfo.AvatarURL != "" {
-					avatarURL = &userInfo.AvatarURL
-				}
-
-				insertQ := fmt.Sprintf(
-					`INSERT INTO %s.users (email, display_name, avatar_url, provider, provider_user_id, email_confirmed_at, metadata)
-					 VALUES ($1, $2, $3, $4, $5, now(), '{}'::jsonb)
-					 RETURNING id, email, display_name, avatar_url, metadata, created_at, updated_at`,
-					quoteIdent(schemaName),
-				)
-				err = tx.QueryRow(ctx, insertQ, emailLower, displayName, avatarURL, providerName, userInfo.ProviderID).
-					Scan(&user.ID, &user.Email, &user.DisplayName, &user.AvatarURL, &metadataJSON, &user.CreatedAt, &user.UpdatedAt)
-				if err != nil {
-					return fmt.Errorf("create oauth user: %w", err)
-				}
-				_ = json.Unmarshal(metadataJSON, &user.Metadata)
-				slog.Info("end-user signed up via oauth", "schema", schemaName, "user_id", user.ID, "provider", providerName)
-			} else if err != nil {
+			var exists int
+			err = tx.QueryRow(ctx, findByEmailQ, emailLower).Scan(&exists)
+			if err == nil {
+				slog.Warn("oauth signup blocked — email already registered to another identity",
+					"schema", schemaName, "provider", providerName, "email_lower", emailLower)
+				return ErrAccountExistsLinkRequired
+			}
+			if err != pgx.ErrNoRows {
 				return fmt.Errorf("query user by email: %w", err)
-			} else {
-				// Existing user found by email — auto-confirm email.
-				_ = json.Unmarshal(metadataJSON, &user.Metadata)
-				confirmQ := fmt.Sprintf(
-					`UPDATE %s.users SET email_confirmed_at = COALESCE(email_confirmed_at, now()), updated_at = now() WHERE id = $1`,
-					quoteIdent(schemaName),
-				)
-				_, _ = tx.Exec(ctx, confirmQ, user.ID)
-				slog.Info("end-user linked oauth account", "schema", schemaName, "user_id", user.ID, "provider", providerName)
 			}
 
-			// Create identity row (additive — doesn't overwrite other providers).
+			// No existing user for this email — create a fresh one.
+			var displayName *string
+			if userInfo.Name != "" {
+				displayName = &userInfo.Name
+			}
+			var avatarURL *string
+			if userInfo.AvatarURL != "" {
+				avatarURL = &userInfo.AvatarURL
+			}
+
+			insertQ := fmt.Sprintf(
+				`INSERT INTO %s.users (email, display_name, avatar_url, provider, provider_user_id, email_confirmed_at, metadata)
+				 VALUES ($1, $2, $3, $4, $5, now(), '{}'::jsonb)
+				 RETURNING id, email, display_name, avatar_url, metadata, created_at, updated_at`,
+				quoteIdent(schemaName),
+			)
+			err = tx.QueryRow(ctx, insertQ, emailLower, displayName, avatarURL, providerName, userInfo.ProviderID).
+				Scan(&user.ID, &user.Email, &user.DisplayName, &user.AvatarURL, &metadataJSON, &user.CreatedAt, &user.UpdatedAt)
+			if err != nil {
+				return fmt.Errorf("create oauth user: %w", err)
+			}
+			_ = json.Unmarshal(metadataJSON, &user.Metadata)
+			slog.Info("end-user signed up via oauth", "schema", schemaName, "user_id", user.ID, "provider", providerName)
+
+			// Create identity row.
 			upsertIdentityQ := fmt.Sprintf(
 				`INSERT INTO %s.user_identities (user_id, provider, provider_user_id, identity_data, last_sign_in_at)
 				 VALUES ($1, $2, $3, $4, now())

--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -2,6 +2,7 @@ package enduser
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -538,7 +539,16 @@ func HandleOAuthCallback(svc *AuthService) http.HandlerFunc {
 		resp, err := svc.SignInWithOAuth(r.Context(), pc.SchemaName, pc.JWTSecret, pc.ProjectID, config, providerName, code, callbackURL)
 		if err != nil {
 			slog.Warn("oauth signin failed", "error", err, "provider", providerName, "project_id", pc.ProjectID)
-			// Redirect to client with error.
+			// Closed advisory GHSA-269x-fqhj-x9jq: when OAuth signin
+			// resolves to an existing user by email but no provider
+			// identity is linked, refuse to auto-link. Surface a
+			// distinct error code so client apps can guide the user
+			// to sign in with their existing credentials and link
+			// the provider from settings.
+			if errors.Is(err, ErrAccountExistsLinkRequired) {
+				redirectWithError(w, r, clientRedirectURL, "account_exists_link_required", err.Error())
+				return
+			}
 			redirectWithError(w, r, clientRedirectURL, "oauth_error", err.Error())
 			return
 		}

--- a/internal/enduser/oauth_link_test.go
+++ b/internal/enduser/oauth_link_test.go
@@ -1,0 +1,54 @@
+package enduser
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Closes advisory GHSA-269x-fqhj-x9jq — OAuth callback must not auto-link
+// to an existing user by email. The new behaviour returns
+// ErrAccountExistsLinkRequired which the handler maps to a distinct
+// redirect error code.
+//
+// The full path (real OAuth provider exchange + tenant schema + user
+// insert) is exercised by an integration test that requires a live DB.
+// These unit tests cover the surface that doesn't need a database:
+// sentinel identity and error-wrapping behaviour. They guard against
+// accidental sentinel renaming or wrap-stripping in future refactors.
+
+func TestErrAccountExistsLinkRequired_SentinelIsDetectable(t *testing.T) {
+	if ErrAccountExistsLinkRequired == nil {
+		t.Fatal("ErrAccountExistsLinkRequired must be a non-nil error value")
+	}
+	wrapped := fmt.Errorf("oauth callback: %w", ErrAccountExistsLinkRequired)
+	if !errors.Is(wrapped, ErrAccountExistsLinkRequired) {
+		t.Error("errors.Is must detect the sentinel through fmt.Errorf %w wrapping")
+	}
+	other := errors.New("something else")
+	if errors.Is(other, ErrAccountExistsLinkRequired) {
+		t.Error("errors.Is must NOT match an unrelated error against the sentinel")
+	}
+}
+
+func TestErrAccountExistsLinkRequired_MessageMentionsLink(t *testing.T) {
+	// The error message is surfaced to the OAuth client as the
+	// error_description query parameter on the redirect. It should
+	// guide the user toward signing in with their existing credentials
+	// rather than reading like a generic OAuth failure.
+	msg := ErrAccountExistsLinkRequired.Error()
+	for _, want := range []string{"account exists", "settings"} {
+		if !contains(msg, want) {
+			t.Errorf("error message %q should mention %q", msg, want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/bucket_test.go
+++ b/internal/storage/bucket_test.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eurobase/euroback/internal/auth"
+)
+
+// Closes advisory GHSA-gvrg-vq6j-j647 — storage bucket name must come
+// from the authenticated ProjectContext, never from the X-Project-Slug
+// request header. The previous version trusted the header verbatim and
+// let any authenticated SDK caller upload/list/signed-url-mint against
+// any tenant's bucket.
+
+func TestBucketForRequest_UsesProjectContextSlug(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/storage/upload", nil)
+	ctx := auth.ContextWithProject(r.Context(), &auth.ProjectContext{
+		ProjectID:  "p1",
+		SchemaName: "tenant_p1",
+		Slug:       "alpha",
+	})
+	r = r.WithContext(ctx)
+
+	got, err := bucketForRequest(r)
+	if err != nil {
+		t.Fatalf("bucketForRequest: unexpected error %v", err)
+	}
+	if got != "eurobase-alpha" {
+		t.Errorf("bucketForRequest = %q, want %q", got, "eurobase-alpha")
+	}
+}
+
+func TestBucketForRequest_IgnoresXProjectSlugHeader(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/storage/upload", nil)
+	r.Header.Set("X-Project-Slug", "victim")
+	ctx := auth.ContextWithProject(r.Context(), &auth.ProjectContext{
+		ProjectID:  "p1",
+		SchemaName: "tenant_p1",
+		Slug:       "alpha",
+	})
+	r = r.WithContext(ctx)
+
+	got, err := bucketForRequest(r)
+	if err != nil {
+		t.Fatalf("bucketForRequest: unexpected error %v", err)
+	}
+	if got == "eurobase-victim" {
+		t.Fatalf("bucketForRequest honored X-Project-Slug header — that's the GHSA-gvrg-vq6j-j647 vector")
+	}
+	if got != "eurobase-alpha" {
+		t.Errorf("bucketForRequest = %q, want %q", got, "eurobase-alpha")
+	}
+}
+
+func TestBucketForRequest_RejectsMissingProjectContext(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/storage/upload", nil)
+	// No ProjectContext on r.Context() — this should fail closed.
+	r.Header.Set("X-Project-Slug", "victim")
+
+	_, err := bucketForRequest(r)
+	if err == nil {
+		t.Fatal("bucketForRequest succeeded with no ProjectContext — must reject")
+	}
+	if !strings.Contains(err.Error(), "project context") {
+		t.Errorf("error = %v, want a project-context-related error", err)
+	}
+}
+
+func TestBucketForRequest_RejectsEmptySlugInContext(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/storage/upload", nil)
+	ctx := auth.ContextWithProject(r.Context(), &auth.ProjectContext{
+		ProjectID:  "p1",
+		SchemaName: "tenant_p1",
+		// Slug intentionally empty — represents a misconfigured upstream
+		// middleware that didn't populate it.
+	})
+	r = r.WithContext(ctx)
+	r.Header.Set("X-Project-Slug", "victim") // header is irrelevant
+
+	_, err := bucketForRequest(r)
+	if err == nil {
+		t.Fatal("bucketForRequest succeeded with empty Slug — must reject (cannot fall back to header)")
+	}
+}

--- a/internal/storage/handler.go
+++ b/internal/storage/handler.go
@@ -79,15 +79,25 @@ func isAuthenticated(r *http.Request) (string, bool) {
 	return "", false
 }
 
-// bucketForRequest derives the tenant's S3 bucket name from the request
-// context. The bucket naming convention is "eurobase-{slug}". The slug is
-// provided via the X-Project-Slug header.
+// bucketForRequest derives the tenant's S3 bucket name from the
+// authenticated ProjectContext. The bucket naming convention is
+// "eurobase-{slug}".
+//
+// The slug is read from auth.ProjectContext only — never from a request
+// header. Reading it from a header (as a previous version did) let any
+// authenticated SDK caller choose another tenant's bucket by sending
+// `X-Project-Slug: victim` (advisory GHSA-gvrg-vq6j-j647).
+//
+// Both the SDK path (apiKeyMiddleware sets ProjectContext.Slug from
+// the API-key → project lookup) and the platform path
+// (PlatformStorageContext sets it after the membership check) populate
+// Slug server-side.
 func bucketForRequest(r *http.Request) (string, error) {
-	slug := r.Header.Get("X-Project-Slug")
-	if slug == "" {
-		return "", fmt.Errorf("missing X-Project-Slug header")
+	pc, ok := auth.ProjectFromContext(r.Context())
+	if !ok || pc == nil || pc.Slug == "" {
+		return "", fmt.Errorf("project context missing — storage requires authenticated project")
 	}
-	return "eurobase-" + slug, nil
+	return "eurobase-" + pc.Slug, nil
 }
 
 // Routes returns a chi.Router with all storage sub-routes mounted.

--- a/internal/tenant/context.go
+++ b/internal/tenant/context.go
@@ -128,13 +128,13 @@ func PlatformStorageContext(pool *pgxpool.Pool) func(http.Handler) http.Handler 
 				return
 			}
 
-			// Inject both the legacy header (for bucket naming) and a
-			// ProjectContext so handlers can read the schema name from
-			// authenticated state rather than the header.
-			r.Header.Set("X-Project-Slug", slug)
+			// Storage handlers read slug + schema from the authenticated
+			// ProjectContext only. The X-Project-Slug header is no longer
+			// trusted (advisory GHSA-gvrg-vq6j-j647).
 			ctx := auth.ContextWithProject(r.Context(), &auth.ProjectContext{
 				ProjectID:  projectID,
 				SchemaName: schema,
+				Slug:       slug,
 			})
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/internal/tenant/members.go
+++ b/internal/tenant/members.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -545,9 +546,20 @@ func hashToken(raw string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// defaultConsoleURL is the production console origin used when the
+// CONSOLE_URL env var is not set. Keeps prod working out of the box and
+// lets dev/staging/self-hosted deployments override.
+const defaultConsoleURL = "https://console.eurobase.app"
+
+func consoleURL() string {
+	if u := strings.TrimRight(os.Getenv("CONSOLE_URL"), "/"); u != "" {
+		return u
+	}
+	return defaultConsoleURL
+}
+
 func renderInviteEmail(projectName, recipientEmail, role, inviterEmail, token string) string {
-	// In production, CONSOLE_URL would be used. For now, hardcode the pattern.
-	acceptURL := fmt.Sprintf("https://console.eurobase.app/invite?token=%s", token)
+	acceptURL := fmt.Sprintf("%s/invite?token=%s", consoleURL(), token)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html>


### PR DESCRIPTION
First of three security-fix PRs from the multi-tenant security review.

## Closes (or contributes to closing — advisories don't auto-close on merge)

- 🔒 [GHSA-fjjq-cqq9-q793](../security/advisories/GHSA-fjjq-cqq9-q793) — Cron SQL privilege escalation across all tenants
- 🔒 [GHSA-gvrg-vq6j-j647](../security/advisories/GHSA-gvrg-vq6j-j647) — Storage bucket from `X-Project-Slug` request header
- 🔒 [GHSA-269x-fqhj-x9jq](../security/advisories/GHSA-269x-fqhj-x9jq) — OAuth callback auto-links existing user by email
- Fixes #57 — Invite email URL hardcoded

## What changed

### C1 — cron SQL hardening (`internal/cron/`)

The previous `pool.Exec(ctx, "SET search_path TO X; <user-sql>")` ran user SQL via pgx's simple-query protocol, executing every `;`-separated statement. Combined with the gateway role's DML on `public.*` and every tenant schema, any project member could pivot to platform takeover.

Now:
- Multi-statement rejected via `query.HasMultipleStatements`
- Forbidden-schema references (`public.`, `pg_catalog.`, `information_schema.`, `tenant_<other>.`) rejected via a regex run on string- and comment-stripped SQL
- Action runs in a transaction with `SET LOCAL search_path TO {tenant}` (no \`, public\`) and `SET LOCAL statement_timeout = '30s'` — both auto-reset on commit
- `action_type='rpc'` validated as a safe identifier and executed via parameterised \`SELECT %s()\`
- Defence-in-depth: `tx.Exec` uses the extended-query protocol so even if the multi-statement guard regressed, only the first statement would run

### C2 — storage bucket from authenticated context (`internal/storage/`, `internal/auth/`, `internal/tenant/`)

`bucketForRequest` previously returned `\"eurobase-\" + r.Header.Get(\"X-Project-Slug\")`. SDK callers sent any slug. Now the slug comes only from `auth.ProjectContext.Slug`, populated server-side:

- `apikey_middleware.go` — added `p.slug` to the API-key lookup query
- `subdomain_middleware.go` — slug is already the URL-derived value, now stored on the context too
- `tenant.PlatformStorageContext` — sets `Slug` after the membership check

The `X-Project-Slug` header is no longer trusted. Failing closed when slug is missing.

### C4 — OAuth account linking refused (`internal/enduser/`)

When `userInfo.Email` matched an existing user, the code signed the OAuth caller in as that user and added the provider-identity row, **without checking the provider's email_verified flag**. Now: return \`ErrAccountExistsLinkRequired\`. The handler maps it to a distinct redirect error code (\`account_exists_link_required\`) so client apps can guide the user to sign in with their existing credentials and link the provider from authenticated settings.

### M9 — invite URL respects CONSOLE_URL env (`internal/tenant/members.go`)

Reads \`CONSOLE_URL\` consistent with the email service; falls back to the production default.

## Tests

| File | Cases |
|---|---|
| `internal/cron/validate_test.go` | Single-statement accepted, multi-statement rejected, public/pg_catalog/information_schema/cross-tenant rejected (incl. case-insensitive + whitespace-before-dot), comment-stripping prevents false positives on commented forbidden refs, dollar-quoted string false-positive avoidance, RPC name regex |
| `internal/storage/bucket_test.go` | Bucket comes from `ProjectContext.Slug`, `X-Project-Slug` header ignored, missing context fails closed, empty Slug fails closed |
| `internal/enduser/oauth_link_test.go` | Sentinel identity through `errors.Is`, helpful user-facing message |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass

## Known test gap

The full `SignInWithOAuth` end-to-end flow (real tenant DB + mocked OAuth provider returning a colliding email) isn't covered here — would need new test infrastructure. The sentinel and the handler's wrapping are tested. Tracked as follow-up.

## After merge

The four security advisories need to be **manually published** (or kept as drafts) — GitHub doesn't auto-publish based on PR merge. Once 0.x release ships in production, advisories should be published so users on older deploys are warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)