### PR TITLE
DSAR console: use typed api client methods (fixes JSON error on Export button)

### DIFF
--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -1013,6 +1013,35 @@ export class EurobaseAPI {
 		return this.fetch<AuditLogResult>(`/platform/projects/${projectId}/compliance/audit-log${query}`);
 	}
 
+	// ---- DSAR exports ----
+
+	/** Request a full-tenant DSAR export. Returns the created export request row. */
+	async requestTenantExport(projectId: string, format: 'json' | 'csv'): Promise<ExportRequestRow> {
+		return this.fetch<ExportRequestRow>(`/platform/projects/${projectId}/compliance/export`, {
+			method: 'POST',
+			body: JSON.stringify({ format }),
+		});
+	}
+
+	/** Request a per-user DSAR export. */
+	async requestUserExport(projectId: string, userId: string, format: 'json' | 'csv'): Promise<ExportRequestRow> {
+		return this.fetch<ExportRequestRow>(`/platform/projects/${projectId}/compliance/user-export`, {
+			method: 'POST',
+			body: JSON.stringify({ user_id: userId, format }),
+		});
+	}
+
+	/** Paginated history of export requests for a project. */
+	async listExports(projectId: string, limit = 20, offset = 0): Promise<{ exports: ExportRequestRow[] }> {
+		const qs = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+		return this.fetch<{ exports: ExportRequestRow[] }>(`/platform/projects/${projectId}/compliance/exports?${qs}`);
+	}
+
+	/** Get a single export by ID. download_url is populated when status === 'completed'. */
+	async getExport(projectId: string, exportId: string): Promise<ExportRequestRow> {
+		return this.fetch<ExportRequestRow>(`/platform/projects/${projectId}/compliance/exports/${exportId}`);
+	}
+
 	// ---- Team Members ----
 
 	/** List members and pending invitations for a project. */
@@ -1587,6 +1616,26 @@ export interface AuditLogEntry {
 export interface AuditLogResult {
 	entries: AuditLogEntry[];
 	total: number;
+}
+
+/** DSAR export request row, returned by requestTenantExport / requestUserExport /
+ * listExports / getExport. Mirrors compliance.ExportRequest on the Go side. */
+export interface ExportRequestRow {
+	id: string;
+	project_id: string;
+	user_id?: string | null;
+	status: 'pending' | 'running' | 'completed' | 'failed';
+	format: 'json' | 'csv';
+	s3_key?: string | null;
+	file_size?: number | null;
+	error?: string | null;
+	requested_by: string;
+	requested_by_type: 'platform' | 'enduser';
+	download_url?: string;
+	started_at?: string | null;
+	completed_at?: string | null;
+	expires_at?: string | null;
+	created_at: string;
 }
 
 export interface EdgeFunction {

--- a/console/src/routes/(app)/p/[id]/compliance/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/compliance/+page.svelte
@@ -144,9 +144,8 @@
 		exportsLoading = true;
 		exportError = null;
 		try {
-			const res = await api.fetch(`/platform/projects/${projectId}/compliance/exports?limit=20`);
-			const data = await res.json();
-			exports = data.exports ?? [];
+			const data = await api.listExports(projectId);
+			exports = (data.exports ?? []) as unknown as ExportEntry[];
 		} catch (err) {
 			exportError = err instanceof Error ? err.message : 'Failed to load exports';
 		} finally {
@@ -158,23 +157,13 @@
 		exportRequesting = true;
 		exportError = null;
 		try {
-			const res = await api.fetch(`/platform/projects/${projectId}/compliance/export`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ format: exportFormat })
-			});
-			if (res.status === 429) {
-				exportError = 'Rate limit: 1 export per hour. Please wait.';
-				return;
-			}
-			if (!res.ok) {
-				const data = await res.json();
-				exportError = data.error || 'Failed to request export';
-				return;
-			}
+			await api.requestTenantExport(projectId, exportFormat);
 			await loadExports();
 		} catch (err) {
-			exportError = err instanceof Error ? err.message : 'Failed to request export';
+			const msg = err instanceof Error ? err.message : 'Failed to request export';
+			// parseAPIError surfaces rate-limit text as a friendly message;
+			// keep the explicit hint for the 429 case so the UI is unchanged.
+			exportError = /rate.?limit/i.test(msg) ? 'Rate limit: 1 export per hour. Please wait.' : msg;
 		} finally {
 			exportRequesting = false;
 		}
@@ -182,9 +171,8 @@
 
 	async function refreshExportStatus(exportId: string) {
 		try {
-			const res = await api.fetch(`/platform/projects/${projectId}/compliance/exports/${exportId}`);
-			const updated = await res.json();
-			exports = exports.map(e => e.id === exportId ? updated : e);
+			const updated = await api.getExport(projectId, exportId);
+			exports = exports.map(e => e.id === exportId ? (updated as unknown as ExportEntry) : e);
 		} catch { /* ignore */ }
 	}
 


### PR DESCRIPTION
## Symptom

Clicking **Export Project Data** in the Compliance → Data Export tab produced a red error: \`(intermediate value).json is not a function\`. Same problem would show on any other Data Export action.

## Root cause

The compliance page called the api object's **private** \`fetch\` helper as if it returned a Response, then chained \`.json()\`:

\`\`\`ts
const res = await api.fetch(\`/.../compliance/export\`, {...});
const data = await res.json();   // ← res is already the parsed payload
\`\`\`

TypeScript's \`private\` is compile-time only and svelte-check is disabled in CI, so the type error didn't surface. At runtime \`api.fetch\` parses JSON internally and returns the typed payload — so \`.json()\` was being called on a plain object that has no such method.

## Fix

Add four typed public methods on the api client mirroring the Go handlers:

- \`api.requestTenantExport(projectId, format)\`
- \`api.requestUserExport(projectId, userId, format)\`
- \`api.listExports(projectId, limit?, offset?)\`
- \`api.getExport(projectId, exportId)\`

Plus an \`ExportRequestRow\` type that mirrors \`compliance.ExportRequest\` on the Go side. The page now uses these directly — no more dipping into private helpers, no more double-parse.

## Test plan
- [x] \`npm run build\` clean (console)
- [ ] After deploy: click **Export Project Data** → expect a 202-shaped response showing in Export History (status \`pending\` → \`running\` → \`completed\`).
- [ ] Smoke the rate-limit path (click twice within an hour) → expect the friendly "Rate limit: 1 export per hour" message instead of the JSON error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)