### PR TITLE
Sec PR 3d: enforce strict HMAC mode on the functions runner

### DIFF
--- a/deploy/k8s/functions.yaml
+++ b/deploy/k8s/functions.yaml
@@ -61,6 +61,14 @@ spec:
               value: "200"
             - name: CODE_CACHE_TTL_SECONDS
               value: "300"
+            # Closes Phase 2 of GHSA-7428-mvpp-rhr7 layer 3: strict
+            # HMAC verification on every /invoke request. Missing or
+            # invalid signature → 401. Soft-mode warnings observed in
+            # logs after the PR 3c rollout window stabilised should now
+            # be impossible — every gateway pod has the secret and
+            # signs its requests.
+            - name: FUNCTIONS_RUNNER_HMAC_REQUIRE_SIGNED
+              value: "true"
       imagePullSecrets:
         - name: scw-registry
 ---


### PR DESCRIPTION
Phase 2 of advisory [GHSA-7428-mvpp-rhr7](../security/advisories/GHSA-7428-mvpp-rhr7) layer 3.

## What changes

One env var added to \`deploy/k8s/functions.yaml\`:

\`\`\`yaml
- name: FUNCTIONS_RUNNER_HMAC_REQUIRE_SIGNED
  value: \"true\"
\`\`\`

This flips the runner from **soft mode** (warn-only on missing signatures) to **strict mode** (\`401\` on missing or invalid signatures). After the new pod comes up, a cluster-internal attacker without the shared HMAC secret cannot reach \`functions:8000/invoke\`.

## Why now

After #68 deployed (PR 3c), I confirmed:

- Both gateway pods logged \`functions runner HMAC signing enabled\` (the secret is in the env, Signer constructed cleanly).
- New gateway and functions pods are on the same image SHA.
- The rolling-update window is past — no \"accepting unsigned request (soft mode)\" warnings expected.

So strict mode is safe to enable. It's a small atomic change so rollback is trivial if anything goes sideways.

## Behaviour matrix after deploy

| Request shape | Pre-PR-3d (soft) | Post-PR-3d (strict) |
|---|---|---|
| Valid HMAC | proceed | proceed |
| Wrong HMAC | 401 | 401 |
| Out-of-window timestamp | 401 | 401 |
| Missing signature header | warn + proceed | **401** |

## Test plan

- [x] \`go build ./...\` (no Go change but sanity)
- [x] \`go vet ./...\`
- [ ] Post-deploy: confirm runner logs show no errors
- [ ] Post-deploy negative test: \`kubectl exec -it <a-non-functions-pod> -- curl -X POST http://functions:8000/invoke -H \"X-Function-ID: any\"\` — must return 401 (was 400 in soft mode)
- [ ] Post-deploy positive test: invoke a real function from the SDK — must succeed

## After this lands

Advisory \`GHSA-7428-mvpp-rhr7\` (C3) is fully closed in production across all three layers:

| Layer | What | When |
|---|---|---|
| 1 | Per-tenant DB role | merged in #66, deployed |
| 2 | Worker isolate | merged in #67, deployed |
| 3 | HMAC (signing infra) | merged in #68, deployed |
| 3 | HMAC (strict enforcement) | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)