### PR TITLE
Functions: implement ctx.vault.get() + Deno test job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,12 @@ jobs:
       - name: Run tests
         # --no-check: skip type-checking remote std imports (slow, not what
         # this job is for — Docker build catches type errors at image-build
-        # time). Permissions: read for blob-URL worker bootstrap, env so
-        # vault_test can set/clear VAULT_ENCRYPTION_KEY, net for the std
-        # assert imports.
-        run: deno test --no-check --allow-read --allow-env --allow-net functions-runner/
+        # time). --unstable-worker-options: needed for sandbox_test.ts
+        # which exercises the `Worker { deno: { permissions: 'none' } }`
+        # API the runtime relies on. Permissions: read for blob-URL worker
+        # bootstrap, env so vault_test can set/clear VAULT_ENCRYPTION_KEY,
+        # net for the std assert imports.
+        run: deno test --no-check --unstable-worker-options --allow-read --allow-env --allow-net functions-runner/
 
   # -------------------------------------------------------------------------
   # MCP server build check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,26 @@ jobs:
       #     npm run check --if-present
 
   # -------------------------------------------------------------------------
+  # Functions runner (Deno) tests — sandbox isolation + ctx.vault.get path
+  # -------------------------------------------------------------------------
+  test-functions-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run tests
+        # --no-check: skip type-checking remote std imports (slow, not what
+        # this job is for — Docker build catches type errors at image-build
+        # time). Permissions: read for blob-URL worker bootstrap, env so
+        # vault_test can set/clear VAULT_ENCRYPTION_KEY, net for the std
+        # assert imports.
+        run: deno test --no-check --allow-read --allow-env --allow-net functions-runner/
+
+  # -------------------------------------------------------------------------
   # MCP server build check
   # -------------------------------------------------------------------------
   test-mcp:
@@ -85,7 +105,7 @@ jobs:
   # Only on main branch after tests pass.
   # -------------------------------------------------------------------------
   deploy:
-    needs: [test-go, test-console, test-mcp]
+    needs: [test-go, test-console, test-mcp, test-functions-runner]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/functions-runner/sandbox_test.ts
+++ b/functions-runner/sandbox_test.ts
@@ -17,7 +17,7 @@
 //  for blob URL loading. The PARENT having permissions does not grant them
 //  to the worker; permissions: 'none' is the load-bearing setting.)
 //
-// CI doesn't currently run Deno tests; these are local + documentation.
+// CI runs these via the test-functions-runner job (.github/workflows/ci.yml).
 
 import { assert, assertEquals, assertStrictEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import type { ParentToWorker, WorkerToParent } from "./bridge.ts";

--- a/functions-runner/server.ts
+++ b/functions-runner/server.ts
@@ -16,6 +16,7 @@ import type {
   WorkerToParent,
 } from "./bridge.ts";
 import { newVerifier, type Verifier } from "./hmac.ts";
+import { resolveVaultSecret } from "./vault.ts";
 
 // Closes GHSA-7428-mvpp-rhr7 layer 1: the runner now connects as
 // `eurobase_function_runner`, a role with no direct grants on any tenant
@@ -266,6 +267,7 @@ async function executeFunction(
     user: userId ? { id: userId, email: userEmail } : null,
     timeoutMs,
     runDBSql,
+    db,
     logCapture,
   });
 }
@@ -283,6 +285,8 @@ async function runUserHandlerInWorker(opts: {
   timeoutMs: number;
   runDBSql: (query: string, params: unknown[]) => Promise<unknown>;
   // deno-lint-ignore no-explicit-any
+  db: any;
+  // deno-lint-ignore no-explicit-any
   logCapture: ReturnType<typeof createLogCapture>;
 }): Promise<Response> {
   const {
@@ -294,6 +298,7 @@ async function runUserHandlerInWorker(opts: {
     user,
     timeoutMs,
     runDBSql,
+    db,
     logCapture,
   } = opts;
 
@@ -392,10 +397,23 @@ async function runUserHandlerInWorker(opts: {
           break;
         }
         case "vault.get.call": {
-          // Vault remains a stub for this PR — see comment in the
-          // legacy ctx.vault.get implementation. Always returns null.
-          const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: null };
-          worker.postMessage(reply);
+          // Closes #79: read the encrypted blob via the SECURITY DEFINER
+          // helper public.vault_get_for_runner (added by migration 000049)
+          // and decrypt locally with VAULT_ENCRYPTION_KEY. Failure modes
+          // (missing secret, no encryption key, decrypt failure) all
+          // resolve to null so the worker contract stays `string | null`.
+          resolveVaultSecret(db, projectId, msg.name)
+            .then((value) => {
+              if (settled) return;
+              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value };
+              worker.postMessage(reply);
+            })
+            .catch((err) => {
+              if (settled) return;
+              console.error(`[fn:${projectId}] vault.get failed`, err);
+              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: null };
+              worker.postMessage(reply);
+            });
           break;
         }
       }

--- a/functions-runner/vault.ts
+++ b/functions-runner/vault.ts
@@ -1,0 +1,80 @@
+// Vault read path for edge functions. Closes #79.
+//
+// Worker calls ctx.vault.get(name) → bridge.ts emits a vault.get.call →
+// server.ts (parent) calls resolveVaultSecret() here → we query
+// public.vault_get_for_runner(projectId, name) (SECURITY DEFINER, granted
+// only to eurobase_function_runner, added by migration 000049), get back
+// the encrypted blob and nonce, and decrypt locally with VAULT_ENCRYPTION_KEY.
+//
+// Layout compatibility with the Go gateway:
+//   gcm.Seal(nil, nonce, plaintext, nil)  → ciphertext || tag (16 bytes)
+//   crypto.subtle.decrypt({name:"AES-GCM", iv}, key, blob)
+// Web Crypto's AES-GCM expects the auth tag appended to the ciphertext —
+// same layout as Go's GCM, so we pass the bytea blob through directly.
+
+const VAULT_ENCRYPTION_KEY = Deno.env.get("VAULT_ENCRYPTION_KEY") ?? "";
+
+let _key: CryptoKey | null = null;
+
+async function getCryptoKey(): Promise<CryptoKey | null> {
+  if (_key) return _key;
+  if (!VAULT_ENCRYPTION_KEY) return null;
+  let raw: Uint8Array;
+  try {
+    raw = Uint8Array.from(atob(VAULT_ENCRYPTION_KEY), (c) => c.charCodeAt(0));
+  } catch (_) {
+    console.error("[vault] VAULT_ENCRYPTION_KEY is not valid base64");
+    return null;
+  }
+  if (raw.byteLength !== 32) {
+    console.error(`[vault] VAULT_ENCRYPTION_KEY must decode to 32 bytes (got ${raw.byteLength})`);
+    return null;
+  }
+  _key = await crypto.subtle.importKey("raw", raw, "AES-GCM", false, ["decrypt"]);
+  return _key;
+}
+
+// resolveVaultSecret returns the decrypted secret value for (projectId, name)
+// or null when the secret doesn't exist, the encryption key isn't configured,
+// or decryption fails. All failure modes return null deliberately — the
+// worker contract is `string | null`, and surfacing exceptions through the
+// RPC bridge would just leak internals to user code.
+export async function resolveVaultSecret(
+  // deno-lint-ignore no-explicit-any
+  db: any,
+  projectId: string,
+  name: string,
+): Promise<string | null> {
+  if (!projectId || !name) return null;
+  const key = await getCryptoKey();
+  if (!key) {
+    console.warn("[vault] VAULT_ENCRYPTION_KEY not configured; ctx.vault.get returns null");
+    return null;
+  }
+
+  // postgres.js returns bytea columns as Uint8Array. The SECURITY DEFINER
+  // function returns at most one row (vault_secrets.name has a unique
+  // constraint) — destructure with a length guard for safety.
+  let rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array }>;
+  try {
+    rows = await db`SELECT encrypted, nonce FROM public.vault_get_for_runner(${projectId}::uuid, ${name})`;
+  } catch (err) {
+    console.error("[vault] DB read failed", err instanceof Error ? err.message : err);
+    return null;
+  }
+  if (!rows || rows.length === 0) return null;
+  const { encrypted, nonce } = rows[0];
+  if (!encrypted || !nonce) return null;
+
+  try {
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: nonce },
+      key,
+      encrypted,
+    );
+    return new TextDecoder().decode(plain);
+  } catch (err) {
+    console.error("[vault] decryption failed", err instanceof Error ? err.message : err);
+    return null;
+  }
+}

--- a/functions-runner/vault.ts
+++ b/functions-runner/vault.ts
@@ -12,16 +12,23 @@
 // Web Crypto's AES-GCM expects the auth tag appended to the ciphertext —
 // same layout as Go's GCM, so we pass the bytea blob through directly.
 
-const VAULT_ENCRYPTION_KEY = Deno.env.get("VAULT_ENCRYPTION_KEY") ?? "";
-
+// Lazy: read VAULT_ENCRYPTION_KEY on first use rather than at module
+// load. Lets tests set the env var after import without resorting to
+// cache-busting URL params, and matches how the gateway boots vault.
 let _key: CryptoKey | null = null;
+let _keyEnv: string | null = null;
 
 async function getCryptoKey(): Promise<CryptoKey | null> {
-  if (_key) return _key;
-  if (!VAULT_ENCRYPTION_KEY) return null;
+  const env = Deno.env.get("VAULT_ENCRYPTION_KEY") ?? "";
+  if (_key && env === _keyEnv) return _key;
+  // Reset if env changed (only meaningful in tests; in production the
+  // pod env is fixed for its lifetime).
+  _key = null;
+  _keyEnv = env;
+  if (!env) return null;
   let raw: Uint8Array;
   try {
-    raw = Uint8Array.from(atob(VAULT_ENCRYPTION_KEY), (c) => c.charCodeAt(0));
+    raw = Uint8Array.from(atob(env), (c) => c.charCodeAt(0));
   } catch (_) {
     console.error("[vault] VAULT_ENCRYPTION_KEY is not valid base64");
     return null;

--- a/functions-runner/vault_test.ts
+++ b/functions-runner/vault_test.ts
@@ -1,0 +1,86 @@
+// Tests for the vault read path. Closes #79.
+//
+// We focus on the decrypt half: given an AES-256-GCM ciphertext + nonce
+// produced exactly the way the Go gateway produces it
+// (gcm.Seal(nil, nonce, plaintext, nil) → ciphertext || tag), the runner
+// must recover the plaintext. The DB query is mocked via a stub `db`
+// tagged-template so the tests are hermetic.
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { resolveVaultSecret } from "./vault.ts";
+
+const KEY_RAW = new Uint8Array(32);
+for (let i = 0; i < 32; i++) KEY_RAW[i] = i;
+const KEY_B64 = btoa(String.fromCharCode(...KEY_RAW));
+
+// Encrypt with the same layout the Go gateway uses so the test exercises
+// the actual on-disk byte format. iv is 12 bytes (GCM standard / what
+// crypto/cipher's NewGCM uses by default).
+async function encryptForGateway(
+  plaintext: string,
+  rawKey: Uint8Array,
+): Promise<{ encrypted: Uint8Array; nonce: Uint8Array }> {
+  const key = await crypto.subtle.importKey("raw", rawKey, "AES-GCM", false, ["encrypt"]);
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const buf = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  return { encrypted: new Uint8Array(buf), nonce };
+}
+
+// Tagged-template stub matching postgres.js's call shape.
+// deno-lint-ignore no-explicit-any
+function stubDB(rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array }>): any {
+  return (_strings: TemplateStringsArray, ..._values: unknown[]) => Promise.resolve(rows);
+}
+
+// deno-lint-ignore no-explicit-any
+function stubDBThrowing(message: string): any {
+  return (_strings: TemplateStringsArray, ..._values: unknown[]) => Promise.reject(new Error(message));
+}
+
+Deno.test("vault.get round-trips a Go-encrypted secret", async () => {
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  // Re-import to pick up the env var (Deno caches modules, but we run
+  // this file once per `deno test` invocation so this is fine).
+  const { resolveVaultSecret: resolve } = await import("./vault.ts?cb=" + Date.now());
+  const { encrypted, nonce } = await encryptForGateway("fal_ai_key_value", KEY_RAW);
+
+  const got = await resolve(stubDB([{ encrypted, nonce }]), "11111111-2222-3333-4444-555555555555", "FAL_AI_KEY");
+  assertEquals(got, "fal_ai_key_value");
+});
+
+Deno.test("vault.get returns null when the secret does not exist", async () => {
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const got = await resolveVaultSecret(stubDB([]), "11111111-2222-3333-4444-555555555555", "MISSING");
+  assertEquals(got, null);
+});
+
+Deno.test("vault.get returns null when the DB query throws (no exception leak)", async () => {
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const got = await resolveVaultSecret(stubDBThrowing("permission denied"), "11111111-2222-3333-4444-555555555555", "X");
+  assertEquals(got, null);
+});
+
+Deno.test("vault.get returns null with no projectId or name (no DB call)", async () => {
+  let called = false;
+  // deno-lint-ignore no-explicit-any
+  const db: any = () => {
+    called = true;
+    return Promise.resolve([]);
+  };
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  assertEquals(await resolveVaultSecret(db, "", "X"), null);
+  assertEquals(await resolveVaultSecret(db, "p", ""), null);
+  assertEquals(called, false);
+});
+
+Deno.test("vault.get returns null when ciphertext was tampered (auth tag mismatch)", async () => {
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const { encrypted, nonce } = await encryptForGateway("secret", KEY_RAW);
+  encrypted[0] ^= 0xff; // flip a bit in the ciphertext
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "p", "K");
+  assertEquals(got, null);
+});

--- a/functions-runner/vault_test.ts
+++ b/functions-runner/vault_test.ts
@@ -43,13 +43,16 @@ function stubDBThrowing(message: string): any {
 
 Deno.test("vault.get round-trips a Go-encrypted secret", async () => {
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
-  // Re-import to pick up the env var (Deno caches modules, but we run
-  // this file once per `deno test` invocation so this is fine).
-  const { resolveVaultSecret: resolve } = await import("./vault.ts?cb=" + Date.now());
   const { encrypted, nonce } = await encryptForGateway("fal_ai_key_value", KEY_RAW);
-
-  const got = await resolve(stubDB([{ encrypted, nonce }]), "11111111-2222-3333-4444-555555555555", "FAL_AI_KEY");
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "11111111-2222-3333-4444-555555555555", "FAL_AI_KEY");
   assertEquals(got, "fal_ai_key_value");
+});
+
+Deno.test("vault.get returns null when VAULT_ENCRYPTION_KEY is unset", async () => {
+  Deno.env.delete("VAULT_ENCRYPTION_KEY");
+  const { encrypted, nonce } = await encryptForGateway("x", KEY_RAW);
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "p", "K");
+  assertEquals(got, null);
 });
 
 Deno.test("vault.get returns null when the secret does not exist", async () => {

--- a/migrations/000049_vault_get_for_runner.down.sql
+++ b/migrations/000049_vault_get_for_runner.down.sql
@@ -1,0 +1,10 @@
+-- 000049_vault_get_for_runner.down.sql
+--
+-- Reverse 000049: drop the SECURITY DEFINER vault read helper. After this
+-- runs, ctx.vault.get(name) inside edge functions returns null again.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.vault_get_for_runner(uuid, text);
+
+COMMIT;

--- a/migrations/000049_vault_get_for_runner.up.sql
+++ b/migrations/000049_vault_get_for_runner.up.sql
@@ -1,0 +1,59 @@
+-- 000049_vault_get_for_runner.up.sql
+--
+-- Closes #79: ctx.vault.get(name) inside an edge function always returned
+-- null because the runner had no way to read tenant_*.vault_secrets — RLS
+-- on that table requires public.is_service_role(), and the runner connects
+-- as eurobase_function_runner which is not a service role.
+--
+-- This migration adds a single SECURITY DEFINER function that the runner
+-- can call to fetch the encrypted blob + nonce for a given (project_id,
+-- secret_name) tuple. The runner decrypts locally using
+-- VAULT_ENCRYPTION_KEY (already present in its env via the
+-- eurobase-secrets k8s Secret) — the encryption key never leaves the
+-- pod, the SECURITY DEFINER scope is keyed on (project_id, name) so
+-- there is no enumeration path, and EXECUTE is granted only to
+-- eurobase_function_runner.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.vault_get_for_runner(
+    p_project_id uuid,
+    p_name       text
+)
+RETURNS TABLE(encrypted bytea, nonce bytea)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_schema text;
+BEGIN
+    -- Resolve the project's tenant schema. SECURITY DEFINER means we
+    -- read public.projects with the function owner's privileges
+    -- (eurobase_migrator), bypassing the runner role's lack of direct
+    -- access. Empty result for unknown project_id — never raises so the
+    -- runner just sees `not found` and replies null to the worker.
+    SELECT schema_name INTO v_schema
+    FROM public.projects
+    WHERE id = p_project_id;
+
+    IF v_schema IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Format-then-USING the parameter avoids any SQL injection through
+    -- p_name since it's bound as a parameter, not interpolated. The
+    -- schema name comes from public.projects (UUID-derived) so it's
+    -- safe to interpolate via %I.
+    RETURN QUERY EXECUTE format(
+        'SELECT secret, nonce FROM %I.vault_secrets WHERE name = $1',
+        v_schema
+    ) USING p_name;
+END;
+$$;
+
+ALTER FUNCTION public.vault_get_for_runner(uuid, text) OWNER TO eurobase_migrator;
+REVOKE ALL ON FUNCTION public.vault_get_for_runner(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.vault_get_for_runner(uuid, text) TO eurobase_function_runner;
+
+COMMIT;


### PR DESCRIPTION
Closes #79.

## Summary
- **Migration 000049** adds \`public.vault_get_for_runner(uuid, text)\`, a SECURITY DEFINER helper owned by \`eurobase_migrator\` and EXECUTE-granted only to \`eurobase_function_runner\`. Returns the encrypted blob + nonce for a (project_id, secret_name) tuple. Schema lookup happens server-side from \`public.projects\` so the function's surface stays narrow.
- **functions-runner/vault.ts** loads \`VAULT_ENCRYPTION_KEY\` (already in the runner pod's env via \`envFrom: eurobase-secrets\`) lazily, calls the SECURITY DEFINER helper, decrypts locally with Web Crypto AES-GCM. Layout matches Go's \`gcm.Seal\` output exactly. Every failure mode (missing secret, no key, decrypt failure, DB error) returns \`null\` so the worker contract stays \`string | null\`.
- **server.ts** replaces the \`vault.get.call\` stub with a call into \`resolveVaultSecret(db, projectId, name)\`.
- **CI** — new \`test-functions-runner\` job runs \`deno test\` on the runner. Picks up \`sandbox_test.ts\` (was dormant) and the new \`vault_test.ts\`. Deploy now gates on it.

## Why
\`ctx.vault.get(name)\` always returned \`null\`. Tenants who wanted to call third-party APIs from a function were forced to copy the secret into \`env_vars\` (plaintext on the function row) — defeating the purpose of having a vault.

## Security note
The runner pod already had \`VAULT_ENCRYPTION_KEY\` in its env (it loads the same \`eurobase-secrets\` Secret as the gateway via \`envFrom\`). This PR uses what's there; no key-distribution changes.

## Test plan
- [x] \`go test ./...\` clean
- [x] Vault tests cover: round-trip, missing secret, DB error, empty inputs, tampered ciphertext (auth-tag mismatch), missing key
- [ ] First-ever Deno CI run — \`deno test --no-check --allow-read --allow-env --allow-net functions-runner/\` against Deno v2.x
- [ ] Smoke after deploy: rewrite \`mood-board\` function to \`const k = await ctx.vault.get('FAL_AI_KEY')\`, expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)