### PR TITLE
Hotfix: vault writes broken since PR #65 (RLS regression)

### DIFF
--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -12,9 +12,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eurobase/euroback/internal/db"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// All vault methods run inside a service-role transaction (db.RunAsService)
+// because PR #65 (advisory GHSA-wcg9-846j-ch78) tightened the RLS policy
+// on tenant_*.vault_secrets to `USING (public.is_service_role())`. The
+// previous direct pool queries silently failed RLS after that migration
+// applied — closes #71. Same pattern that AuthService uses.
 
 // quoteIdent double-quotes a SQL identifier, escaping embedded double quotes.
 func quoteIdent(name string) string {
@@ -99,21 +106,26 @@ func (s *VaultService) decrypt(ciphertext, nonce []byte) (string, error) {
 func (s *VaultService) List(ctx context.Context, schemaName string) ([]Secret, error) {
 	sql := `SELECT id, name, description, created_at, updated_at
 		 FROM ` + vaultTable(schemaName) + ` ORDER BY name`
-	rows, err := s.pool.Query(ctx, sql)
-	if err != nil {
-		return nil, fmt.Errorf("list vault secrets: %w", err)
-	}
-	defer rows.Close()
-
 	secrets := make([]Secret, 0)
-	for rows.Next() {
-		var sec Secret
-		if err := rows.Scan(&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("scan vault secret: %w", err)
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, sql)
+		if err != nil {
+			return fmt.Errorf("list vault secrets: %w", err)
 		}
-		secrets = append(secrets, sec)
+		defer rows.Close()
+		for rows.Next() {
+			var sec Secret
+			if err := rows.Scan(&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt); err != nil {
+				return fmt.Errorf("scan vault secret: %w", err)
+			}
+			secrets = append(secrets, sec)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return secrets, rows.Err()
+	return secrets, nil
 }
 
 // Get returns a single decrypted secret by name.
@@ -123,10 +135,12 @@ func (s *VaultService) Get(ctx context.Context, schemaName, name string) (*Secre
 
 	var sec Secret
 	var encrypted, nonce []byte
-	err := s.pool.QueryRow(ctx, sql, name).Scan(
-		&sec.ID, &sec.Name, &encrypted, &nonce,
-		&sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
-	)
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, sql, name).Scan(
+			&sec.ID, &sec.Name, &encrypted, &nonce,
+			&sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
+		)
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, fmt.Errorf("secret %q not found", name)
@@ -161,9 +175,11 @@ func (s *VaultService) Set(ctx context.Context, schemaName, name, value, descrip
 		 RETURNING id, name, description, created_at, updated_at`
 
 	var sec Secret
-	err = s.pool.QueryRow(ctx, sql, name, encrypted, nonce, description).Scan(
-		&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
-	)
+	err = db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, sql, name, encrypted, nonce, description).Scan(
+			&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
+		)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("upsert vault secret: %w", err)
 	}
@@ -193,9 +209,11 @@ func (s *VaultService) Update(ctx context.Context, schemaName, name string, newV
 			 RETURNING id, name, description, created_at, updated_at`
 
 		var sec Secret
-		err = s.pool.QueryRow(ctx, sql, name, encrypted, nonce, newDescription).Scan(
-			&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
-		)
+		err = db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+			return tx.QueryRow(ctx, sql, name, encrypted, nonce, newDescription).Scan(
+				&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
+			)
+		})
 		if err != nil {
 			if err == pgx.ErrNoRows {
 				return nil, fmt.Errorf("secret %q not found", name)
@@ -213,9 +231,11 @@ func (s *VaultService) Update(ctx context.Context, schemaName, name string, newV
 		 RETURNING id, name, description, created_at, updated_at`
 
 	var sec Secret
-	err := s.pool.QueryRow(ctx, sql, name, *newDescription).Scan(
-		&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
-	)
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, sql, name, *newDescription).Scan(
+			&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
+		)
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, fmt.Errorf("secret %q not found", name)
@@ -228,11 +248,19 @@ func (s *VaultService) Update(ctx context.Context, schemaName, name string, newV
 // Delete removes a secret by name.
 func (s *VaultService) Delete(ctx context.Context, schemaName, name string) error {
 	sql := `DELETE FROM ` + vaultTable(schemaName) + ` WHERE name = $1`
-	tag, err := s.pool.Exec(ctx, sql, name)
+	var rowsAffected int64
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, sql, name)
+		if err != nil {
+			return err
+		}
+		rowsAffected = tag.RowsAffected()
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("delete vault secret: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
+	if rowsAffected == 0 {
 		return fmt.Errorf("secret %q not found", name)
 	}
 	return nil
@@ -242,7 +270,9 @@ func (s *VaultService) Delete(ctx context.Context, schemaName, name string) erro
 func (s *VaultService) Count(ctx context.Context, schemaName string) (int, error) {
 	sql := `SELECT count(*) FROM ` + vaultTable(schemaName)
 	var count int
-	err := s.pool.QueryRow(ctx, sql).Scan(&count)
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, sql).Scan(&count)
+	})
 	if err != nil {
 		return 0, fmt.Errorf("count vault secrets: %w", err)
 	}
@@ -294,7 +324,9 @@ func (s *VaultService) DeleteRaw(ctx context.Context, schemaName, name string) e
 func (s *VaultService) HasRaw(ctx context.Context, schemaName, name string) (bool, error) {
 	sql := `SELECT EXISTS(SELECT 1 FROM ` + vaultTable(schemaName) + ` WHERE name = $1)`
 	var exists bool
-	err := s.pool.QueryRow(ctx, sql, name).Scan(&exists)
+	err := db.RunAsService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, sql, name).Scan(&exists)
+	})
 	if err != nil {
 		return false, fmt.Errorf("check vault secret: %w", err)
 	}

--- a/internal/vault/service_test.go
+++ b/internal/vault/service_test.go
@@ -1,0 +1,256 @@
+package vault
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Closes #71 (regression introduced in PR #65). PR #65 tightened the
+// vault_secrets RLS policy from `USING (true)` to
+// `USING (public.is_service_role())`. The previous service code talked
+// directly to the gateway pool with no service-role context — every
+// vault operation silently failed RLS. These tests pin the round-trip
+// so the regression class can't recur.
+//
+// Run locally with a real Postgres + applied migrations + the test
+// project provisioned by setupTestDB-equivalent. Skips otherwise.
+
+func setupVaultTest(t *testing.T) (*VaultService, string, func()) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = "postgres://eurobase_api:localdev@localhost:5433/eurobase?sslmode=disable"
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Skipf("cannot connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("cannot ping test database: %v", err)
+	}
+
+	// Generate a 32-byte AES key for the test, base64-encoded.
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		pool.Close()
+		t.Fatalf("rand.Read: %v", err)
+	}
+	encKey := base64.StdEncoding.EncodeToString(keyBytes)
+
+	svc, err := NewVaultService(pool, encKey)
+	if err != nil {
+		pool.Close()
+		t.Fatalf("NewVaultService: %v", err)
+	}
+
+	// Provision a test tenant. Mirrors the pattern from
+	// internal/query/engine_test.go setupTestDB. Reuses the
+	// public.platform_users + public.projects + provision_tenant() chain.
+	hankoUserID := fmt.Sprintf("test-vault-%d", os.Getpid())
+	var ownerID string
+	err = pool.QueryRow(ctx,
+		`INSERT INTO platform_users (hanko_user_id, email)
+		 VALUES ($1, $2)
+		 ON CONFLICT (hanko_user_id) DO UPDATE SET email = EXCLUDED.email
+		 RETURNING id`,
+		hankoUserID, "vaulttest@eurobase.app",
+	).Scan(&ownerID)
+	if err != nil {
+		pool.Close()
+		t.Skipf("cannot create test platform user: %v", err)
+	}
+
+	slug := fmt.Sprintf("test-vault-%d", os.Getpid())
+	schemaPlaceholder := fmt.Sprintf("tenant_test_vault_%d", os.Getpid())
+	s3Placeholder := fmt.Sprintf("eurobase-test-vault-%d", os.Getpid())
+	var projectID string
+	err = pool.QueryRow(ctx,
+		`INSERT INTO projects (owner_id, name, slug, schema_name, s3_bucket, region, plan, status)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, 'provisioning')
+		 RETURNING id`,
+		ownerID, "Vault Test", slug, schemaPlaceholder, s3Placeholder, "fr-par", "free",
+	).Scan(&projectID)
+	if err != nil {
+		pool.Close()
+		t.Skipf("cannot create test project: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `SELECT provision_tenant($1, $2, $3)`, projectID, "Vault Test", "free"); err != nil {
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM platform_users WHERE hanko_user_id = $1`, hankoUserID)
+		pool.Close()
+		t.Skipf("cannot provision tenant: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE projects SET status = 'active' WHERE id = $1`, projectID); err != nil {
+		_, _ = pool.Exec(ctx, `SELECT deprovision_tenant($1)`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM platform_users WHERE hanko_user_id = $1`, hankoUserID)
+		pool.Close()
+		t.Skipf("cannot activate project: %v", err)
+	}
+
+	var schemaName string
+	if err := pool.QueryRow(ctx, `SELECT schema_name FROM projects WHERE id = $1`, projectID).Scan(&schemaName); err != nil {
+		pool.Close()
+		t.Skipf("cannot read schema_name: %v", err)
+	}
+
+	cleanup := func() {
+		ctx := context.Background()
+		_, _ = pool.Exec(ctx, `SELECT deprovision_tenant($1)`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM platform_users WHERE hanko_user_id = $1`, hankoUserID)
+		pool.Close()
+	}
+	t.Cleanup(cleanup)
+	return svc, schemaName, cleanup
+}
+
+// TestVaultRoundTrip_SetGetListDelete is the regression-pin for #71.
+// The pre-fix code path would fail at Set with a 500 because RLS denies
+// the INSERT — no service-role context.
+func TestVaultRoundTrip_SetGetListDelete(t *testing.T) {
+	svc, schema, _ := setupVaultTest(t)
+	ctx := context.Background()
+
+	// Set
+	const name = "TEST_KEY"
+	const value = "s3cr3t-v4lu3"
+	const desc = "test secret"
+	created, err := svc.Set(ctx, schema, name, value, desc)
+	if err != nil {
+		t.Fatalf("Set failed (would have happened pre-fix; #71): %v", err)
+	}
+	if created.Name != name || created.Description != desc {
+		t.Errorf("Set returned %+v, want name=%q desc=%q", created, name, desc)
+	}
+
+	// Get
+	got, err := svc.Get(ctx, schema, name)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.Value != value {
+		t.Errorf("Get returned value %q, want %q", got.Value, value)
+	}
+	if got.Description != desc {
+		t.Errorf("Get returned desc %q, want %q", got.Description, desc)
+	}
+
+	// List
+	all, err := svc.List(ctx, schema)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("List returned %d secrets, want 1", len(all))
+	}
+	for _, s := range all {
+		if s.Value != "" {
+			t.Errorf("List should not include decrypted value, got %q", s.Value)
+		}
+	}
+
+	// Update value + description
+	newVal := "new-value"
+	newDesc := "updated"
+	updated, err := svc.Update(ctx, schema, name, &newVal, &newDesc)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if updated.Description != newDesc {
+		t.Errorf("Update returned desc %q, want %q", updated.Description, newDesc)
+	}
+	got2, _ := svc.Get(ctx, schema, name)
+	if got2.Value != newVal {
+		t.Errorf("Get after Update returned %q, want %q", got2.Value, newVal)
+	}
+
+	// Count
+	count, err := svc.Count(ctx, schema)
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Count = %d, want 1", count)
+	}
+
+	// HasRaw
+	has, err := svc.HasRaw(ctx, schema, name)
+	if err != nil || !has {
+		t.Errorf("HasRaw(existing) = %v, %v; want true, nil", has, err)
+	}
+	hasMissing, err := svc.HasRaw(ctx, schema, "DOES_NOT_EXIST")
+	if err != nil || hasMissing {
+		t.Errorf("HasRaw(missing) = %v, %v; want false, nil", hasMissing, err)
+	}
+
+	// Delete
+	if err := svc.Delete(ctx, schema, name); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	count2, _ := svc.Count(ctx, schema)
+	if count2 != 0 {
+		t.Errorf("Count after Delete = %d, want 0", count2)
+	}
+
+	// Get after delete should error not-found.
+	_, err = svc.Get(ctx, schema, name)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Get after Delete: expected not-found error, got %v", err)
+	}
+}
+
+// TestVaultRawHelpers_AreServiceScoped covers the SetRaw/GetRaw/HasRaw
+// path used by tenant-side OAuth-secret storage. Same regression class
+// as #71 — these wrap Set/Get and inherit the service-role behaviour.
+func TestVaultRawHelpers_AreServiceScoped(t *testing.T) {
+	svc, schema, _ := setupVaultTest(t)
+	ctx := context.Background()
+
+	const name = "OAUTH_GOOGLE_SECRET"
+	const value = "oauth-client-secret-xyz"
+
+	if err := svc.SetRaw(ctx, schema, name, value); err != nil {
+		t.Fatalf("SetRaw failed (would have happened pre-fix; #71): %v", err)
+	}
+	got, err := svc.GetRaw(ctx, schema, name)
+	if err != nil {
+		t.Fatalf("GetRaw failed: %v", err)
+	}
+	if got != value {
+		t.Errorf("GetRaw = %q, want %q", got, value)
+	}
+
+	// GetRaw on missing returns "" with nil error (idempotency for
+	// optional secrets).
+	missing, err := svc.GetRaw(ctx, schema, "NOT_PRESENT")
+	if err != nil {
+		t.Errorf("GetRaw(missing) returned error: %v", err)
+	}
+	if missing != "" {
+		t.Errorf("GetRaw(missing) = %q, want empty", missing)
+	}
+
+	// DeleteRaw is idempotent.
+	if err := svc.DeleteRaw(ctx, schema, "NEVER_EXISTED"); err != nil {
+		t.Errorf("DeleteRaw(missing) returned error: %v", err)
+	}
+	if err := svc.DeleteRaw(ctx, schema, name); err != nil {
+		t.Errorf("DeleteRaw(existing) returned error: %v", err)
+	}
+}


### PR DESCRIPTION
**Closes #71.**

## What broke

PR #65 (advisory [GHSA-wcg9-846j-ch78](../security/advisories/GHSA-wcg9-846j-ch78)) tightened the RLS policy on \`tenant_*.vault_secrets\` from \`USING (true)\` to \`USING (public.is_service_role())\`. The intent was correct: only service-role queries should reach vault rows.

But every \`VaultService\` method queried the gateway pool directly with no service-role GUC set. After #65 deployed:

- \`Set\` returned \`pgx.ErrNoRows\` from the RETURNING clause → handler logged \`set vault secret failed\` → 500 to caller.
- \`Get\` returned \`secret not found\` to callers who definitely had stored secrets.
- \`List\` returned an empty slice.
- \`Update\`/\`Delete\` returned not-found / 0 rows affected.

Affected both the platform path (\`/platform/projects/{id}/vault\`) and the SDK path (\`/v1/vault/{name}\`).

## Fix

Wrap every \`VaultService\` method in \`db.RunAsService\` — same pattern \`AuthService\` already uses against tenant tables for the same reason. Each query now runs in a tx that applies \`SELECT set_config('app.end_user_role', 'service', true)\` first.

Methods rewrapped: \`List\`, \`Get\`, \`Set\`, \`Update\`, \`Delete\`, \`Count\`, \`HasRaw\`. \`encrypt\`/\`decrypt\` are pure crypto, unchanged. The \`Raw\` helpers (\`SetRaw\`/\`GetRaw\`/\`DeleteRaw\`) inherit the fix because they delegate to the wrapped methods.

## Test

\`internal/vault/service_test.go\`:

- \`TestVaultRoundTrip_SetGetListDelete\` — full round-trip: \`Set → Get (decrypts) → List (no value leak) → Update value+desc → Get (verifies new value) → Count → HasRaw existing+missing → Delete → Get (not-found)\`. Pre-fix this would error at \`Set\` with a 500.
- \`TestVaultRawHelpers_AreServiceScoped\` — covers the OAuth-secret code path (\`SetRaw\`/\`GetRaw\`/\`DeleteRaw\`).

Both skip cleanly without \`DATABASE_URL\`. Provisions a fresh test tenant via the same pattern as \`internal/query/engine_test.go::setupTestDB\`.

The two tests are the regression-pin for this class of bug — any future change that drops service-role context for vault queries breaks them.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — full suite green
- [ ] Post-deploy: re-run the original repro:
  \`\`\`json
  setSecret { projectId: \"1ac63ce5-1dd0-49a3-bcfe-559fcb4d8506\", name: \"FAL_AI_KEY\", value: \"...\", description: \"...\" }
  \`\`\`
  Should return success (was 500).

## Why this slipped through #65

The PR 2 test suite covered cron/storage/OAuth/SQL-handler but not vault. Adding a real-DB round-trip test for vault would have caught it the moment migration 000046 applied. This PR adds that test as a regression-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)