### PR TITLE
RLS: auth.* compat helpers + map 42501 to HTTP 403

### DIFF
--- a/console/src/routes/(app)/docs/+page.svelte
+++ b/console/src/routes/(app)/docs/+page.svelte
@@ -948,7 +948,7 @@ app.post('/webhooks/eurobase', express.raw({'{'} type: 'application/json' {'}'})
 
 				<h3 class="text-lg font-semibold text-gray-900">Auth helper functions</h3>
 				<p class="text-sm text-gray-700 leading-relaxed">
-					Eurobase provides built-in functions you can use in RLS policies to access the current user's identity:
+					Eurobase provides built-in functions you can use in RLS policies to access the current user's identity. Both the native (no-dot) and Supabase-style (<code class="bg-gray-100 border border-gray-200 rounded px-1">auth.*</code>) forms are equivalent &mdash; pick whichever reads better. <code class="bg-gray-100 border border-gray-200 rounded px-1">is_service_role()</code> is true for service-key calls and lets you write a single policy that admits both end-users and trusted server-side code.
 				</p>
 
 				<div class="rounded-lg border border-gray-200 overflow-hidden">
@@ -961,11 +961,20 @@ app.post('/webhooks/eurobase', express.raw({'{'} type: 'application/json' {'}'})
 							</tr>
 						</thead>
 						<tbody class="divide-y divide-gray-100">
-							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_uid()</td><td class="px-3 py-1.5 text-gray-500">uuid</td><td class="px-3 py-1.5 text-gray-500">Current user's ID</td></tr>
-							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_email()</td><td class="px-3 py-1.5 text-gray-500">text</td><td class="px-3 py-1.5 text-gray-500">Current user's email</td></tr>
-							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_role()</td><td class="px-3 py-1.5 text-gray-500">text</td><td class="px-3 py-1.5 text-gray-500">'authenticated' or 'anon'</td></tr>
+							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_uid() / auth.uid()</td><td class="px-3 py-1.5 text-gray-500">uuid</td><td class="px-3 py-1.5 text-gray-500">Current user's ID, NULL when no end-user context</td></tr>
+							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_email() / auth.email()</td><td class="px-3 py-1.5 text-gray-500">text</td><td class="px-3 py-1.5 text-gray-500">Current user's email</td></tr>
+							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth_role() / auth.role()</td><td class="px-3 py-1.5 text-gray-500">text</td><td class="px-3 py-1.5 text-gray-500">'service_role', 'authenticated', or 'anon'</td></tr>
+							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">is_service_role()</td><td class="px-3 py-1.5 text-gray-500">boolean</td><td class="px-3 py-1.5 text-gray-500">True for calls made with the service key (bypasses end-user RLS)</td></tr>
+							<tr><td class="px-3 py-1.5 text-gray-700 font-mono">auth.jwt()</td><td class="px-3 py-1.5 text-gray-500">jsonb</td><td class="px-3 py-1.5 text-gray-500">{'{'} sub, email, role {'}'} &mdash; for policies that read JWT claims</td></tr>
 						</tbody>
 					</table>
+				</div>
+
+				<div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 mt-3">
+					<p class="text-xs text-amber-800">
+						<strong>Heads up &mdash; do not redefine <code class="bg-amber-100 border border-amber-200 rounded px-1">auth.uid()</code> in your migrations.</strong>
+						The Supabase boilerplate that reads <code class="bg-amber-100 border border-amber-200 rounded px-1">request.jwt.claims</code> won't work here &mdash; Eurobase uses a different session GUC. The built-in <code class="bg-amber-100 border border-amber-200 rounded px-1">auth.uid()</code> already does the right thing.
+					</p>
 				</div>
 
 				<h3 class="text-lg font-semibold text-gray-900 mt-6">Common RLS patterns</h3>

--- a/internal/query/handler.go
+++ b/internal/query/handler.go
@@ -461,6 +461,17 @@ func handleCallFunction(engine *QueryEngine) http.HandlerFunc {
 // handleQueryError writes the appropriate HTTP error response for a query engine error.
 // Returns true if it handled the error, false if the caller should use a generic 500.
 func handleQueryError(w http.ResponseWriter, err error) bool {
+	if isRLSViolation(err) {
+		policy := extractRLSPolicy(err)
+		body := map[string]string{"error": "row-level security policy denied this operation"}
+		if policy != "" {
+			body["policy"] = policy
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(body)
+		return true
+	}
 	if isUniqueViolation(err) {
 		field := extractConflictField(err)
 		msg := "a record with this value already exists"
@@ -554,6 +565,32 @@ func extractConstraintMessage(err error) string {
 func isUniqueViolation(err error) bool {
 	msg := err.Error()
 	return contains(msg, "SQLSTATE 23505") || contains(msg, "duplicate key") || contains(msg, "unique constraint")
+}
+
+// isRLSViolation checks if the error is a PostgreSQL row-level security check
+// failure (SQLSTATE 42501, "new row violates row-level security policy").
+// SELECT-side denials silently filter rows and never reach this path; only
+// INSERT/UPDATE/DELETE that fail WITH CHECK or USING surface as errors.
+func isRLSViolation(err error) bool {
+	msg := err.Error()
+	return contains(msg, "new row violates row-level security policy") ||
+		(contains(msg, "SQLSTATE 42501") && contains(msg, "row-level security"))
+}
+
+// extractRLSPolicy pulls the policy name out of a Postgres RLS violation
+// message of the form: `new row violates row-level security policy "<name>" for table "<t>"`.
+func extractRLSPolicy(err error) string {
+	msg := err.Error()
+	const marker = "row-level security policy \""
+	idx := strings.Index(msg, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := msg[idx+len(marker):]
+	if end := strings.IndexByte(rest, '"'); end >= 0 {
+		return rest[:end]
+	}
+	return ""
 }
 
 // extractConflictField tries to extract the column name from a unique violation error.

--- a/internal/query/rls_error_test.go
+++ b/internal/query/rls_error_test.go
@@ -1,0 +1,70 @@
+package query
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Closes #77 (part 2): an RLS WITH CHECK violation must not leak as an
+// opaque 500 — it's an authorization failure and the developer needs to
+// see which policy denied the write.
+
+func TestHandleQueryError_RLSViolation_Returns403WithPolicyName(t *testing.T) {
+	err := errors.New(`ERROR: new row violates row-level security policy "own_things" for table "things" (SQLSTATE 42501)`)
+	rr := httptest.NewRecorder()
+	if !handleQueryError(rr, err) {
+		t.Fatal("expected handleQueryError to recognise an RLS violation")
+	}
+	if rr.Code != 403 {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "row-level security policy denied") {
+		t.Errorf("body should explain RLS denial, got %q", body)
+	}
+	if !strings.Contains(body, `"policy":"own_things"`) {
+		t.Errorf("body should include the policy name, got %q", body)
+	}
+}
+
+func TestHandleQueryError_RLSViolation_NoPolicyNameStillSurfaces403(t *testing.T) {
+	// Defensive: if the message format changes and no quoted name is
+	// present, we still want a 403 so the user sees an authz error
+	// rather than a 500 outage.
+	err := errors.New("ERROR: new row violates row-level security policy (SQLSTATE 42501)")
+	rr := httptest.NewRecorder()
+	if !handleQueryError(rr, err) {
+		t.Fatal("expected handleQueryError to recognise an RLS violation without a policy name")
+	}
+	if rr.Code != 403 {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestExtractRLSPolicy_PullsQuotedName(t *testing.T) {
+	cases := map[string]string{
+		`new row violates row-level security policy "own_things" for table "things"`: "own_things",
+		`new row violates row-level security policy "Users can CRUD own X" for table "x"`: "Users can CRUD own X",
+		`new row violates row-level security policy (SQLSTATE 42501)`:                "",
+	}
+	for msg, want := range cases {
+		got := extractRLSPolicy(errors.New(msg))
+		if got != want {
+			t.Errorf("extractRLSPolicy(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}
+
+func TestIsRLSViolation_DoesNotMatchUnrelatedErrors(t *testing.T) {
+	for _, msg := range []string{
+		"duplicate key value violates unique constraint (SQLSTATE 23505)",
+		"null value in column violates not-null constraint (SQLSTATE 23502)",
+		"connection refused",
+	} {
+		if isRLSViolation(errors.New(msg)) {
+			t.Errorf("isRLSViolation(%q) = true, expected false", msg)
+		}
+	}
+}

--- a/migrations/000048_auth_compat_schema.down.sql
+++ b/migrations/000048_auth_compat_schema.down.sql
@@ -1,0 +1,18 @@
+-- 000048_auth_compat_schema.down.sql
+--
+-- Reverse 000048: drop the auth.* compat helpers. Any RLS policies that
+-- reference auth.uid()/auth.role()/auth.email()/auth.jwt() must be
+-- rewritten to use the public/auth_uid equivalents BEFORE running this
+-- down migration. The drop is intentionally not CASCADE so a stray
+-- dependency raises a clear error rather than silently destroying
+-- policies.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS auth.jwt();
+DROP FUNCTION IF EXISTS auth.email();
+DROP FUNCTION IF EXISTS auth.role();
+DROP FUNCTION IF EXISTS auth.uid();
+DROP SCHEMA IF EXISTS auth;
+
+COMMIT;

--- a/migrations/000048_auth_compat_schema.up.sql
+++ b/migrations/000048_auth_compat_schema.up.sql
@@ -1,0 +1,86 @@
+-- 000048_auth_compat_schema.up.sql
+--
+-- Closes #77: Supabase-style RLS policies (USING (auth.uid() = user_id))
+-- silently broke because Eurobase had no auth.uid(). Users who copy-pasted
+-- a Supabase-flavoured CREATE FUNCTION auth.uid() into their migration got
+-- a function that reads `request.jwt.claims` — a GUC the gateway never
+-- populates — so policies always evaluated against NULL.
+--
+-- This migration adds a global `auth` schema with helpers that read the
+-- same `app.end_user_*` GUCs the existing public.current_end_user_id() /
+-- per-tenant auth_uid() chain reads. Both forms now work identically:
+--
+--   USING (auth.uid()  = user_id)   -- Supabase-style, schema-qualified
+--   USING (auth_uid()  = user_id)   -- Eurobase native, search_path-resolved
+--
+-- The functions are STABLE / SECURITY INVOKER and access only session
+-- GUCs already populated by the gateway via SET LOCAL — no privilege
+-- escalation surface.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS auth;
+ALTER SCHEMA auth OWNER TO eurobase_migrator;
+
+-- ── auth.uid() ── current end-user UUID, NULL when no end-user context
+--                  (matches public.current_end_user_id() exactly so any
+--                  Supabase tutorial that uses auth.uid() Just Works).
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
+    LANGUAGE sql STABLE AS $$
+    SELECT public.current_end_user_id()
+$$;
+
+-- ── auth.role() ── PostgREST/Supabase-style role label:
+--                     'service_role'  — service key calls (app.end_user_role='service')
+--                     'authenticated' — end-user JWT present
+--                     'anon'          — neither
+--                   This is purely for policy ergonomics; Eurobase RLS
+--                   should still prefer is_service_role() / auth.uid().
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text
+    LANGUAGE sql STABLE AS $$
+    SELECT CASE
+        WHEN current_setting('app.end_user_role', true) = 'service' THEN 'service_role'
+        WHEN public.current_end_user_id() IS NOT NULL THEN 'authenticated'
+        ELSE 'anon'
+    END
+$$;
+
+-- ── auth.email() ── current end-user email, NULL when not set.
+CREATE OR REPLACE FUNCTION auth.email() RETURNS text
+    LANGUAGE sql STABLE AS $$
+    SELECT NULLIF(current_setting('app.end_user_email', true), '')
+$$;
+
+-- ── auth.jwt() ── synthetic claims object so policies that expect
+--                  `auth.jwt() ->> 'sub'` (Supabase pattern) keep working.
+--                  Keys present: sub, email, role.
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb
+    LANGUAGE sql STABLE AS $$
+    SELECT jsonb_strip_nulls(jsonb_build_object(
+        'sub',   public.current_end_user_id(),
+        'email', NULLIF(current_setting('app.end_user_email', true), ''),
+        'role',  auth.role()
+    ))
+$$;
+
+ALTER FUNCTION auth.uid()   OWNER TO eurobase_migrator;
+ALTER FUNCTION auth.role()  OWNER TO eurobase_migrator;
+ALTER FUNCTION auth.email() OWNER TO eurobase_migrator;
+ALTER FUNCTION auth.jwt()   OWNER TO eurobase_migrator;
+
+-- The functions only read session GUCs and call already-public helpers;
+-- they touch no privileged data. Grant USAGE + EXECUTE to every runtime
+-- role so RLS policies that reference auth.* compile under any of them.
+GRANT USAGE ON SCHEMA auth TO eurobase_gateway, eurobase_function_runner;
+GRANT EXECUTE ON FUNCTION auth.uid()   TO eurobase_gateway, eurobase_function_runner;
+GRANT EXECUTE ON FUNCTION auth.role()  TO eurobase_gateway, eurobase_function_runner;
+GRANT EXECUTE ON FUNCTION auth.email() TO eurobase_gateway, eurobase_function_runner;
+GRANT EXECUTE ON FUNCTION auth.jwt()   TO eurobase_gateway, eurobase_function_runner;
+
+-- Per-tenant <schema>_func roles inherit through eurobase_function_runner
+-- (000047 makes the runner a member of each), so the GRANT above covers
+-- them. eurobase_developer inherits from eurobase_migrator (000044), so
+-- developer/MCP traffic inherits ownership privileges and doesn't need
+-- a separate grant.
+
+COMMIT;


### PR DESCRIPTION
Closes #77.

## Summary
- New migration `000048_auth_compat_schema` adds a global `auth` schema with `auth.uid()`, `auth.role()`, `auth.email()`, `auth.jwt()` — all delegate to the existing `public.current_end_user_id()` / `app.end_user_*` GUCs. Supabase-style policies (`USING (auth.uid() = user_id)`) now Just Work; the native `auth_uid()` helper continues to work unchanged.
- `internal/query/handler.go` recognises `SQLSTATE 42501` / `new row violates row-level security policy "<name>"` and maps it to `403 {"error":"row-level security policy denied this operation","policy":"<name>"}` instead of an opaque 500.
- Docs page lists the new helpers alongside the native ones, calls out `is_service_role()` and `auth.jwt()`, and warns developers not to redefine `auth.uid()` with the Supabase `request.jwt.claims` boilerplate.

## Why
Beta tester wrote `CREATE POLICY ... USING (auth.uid() = user_id)` (Supabase-flavoured), every authenticated SELECT silently returned `[]`, and INSERT/UPDATE produced HTTP 500 with `internal server error` — a maximally hostile failure mode for the most common RLS pattern.

## Test plan
- [x] `go test ./internal/query/...` — 4 new tests in `rls_error_test.go` cover policy-name extraction, missing-name fallback, and non-matching errors
- [x] `go test ./...` clean
- [x] `svelte-check` — no new errors on docs page
- [ ] Smoke after deploy: apply 000048, recreate the `things` table from #77, INSERT with matching `user_id` → 200; INSERT with mismatched `user_id` → 403 with `policy` in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)