### PR TITLE
Sec: validate WebSocket Origin against CORS allowlist (closes #47)

### DIFF
--- a/internal/gateway/cors.go
+++ b/internal/gateway/cors.go
@@ -33,14 +33,7 @@ import (
 // global allowlist. Beta testers hitting `{slug}.eurobase.app` get
 // per-project CORS automatically.
 func NewCORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
-	patterns := make([]originPattern, 0, len(allowedOrigins))
-	for _, o := range allowedOrigins {
-		o = strings.TrimSpace(o)
-		if o == "" {
-			continue
-		}
-		patterns = append(patterns, compileOriginPattern(o))
-	}
+	check := BuildOriginChecker(allowedOrigins)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,15 +43,7 @@ func NewCORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler 
 				return
 			}
 
-			allowed := originAllowed(origin, patterns)
-			if !allowed {
-				if pc, ok := auth.ProjectFromContext(r.Context()); ok && pc != nil && len(pc.AuthConfig) > 0 {
-					cfg := tenant.ParseAuthConfig(pc.AuthConfig)
-					if cfg.IsCORSOriginAllowed(origin) {
-						allowed = true
-					}
-				}
-			}
+			allowed := check(r)
 
 			if !allowed {
 				// Not allowed by global or per-project. For preflight
@@ -92,6 +77,43 @@ func NewCORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler 
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// BuildOriginChecker compiles the global allowlist patterns once and
+// returns a closure that decides per-request whether the request's
+// Origin header is allowed. The closure layers the same two checks as
+// NewCORSMiddleware (global allowlist, then per-project cors_origins
+// from ProjectContext) so anything that needs an origin check —
+// including the WebSocket upgrader — gets identical behaviour.
+//
+// Empty Origin returns false. Callers that want to permit
+// non-CORS-shaped requests (e.g. server-to-server) should branch on
+// that themselves rather than rely on this helper.
+func BuildOriginChecker(allowedOrigins []string) func(*http.Request) bool {
+	patterns := make([]originPattern, 0, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		patterns = append(patterns, compileOriginPattern(o))
+	}
+	return func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return false
+		}
+		if originAllowed(origin, patterns) {
+			return true
+		}
+		if pc, ok := auth.ProjectFromContext(r.Context()); ok && pc != nil && len(pc.AuthConfig) > 0 {
+			cfg := tenant.ParseAuthConfig(pc.AuthConfig)
+			if cfg.IsCORSOriginAllowed(origin) {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -417,7 +417,7 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 		if !isDev {
 			tokenValidator = platformAuth.ValidateToken
 		}
-		wsHandler := realtime.HandleWebSocket(hub, tokenValidator, buildTenantResolver(pool), isDev)
+		wsHandler := realtime.HandleWebSocket(hub, tokenValidator, buildTenantResolver(pool), BuildOriginChecker(allowedOrigins), isDev)
 		r.Get("/v1/realtime", wsHandler)
 	} else {
 		slog.Warn("realtime hub not configured, websocket route disabled")

--- a/internal/realtime/handler.go
+++ b/internal/realtime/handler.go
@@ -15,16 +15,6 @@ const (
 	proConnectionLimit  = 10000
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		// In production, this should validate the Origin header against
-		// allowed origins for the tenant. For now, allow all origins.
-		return true
-	},
-}
-
 // TenantResolver resolves a user subject (Hanko ID) to a tenant ID and plan.
 // It is injected by the caller so the realtime package does not depend on the
 // auth or tenant packages directly.
@@ -36,7 +26,29 @@ type TenantResolver func(ctx context.Context, subject string) (tenantID, plan st
 //
 // tokenValidator, if non-nil, validates the token and returns the user subject.
 // When nil (dev mode), connections are accepted without authentication.
-func HandleWebSocket(hub *Hub, tokenValidator func(token string) (subject string, err error), tenantResolver TenantResolver, devMode bool) http.HandlerFunc {
+//
+// originChecker validates the browser Origin header on the upgrade request.
+// Same layered logic as the HTTP CORS path (global allowlist + per-project
+// cors_origins), built by gateway.BuildOriginChecker. nil → accept all
+// origins, used only in devMode. Closes #47 (CSWSH defence-in-depth).
+func HandleWebSocket(hub *Hub, tokenValidator func(token string) (subject string, err error), tenantResolver TenantResolver, originChecker func(*http.Request) bool, devMode bool) http.HandlerFunc {
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			if devMode {
+				return true
+			}
+			if originChecker == nil {
+				// Production with no checker configured: refuse so a
+				// misconfiguration fails closed rather than falling back
+				// to "allow any origin" (the old behaviour, advisory #47).
+				return false
+			}
+			return originChecker(r)
+		},
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		var tenantID, plan string
 

--- a/internal/realtime/handler_origin_test.go
+++ b/internal/realtime/handler_origin_test.go
@@ -1,0 +1,152 @@
+package realtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// Closes #47. The WS upgrader used to call CheckOrigin → return true
+// unconditionally, leaving the realtime endpoint open to cross-site
+// WebSocket hijacking from any origin. These tests assert the new
+// origin checker is plumbed through and that the previous fail-open
+// behaviour is gone.
+
+// startServer spins up an httptest server in front of HandleWebSocket
+// with the given origin checker and dev-mode flag. Returns the WS URL
+// and a cleanup. In production mode the handler is wired with stub
+// auth (any token accepted, fixed tenant returned) so we can exercise
+// the CheckOrigin path past the auth gate.
+func startServer(t *testing.T, originChecker func(*http.Request) bool, devMode bool) (string, func()) {
+	t.Helper()
+	hub := NewHub()
+	go hub.Run()
+
+	var tokenValidator func(string) (string, error)
+	var tenantResolver TenantResolver
+	if !devMode {
+		tokenValidator = func(token string) (string, error) { return "subj-1", nil }
+		tenantResolver = func(_ context.Context, _ string) (string, string, error) {
+			return "t-1", "free", nil
+		}
+	}
+
+	srv := httptest.NewServer(HandleWebSocket(hub, tokenValidator, tenantResolver, originChecker, devMode))
+	wsURL := strings.Replace(srv.URL, "http://", "ws://", 1)
+	return wsURL, srv.Close
+}
+
+func dialWith(t *testing.T, wsURL, origin string) (*http.Response, error) {
+	t.Helper()
+	hdr := http.Header{}
+	if origin != "" {
+		hdr.Set("Origin", origin)
+	}
+	// Token only needed in production mode; dev mode ignores it. Either
+	// way the stub validator above accepts anything.
+	c, resp, err := websocket.DefaultDialer.Dial(wsURL+"?token=t&tenant_id=t-1", hdr)
+	if c != nil {
+		_ = c.Close()
+	}
+	return resp, err
+}
+
+func TestCheckOrigin_ProductionRejectsDisallowedOrigin(t *testing.T) {
+	checker := func(r *http.Request) bool {
+		return r.Header.Get("Origin") == "https://app.example.com"
+	}
+	wsURL, stop := startServer(t, checker, false)
+	defer stop()
+
+	resp, err := dialWith(t, wsURL, "https://attacker.example")
+	if err == nil {
+		t.Fatal("expected handshake to fail for disallowed origin")
+	}
+	// gorilla/websocket surfaces 403 when CheckOrigin returns false.
+	if resp == nil || resp.StatusCode != http.StatusForbidden {
+		dump, _ := httputil.DumpResponse(resp, false)
+		t.Errorf("expected 403, got %v\n%s", resp, string(dump))
+	}
+}
+
+func TestCheckOrigin_ProductionAcceptsAllowedOrigin(t *testing.T) {
+	checker := func(r *http.Request) bool {
+		return r.Header.Get("Origin") == "https://app.example.com"
+	}
+	wsURL, stop := startServer(t, checker, false)
+	defer stop()
+
+	resp, err := dialWith(t, wsURL, "https://app.example.com")
+	if err != nil {
+		body := ""
+		if resp != nil {
+			d, _ := httputil.DumpResponse(resp, false)
+			body = string(d)
+		}
+		t.Fatalf("expected handshake to succeed for allowed origin, got %v\n%s", err, body)
+	}
+}
+
+func TestCheckOrigin_ProductionRejectsMissingOrigin(t *testing.T) {
+	// Browsers always send Origin on cross-origin requests. A missing
+	// header in production is suspicious; we fail closed (the checker
+	// returns false on empty Origin).
+	checker := func(r *http.Request) bool {
+		return r.Header.Get("Origin") != ""
+	}
+	wsURL, stop := startServer(t, checker, false)
+	defer stop()
+
+	resp, err := dialWith(t, wsURL, "")
+	if err == nil {
+		t.Fatal("expected handshake to fail when Origin missing in production")
+	}
+	if resp == nil || resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %v", resp)
+	}
+}
+
+func TestCheckOrigin_ProductionWithNilCheckerFailsClosed(t *testing.T) {
+	// A misconfigured production deploy (originChecker = nil) used to
+	// fall through to "allow all". The new code rejects.
+	wsURL, stop := startServer(t, nil, false)
+	defer stop()
+
+	resp, err := dialWith(t, wsURL, "https://app.example.com")
+	if err == nil {
+		t.Fatal("expected handshake to fail when checker is nil in production")
+	}
+	if resp == nil || resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 fail-closed, got %v", resp)
+	}
+}
+
+func TestCheckOrigin_DevModeAcceptsAnyOrigin(t *testing.T) {
+	wsURL, stop := startServer(t, nil, true)
+	defer stop()
+
+	resp, err := dialWith(t, wsURL, "https://anything.example")
+	if err != nil {
+		body := ""
+		if resp != nil {
+			d, _ := httputil.DumpResponse(resp, false)
+			body = string(d)
+		}
+		t.Fatalf("expected dev mode to accept any origin, got %v\n%s", err, body)
+	}
+}
+
+// Sanity: the URL helper isn't doing anything funny.
+func TestStartServer_URLShape(t *testing.T) {
+	wsURL, stop := startServer(t, nil, true)
+	defer stop()
+	if u, err := url.Parse(wsURL); err != nil || u.Scheme != "ws" {
+		t.Errorf("expected ws://… URL, got %q (%v)", wsURL, err)
+	}
+}


### PR DESCRIPTION
Closes #47.

## Problem

The realtime WebSocket upgrader's \`CheckOrigin\` returned \`true\` unconditionally — \`/v1/realtime\` accepted handshakes from any browser origin. With the \`?token=\` query-param auth model, a page on \`attacker.example\` could open a socket to the gateway, attach the victim's JWT (which a CSRF-style flow could obtain), and exfiltrate realtime events the victim is subscribed to. Classic CSWSH (Cross-Site WebSocket Hijacking).

## Fix

- **\`gateway.BuildOriginChecker\`** — extracted the CORS layering (global allowlist + per-project \`cors_origins\` from \`ProjectContext\`) into one reusable closure. \`NewCORSMiddleware\` now uses it; the WS upgrader uses the same closure so HTTP and WS paths share identical origin rules, including the per-project \`cors_origins\` list from #76.
- **\`realtime.HandleWebSocket\`** — upgrader is now built per-call instead of as a package-level global, scoping the origin checker and dev-mode flag to each invocation. In production: empty Origin or nil checker → fail closed (403). In dev: accept any origin (preserves \`wscat\` workflows).

## Test plan
- [x] 6 new tests in \`handler_origin_test.go\` — disallowed (403), allowed (101 upgrade), missing Origin (403), nil checker in production (403 fail-closed), dev-mode allow-all, helper sanity.
- [x] \`go test ./...\` clean
- [ ] Smoke after deploy: connect with \`wscat\` from an allowed origin → upgrade succeeds; from a forged origin → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)