### PR TITLE
Sec PR 2: SDK SQL cross-schema guard + tighten system-table RLS

### DIFF
--- a/internal/query/cross_schema.go
+++ b/internal/query/cross_schema.go
@@ -1,0 +1,213 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateNoCrossSchemaRefs returns an error if the SQL contains a
+// qualified reference (`schema.relation`) where the schema is not the
+// caller's tenant schema and is not `pg_temp`.
+//
+// Closes advisory GHSA-5cj5-c9f7-9gcj — without this check the gateway
+// pool's broad cross-schema grants combined with the service-role RLS
+// bypass let any caller with a secret API key read another tenant's
+// data via `SELECT * FROM tenant_<other-uuid>.users`.
+//
+// The check uses a state-machine scanner that recognises:
+//   - single-quoted strings (`'…'`, with `''` escape)
+//   - double-quoted identifiers (`"…"`, with `""` escape)
+//   - dollar-quoted strings (`$$…$$` and `$tag$…$tag$`)
+//   - line comments (`-- …`)
+//   - block comments (`/* … */`, may nest)
+//
+// All five are skipped — content inside them isn't treated as code.
+//
+// Tokens outside those constructs are collected. The scanner reports any
+// `identifier . identifier` pair where the leading identifier names a
+// forbidden schema. This is a textual check rather than an AST parse,
+// so it's deliberately strict: the only legitimate qualified references
+// for an SDK caller's tenant are to its own schema, so disallowing
+// everything else has near-zero legitimate impact.
+//
+// False positives can occur if an alias or column name matches a
+// forbidden schema (e.g. `SELECT public.col FROM t public`). The fix for
+// such queries is to alias to a non-schema name (`SELECT t.col FROM t`).
+//
+// Defence-in-depth alongside `SET LOCAL search_path TO {tenant}` in the
+// engine, the per-tenant role split planned for a follow-up PR, and the
+// existing `is_service_role()` policy bypass for secret-key callers.
+func ValidateNoCrossSchemaRefs(sql, allowedSchema string) error {
+	allowed := strings.ToLower(allowedSchema)
+	idents := scanIdentifiersAndDots(sql)
+
+	// Walk the token stream. When we see ident, dot, ident in sequence,
+	// the leading ident is in the schema position.
+	for i := 0; i+2 < len(idents); i++ {
+		if idents[i].kind != tokIdent {
+			continue
+		}
+		if idents[i+1].kind != tokDot {
+			continue
+		}
+		if idents[i+2].kind != tokIdent {
+			continue
+		}
+		schema := strings.ToLower(idents[i].value)
+		if schema == allowed || schema == "pg_temp" {
+			continue
+		}
+		if schemaIsForbidden(schema) {
+			return fmt.Errorf("references to schema %q are not allowed (only the caller's tenant schema is in scope)", idents[i].value)
+		}
+	}
+	return nil
+}
+
+// schemaIsForbidden returns true for schema names that an SDK caller has
+// no legitimate reason to reach. The list is conservative: anything not
+// the caller's own schema or pg_temp is suspect, but we explicitly reject
+// the high-value targets so the error message is precise.
+func schemaIsForbidden(s string) bool {
+	switch s {
+	case "public", "pg_catalog", "information_schema":
+		return true
+	}
+	if strings.HasPrefix(s, "tenant_") {
+		return true
+	}
+	if strings.HasPrefix(s, "pg_") && s != "pg_temp" {
+		// pg_toast, pg_global, pg_internal — never legitimately
+		// referenced from user SQL.
+		return true
+	}
+	return false
+}
+
+type tokKind int
+
+const (
+	tokIdent tokKind = iota
+	tokDot
+)
+
+type token struct {
+	kind  tokKind
+	value string
+}
+
+// scanIdentifiersAndDots produces a token stream of identifiers and dots
+// from sql, skipping string/comment/dollar-quoted regions. Whitespace and
+// other punctuation are not emitted; consecutive idents (no dot between)
+// stay as separate tokens.
+func scanIdentifiersAndDots(sql string) []token {
+	var out []token
+	s := sql
+	i := 0
+	n := len(s)
+	for i < n {
+		c := s[i]
+		switch {
+		case c == '\'':
+			// Single-quoted string.
+			i++
+			for i < n {
+				if s[i] == '\'' {
+					if i+1 < n && s[i+1] == '\'' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+		case c == '"':
+			// Double-quoted identifier — emit as ident.
+			i++
+			var b strings.Builder
+			for i < n {
+				if s[i] == '"' {
+					if i+1 < n && s[i+1] == '"' {
+						b.WriteByte('"')
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				b.WriteByte(s[i])
+				i++
+			}
+			out = append(out, token{kind: tokIdent, value: b.String()})
+		case c == '-' && i+1 < n && s[i+1] == '-':
+			// Line comment.
+			i += 2
+			for i < n && s[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < n && s[i+1] == '*':
+			// Block comment, may nest.
+			i += 2
+			depth := 1
+			for i < n && depth > 0 {
+				if i+1 < n && s[i] == '/' && s[i+1] == '*' {
+					depth++
+					i += 2
+					continue
+				}
+				if i+1 < n && s[i] == '*' && s[i+1] == '/' {
+					depth--
+					i += 2
+					continue
+				}
+				i++
+			}
+		case c == '$':
+			// Dollar-quoted string with optional tag.
+			tagEnd := i + 1
+			for tagEnd < n && isCrossSchemaDollarTagChar(s[tagEnd], tagEnd == i+1) {
+				tagEnd++
+			}
+			if tagEnd >= n || s[tagEnd] != '$' {
+				// Stray $.
+				i++
+				continue
+			}
+			tag := s[i : tagEnd+1]
+			closer := strings.Index(s[tagEnd+1:], tag)
+			if closer < 0 {
+				return out
+			}
+			i = tagEnd + 1 + closer + len(tag)
+		case c == '.':
+			out = append(out, token{kind: tokDot})
+			i++
+		case isIdentStart(c):
+			start := i
+			i++
+			for i < n && isIdentCont(s[i]) {
+				i++
+			}
+			out = append(out, token{kind: tokIdent, value: s[start:i]})
+		default:
+			i++
+		}
+	}
+	return out
+}
+
+func isCrossSchemaDollarTagChar(c byte, first bool) bool {
+	if first {
+		return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+	}
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentCont(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}

--- a/internal/query/cross_schema_test.go
+++ b/internal/query/cross_schema_test.go
@@ -1,0 +1,120 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+// Closes advisory GHSA-5cj5-c9f7-9gcj — SDK /v1/db/sql callers must not
+// be able to reference any schema other than their own tenant schema.
+
+func TestValidateNoCrossSchemaRefs_AcceptsLegitimateQueries(t *testing.T) {
+	allowed := "tenant_abc"
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"no qualifier", "SELECT id, name FROM users WHERE active = true"},
+		{"own schema qualifier", "SELECT * FROM tenant_abc.users"},
+		{"own schema, mixed case", "SELECT * FROM TENANT_ABC.users"},
+		{"alias.column not a schema", "SELECT u.email, u.name FROM users u"},
+		{"join with aliases", "SELECT u.id, t.title FROM users u JOIN todos t ON t.user_id = u.id"},
+		{"cte and aliased select", "WITH cte AS (SELECT 1 AS x) SELECT cte.x FROM cte"},
+		{"function call no schema", "SELECT now(), count(*) FROM events"},
+		{"string literal that looks like schema ref", "SELECT 'public.api_keys is private' AS msg"},
+		{"line comment containing forbidden ref", "-- public.api_keys\nSELECT 1 FROM events"},
+		{"block comment containing forbidden ref", "/* public.api_keys */ SELECT 1 FROM events"},
+		{"dollar quoted string containing forbidden ref", "SELECT $$public.api_keys$$ AS s FROM events"},
+		{"tagged dollar quoted string", "SELECT $tag$public.api_keys$tag$ AS s FROM events"},
+		{"pg_temp ref allowed", "SELECT * FROM pg_temp.tmp_data"},
+		{"quoted column name with dot doesn't fool scanner", `SELECT t."weird.col" FROM t`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateNoCrossSchemaRefs(tc.sql, allowed); err != nil {
+				t.Errorf("ValidateNoCrossSchemaRefs(%q, %q) = %v, want nil", tc.sql, allowed, err)
+			}
+		})
+	}
+}
+
+func TestValidateNoCrossSchemaRefs_RejectsForbiddenSchemas(t *testing.T) {
+	allowed := "tenant_abc"
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"public schema", "SELECT * FROM public.api_keys"},
+		{"public mixed case", "SELECT * FROM Public.Api_Keys"},
+		{"public quoted", `SELECT * FROM "public".api_keys`},
+		{"pg_catalog ref", "SELECT * FROM pg_catalog.pg_class"},
+		{"information_schema ref", "SELECT * FROM information_schema.tables"},
+		{"other tenant", "SELECT * FROM tenant_other_uuid.users"},
+		{"other tenant with whitespace before dot", "SELECT * FROM tenant_other  .  users"},
+		{"pg_toast ref", "SELECT * FROM pg_toast.foo"},
+		{"public function call", "SELECT public.uuid_generate_v4()"},
+		{"forbidden ref in CTE", "WITH t AS (SELECT * FROM public.projects) SELECT * FROM t"},
+		{"forbidden ref in subquery", "SELECT (SELECT count(*) FROM pg_catalog.pg_class) AS n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateNoCrossSchemaRefs(tc.sql, allowed)
+			if err == nil {
+				t.Fatalf("ValidateNoCrossSchemaRefs(%q, %q) = nil, want non-nil", tc.sql, allowed)
+			}
+			if !strings.Contains(err.Error(), "not allowed") && !strings.Contains(err.Error(), "schema") {
+				t.Errorf("error %v should mention schema/not allowed", err)
+			}
+		})
+	}
+}
+
+func TestValidateNoCrossSchemaRefs_AllowedSchemaIsCaseInsensitive(t *testing.T) {
+	if err := ValidateNoCrossSchemaRefs("SELECT * FROM tenant_xyz.users", "TENANT_XYZ"); err != nil {
+		t.Errorf("case-insensitive match failed: %v", err)
+	}
+	if err := ValidateNoCrossSchemaRefs("SELECT * FROM TENANT_XYZ.users", "tenant_xyz"); err != nil {
+		t.Errorf("case-insensitive match failed (other direction): %v", err)
+	}
+}
+
+func TestScanIdentifiersAndDots_HandlesQuotedAndUnquoted(t *testing.T) {
+	got := scanIdentifiersAndDots(`SELECT "weird name".col FROM "schema-with-dash".rel`)
+	// Expect: ident="weird name", dot, ident=col, ident=schema-with-dash, dot, ident=rel
+	// ("SELECT" and "FROM" are also idents)
+	if len(got) < 6 {
+		t.Fatalf("expected at least 6 tokens, got %d: %+v", len(got), got)
+	}
+	// Find the 'weird name' . col pair.
+	foundQuotedRef := false
+	foundDashRef := false
+	for i := 0; i+2 < len(got); i++ {
+		if got[i].kind == tokIdent && got[i].value == "weird name" &&
+			got[i+1].kind == tokDot && got[i+2].kind == tokIdent && got[i+2].value == "col" {
+			foundQuotedRef = true
+		}
+		if got[i].kind == tokIdent && got[i].value == "schema-with-dash" &&
+			got[i+1].kind == tokDot && got[i+2].kind == tokIdent && got[i+2].value == "rel" {
+			foundDashRef = true
+		}
+	}
+	if !foundQuotedRef {
+		t.Errorf("did not find quoted-ident.col pair; got %+v", got)
+	}
+	if !foundDashRef {
+		t.Errorf("did not find schema-with-dash.rel pair; got %+v", got)
+	}
+}
+
+func TestSchemaIsForbidden(t *testing.T) {
+	for _, s := range []string{"public", "pg_catalog", "information_schema", "pg_toast", "pg_internal", "tenant_abc", "tenant_xyz"} {
+		if !schemaIsForbidden(s) {
+			t.Errorf("schemaIsForbidden(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"pg_temp", "myschema", "alpha", "u"} {
+		if schemaIsForbidden(s) {
+			t.Errorf("schemaIsForbidden(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/query/sql_handler.go
+++ b/internal/query/sql_handler.go
@@ -106,6 +106,16 @@ func handleSQLInternal(engine *QueryEngine, readOnly bool) http.HandlerFunc {
 				jsonError(w, err.Error(), http.StatusBadRequest)
 				return
 			}
+			// Closes advisory GHSA-5cj5-c9f7-9gcj — without this check the
+			// gateway pool's broad cross-schema grants combined with the
+			// service-role RLS bypass let any caller with a secret API key
+			// read another tenant's data via fully-qualified `tenant_<other>.…`
+			// references. The check rejects qualified references to any
+			// schema other than the caller's tenant schema (and pg_temp).
+			if err := ValidateNoCrossSchemaRefs(req.SQL, schema); err != nil {
+				jsonError(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 
 		// Guard: pgx Tx.Exec uses the extended query protocol, which runs

--- a/migrations/000046_rls_system_tables_service_only.down.sql
+++ b/migrations/000046_rls_system_tables_service_only.down.sql
@@ -1,0 +1,56 @@
+-- 000046_rls_system_tables_service_only.down.sql
+--
+-- Reverts the policy tightening on existing tenants. Does NOT downgrade
+-- provision_tenant (the migration system handles that by re-applying
+-- 000040). Restores the permissive `USING (true)` policies that were
+-- previously in place.
+--
+-- This is intentionally lossy: rolling back means accepting the
+-- pre-fix cross-tenant leak vector from advisory GHSA-wcg9-846j-ch78.
+-- Use only if you need to interoperate with code that depends on the
+-- old permissive shape.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_owner  TEXT;
+    v_table  TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL
+    LOOP
+        FOREACH v_table IN ARRAY ARRAY['refresh_tokens', 'email_tokens', 'vault_secrets', 'user_identities']
+        LOOP
+            EXECUTE format(
+                'SELECT tableowner FROM pg_tables WHERE schemaname = %L AND tablename = %L',
+                v_schema, v_table
+            ) INTO v_owner;
+            IF v_owner IS NULL THEN
+                CONTINUE;
+            END IF;
+
+            EXECUTE format('SET LOCAL ROLE %I', v_owner);
+
+            CASE v_table
+                WHEN 'refresh_tokens' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS refresh_tokens_policy ON %I.refresh_tokens', v_schema);
+                    EXECUTE format('CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens USING (true)', v_schema);
+                WHEN 'email_tokens' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS email_tokens_policy ON %I.email_tokens', v_schema);
+                    EXECUTE format('CREATE POLICY email_tokens_policy ON %I.email_tokens USING (true)', v_schema);
+                WHEN 'vault_secrets' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS vault_secrets_policy ON %I.vault_secrets', v_schema);
+                    EXECUTE format('CREATE POLICY vault_secrets_policy ON %I.vault_secrets USING (true)', v_schema);
+                WHEN 'user_identities' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS user_identities_policy ON %I.user_identities', v_schema);
+                    EXECUTE format('CREATE POLICY user_identities_policy ON %I.user_identities USING (true)', v_schema);
+            END CASE;
+
+            RESET ROLE;
+        END LOOP;
+    END LOOP;
+END$$;
+
+COMMIT;

--- a/migrations/000046_rls_system_tables_service_only.up.sql
+++ b/migrations/000046_rls_system_tables_service_only.up.sql
@@ -1,0 +1,315 @@
+-- 000046_rls_system_tables_service_only.up.sql
+--
+-- Closes advisory GHSA-wcg9-846j-ch78 (H8): permissive `USING (true)`
+-- policies on per-tenant system tables let any code path that touches
+-- them under the gateway role leak data across tenants.
+--
+-- Tightens four policies in every existing tenant schema and bakes the
+-- new shape into provision_tenant() so future tenants get them by default:
+--
+--   refresh_tokens  → USING (public.is_service_role())     [auth-only]
+--   email_tokens    → USING (public.is_service_role())     [auth-only]
+--   vault_secrets   → USING (public.is_service_role())     [auth-only]
+--   user_identities → USING (public.is_service_role() OR user_id = public.current_end_user_id())
+--                                                          [own identities visible to the user]
+--
+-- The sample `todos` table keeps its permissive `USING (true)` policy
+-- — it's the SDK demo surface and intentionally world-readable so the
+-- "Hello, world" SDK example works. That isn't a regression: the demo
+-- design has always been public, callers can apply a real preset via
+-- the DDL endpoint.
+--
+-- Idempotent: each policy is DROP'd IF EXISTS before being recreated, so
+-- re-running the migration is safe.
+--
+-- Authorisation: requires the executing role to be the owner of the
+-- tenant tables. Tables provisioned via the post-#43/#44 path are owned
+-- by `eurobase_migrator`. Older tables created via the pre-fix SDK DDL
+-- path were owned by `eurobase_gateway`; migration 000045 grants
+-- `eurobase_gateway TO eurobase_migrator`, so the migrate Job (running
+-- as `eurobase_migrator`) can `SET LOCAL ROLE eurobase_gateway` to drop
+-- gateway-owned policies. We do that defensively per-table.
+
+BEGIN;
+
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_owner  TEXT;
+    v_table  TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL
+    LOOP
+        FOREACH v_table IN ARRAY ARRAY['refresh_tokens', 'email_tokens', 'vault_secrets', 'user_identities']
+        LOOP
+            -- Find the table's owner so we can run DROP/CREATE POLICY as that role.
+            -- Skip if the table doesn't exist (older tenants might predate vault_secrets).
+            EXECUTE format(
+                'SELECT tableowner FROM pg_tables WHERE schemaname = %L AND tablename = %L',
+                v_schema, v_table
+            ) INTO v_owner;
+            IF v_owner IS NULL THEN
+                CONTINUE;
+            END IF;
+
+            EXECUTE format('SET LOCAL ROLE %I', v_owner);
+
+            CASE v_table
+                WHEN 'refresh_tokens' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS refresh_tokens_policy ON %I.refresh_tokens', v_schema);
+                    EXECUTE format(
+                        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+                            USING (public.is_service_role())
+                            WITH CHECK (public.is_service_role())',
+                        v_schema
+                    );
+                WHEN 'email_tokens' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS email_tokens_policy ON %I.email_tokens', v_schema);
+                    EXECUTE format(
+                        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+                            USING (public.is_service_role())
+                            WITH CHECK (public.is_service_role())',
+                        v_schema
+                    );
+                WHEN 'vault_secrets' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS vault_secrets_policy ON %I.vault_secrets', v_schema);
+                    EXECUTE format(
+                        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+                            USING (public.is_service_role())
+                            WITH CHECK (public.is_service_role())',
+                        v_schema
+                    );
+                WHEN 'user_identities' THEN
+                    EXECUTE format('DROP POLICY IF EXISTS user_identities_policy ON %I.user_identities', v_schema);
+                    EXECUTE format(
+                        'CREATE POLICY user_identities_policy ON %I.user_identities
+                            USING (public.is_service_role() OR user_id = public.current_end_user_id())
+                            WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+                        v_schema
+                    );
+            END CASE;
+
+            RESET ROLE;
+        END LOOP;
+
+        RAISE NOTICE 'tightened RLS policies on tenant schema %', v_schema;
+    END LOOP;
+END$$;
+
+-- =============================================================
+-- Update provision_tenant() so new tenants get the tightened policies.
+-- The body is identical to 000040 except for the four policy lines.
+-- =============================================================
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    -- GHSA-wcg9-846j-ch78: tightened from USING(true).
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    -- todos is the SDK sample table; intentionally world-readable so the
+    -- demo Hello-World query works without needing auth setup.
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+
+    -- NULL-safe auth helpers. auth_uid() delegates to public.current_end_user_id()
+    -- (which returns NULL when the GUC is empty rather than raising an
+    -- invalid-uuid-cast error).
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT current_setting(''app.end_user_email'', true);
+         $_$', v_schema_name
+    );
+
+    -- Grant the gateway runtime role access to this tenant schema.
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;
+
+COMMIT;


### PR DESCRIPTION
Second of three security-fix PRs from the multi-tenant security review.

## Closes

- 🔒 [GHSA-5cj5-c9f7-9gcj](../security/advisories/GHSA-5cj5-c9f7-9gcj) — SDK \`/v1/db/sql\` allows cross-schema reads with secret API key
- 🔒 [GHSA-wcg9-846j-ch78](../security/advisories/GHSA-wcg9-846j-ch78) — Permissive \`USING (true)\` RLS policies on tenant system tables

## What changed

### C5 — block cross-schema references in the SDK SQL endpoint

\`SET LOCAL search_path\` only affects *unqualified* name resolution. The gateway role has SELECT on every tenant schema, and the \`is_service_role()\` RLS branch bypasses everything for secret-key callers. So a leaked \`eb_sk_*\` could read any other tenant's data via:

\`\`\`sql
SELECT * FROM tenant_<victim-uuid>.users
\`\`\`

Adds \`query.ValidateNoCrossSchemaRefs(sql, allowedSchema)\`:

- A state-machine scanner tokenises the SQL, correctly handling single-quoted strings, double-quoted identifiers (\`\"foo\"\`), dollar-quoted strings (\`$$…$$\` and \`$tag$…$tag$\`), line comments, and block comments.
- Identifier-dot-identifier sequences are inspected; if the leading identifier names a forbidden schema (\`public\`, \`pg_catalog\`, \`information_schema\`, \`pg_toast\`, or another \`tenant_*\`), the query is rejected.
- The caller's own tenant schema and \`pg_temp\` are explicitly allowed.

Wired into \`handleSQLInternal\` only on the \`readOnly\` (SDK) branch — the platform/console SQL endpoint stays unrestricted for legitimate operational SQL.

Coverage of bypass attempts (all rejected):

| Attempt | Result |
|---|---|
| \`SELECT * FROM public.api_keys\` | rejected |
| Case variation: \`Public.Api_Keys\` | rejected |
| Quoted: \`\"public\".api_keys\` | rejected |
| Whitespace before dot: \`tenant_other  .  users\` | rejected |
| Function call: \`SELECT public.uuid_generate_v4()\` | rejected |
| In CTE / subquery | rejected |
| Forbidden ref hidden in string literal | accepted (correctly — it's a string) |
| Forbidden ref in comment | accepted (correctly — it's a comment) |
| Forbidden ref in dollar-quoted string | accepted (correctly — it's a string) |

### H8 — tighten RLS on system tenant tables

Migration 000046 rewrites the policies on four per-tenant system tables in every existing tenant schema and bakes the new shape into \`provision_tenant()\` so new tenants inherit it:

| Table | Before | After |
|---|---|---|
| \`refresh_tokens\` | \`USING (true)\` | \`USING (public.is_service_role())\` |
| \`email_tokens\` | \`USING (true)\` | \`USING (public.is_service_role())\` |
| \`vault_secrets\` | \`USING (true)\` | \`USING (public.is_service_role())\` |
| \`user_identities\` | \`USING (true)\` | \`USING (public.is_service_role() OR user_id = public.current_end_user_id())\` |

\`todos\` keeps its permissive policy — it's the SDK demo sample table.

The backfill loop runs \`SET LOCAL ROLE\` to each table's owner before \`DROP/CREATE POLICY\`, so it works against both pre-fix gateway-owned tables and post-fix migrator-owned tables (PR #43/#44 normalised ownership going forward).

Idempotent: \`DROP POLICY IF EXISTS\` then \`CREATE POLICY\`. Safe to re-run.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — all packages pass; new tests cover legitimate-query acceptance, forbidden-schema rejection, scanner robustness against quoted/dollar-quoted/commented bypass attempts.
- [ ] Post-deploy: confirm migration ran (\`schema_migrations\` table shows 000046).
- [ ] Post-deploy: SDK \`/v1/db/sql\` rejects cross-schema reference (manual test with a secret key).

## Known follow-ups

- The structural fix recommended in advisory C5 (per-tenant runtime DB role with grants only on its own schema) is not in this PR — it's a larger refactor. The validator in this PR is the recommended interim mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)