### PR TITLE
Invite email: link to GitHub issue tracker

### DIFF
--- a/internal/tenant/members.go
+++ b/internal/tenant/members.go
@@ -558,6 +558,11 @@ func consoleURL() string {
 	return defaultConsoleURL
 }
 
+// issueTrackerURL points to the public GitHub issues for the Eurobase
+// repository. Surfaced in invite emails so collaborators have a clear
+// place to file bug reports or feature requests.
+const issueTrackerURL = "https://github.com/STGime/euroback/issues"
+
 func renderInviteEmail(projectName, recipientEmail, role, inviterEmail, token string) string {
 	acceptURL := fmt.Sprintf("%s/invite?token=%s", consoleURL(), token)
 
@@ -573,7 +578,12 @@ func renderInviteEmail(projectName, recipientEmail, role, inviterEmail, token st
     </a>
   </p>
   <p style="color: #6b7280; font-size: 13px;">This invitation expires in 7 days. If you don't have a Eurobase account, sign up first and then click the link above.</p>
-  <p style="color: #9ca3af; font-size: 12px; margin-top: 32px;">If you didn't expect this invitation, you can safely ignore this email.</p>
+  <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0 16px;">
+  <p style="color: #6b7280; font-size: 13px; margin: 0 0 8px;">
+    Found a bug or have a feature request? <a href="%s" style="color: #2563eb; text-decoration: underline;">Open an issue on GitHub</a>
+    — Eurobase is open source and your feedback shapes the roadmap.
+  </p>
+  <p style="color: #9ca3af; font-size: 12px; margin: 16px 0 0;">If you didn't expect this invitation, you can safely ignore this email.</p>
 </body>
-</html>`, inviterEmail, projectName, role, acceptURL)
+</html>`, inviterEmail, projectName, role, acceptURL, issueTrackerURL)
 }


### PR DESCRIPTION
Adds a footer paragraph to the project-member invite email pointing collaborators at the public GitHub issues.

## Why

You're about to invite more users. Once they're in, they need a clear place to file bugs / feature requests — easier than asking them to search for the repo or message you out-of-band.

## What changed

\`internal/tenant/members.go\`:
- New constant \`issueTrackerURL = \"https://github.com/STGime/euroback/issues\"\`.
- \`renderInviteEmail\` gets a divider + footer paragraph before the existing \"didn't expect this\" line.

## Render

\`\`\`
You're invited to join a project on Eurobase

<inviter> has invited you to project <project> as a <role>.
Click the button below to accept the invitation:

[ Accept Invitation ]

This invitation expires in 7 days. If you don't have a Eurobase account, sign up first and then click the link above.

──────────────
Found a bug or have a feature request? Open an issue on GitHub
— Eurobase is open source and your feedback shapes the roadmap.

If you didn't expect this invitation, you can safely ignore this email.
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/tenant/...\` — all pass
- [ ] Send a real invite after merge; confirm the link in the email points at the issues page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)