### PR TITLE
Hotfix: pass --unstable-worker-options to runtime deno

### DIFF
--- a/deploy/docker/Dockerfile.fn
+++ b/deploy/docker/Dockerfile.fn
@@ -17,5 +17,10 @@ EXPOSE 8000
 # --allow-net: connect to Postgres, S3, and external HTTPS APIs
 # --allow-env: read configuration from environment variables
 # --allow-read=/app: read cached function code
+# --unstable-worker-options: enables the `Worker { deno: { permissions } }`
+#   API the runner uses to sandbox each invocation. Without this flag,
+#   spawning the per-invocation worker throws and the gateway sees an
+#   EOF on /invoke (every function invocation 502s). Required since
+#   Deno 2.x demoted this API to unstable.
 # --unsafely-ignore-certificate-errors: accept managed DB cert (Scaleway uses internal CA)
-CMD ["deno", "run", "--allow-net", "--allow-env", "--allow-read=/app", "--unsafely-ignore-certificate-errors", "/app/server.ts"]
+CMD ["deno", "run", "--allow-net", "--allow-env", "--allow-read=/app", "--unstable-worker-options", "--unsafely-ignore-certificate-errors", "/app/server.ts"]


### PR DESCRIPTION
**Hotfix.** Every function invocation has been failing with HTTP 502 \`Post \"http://functions:8000/invoke\": EOF\` since the Deno 2.x upgrade — the runner couldn't construct its sandbox worker. Same flag the CI test job needed in #80.

Discovered while testing #79's vault.get path: the function never ran far enough to hit the vault read. Verified via \`edge_function_logs\` for project superapp — both pre- and post-#80 invocations failed identically with EOF, confirming the bug predates the merge.

## Test plan
- [x] CI green (test-functions-runner already has the flag)
- [ ] Smoke after deploy: invoke any function — expect non-502 response (200 if function code is valid, 4xx/5xx with a JSON error body otherwise — but no more EOF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)