### PR TITLE
Sec: deny-by-default CSP on every gateway response (closes #54)

### DIFF
--- a/internal/gateway/security_headers.go
+++ b/internal/gateway/security_headers.go
@@ -2,6 +2,27 @@ package gateway
 
 import "net/http"
 
+// apiCSP is the Content-Security-Policy header sent on every gateway
+// response. The gateway only emits JSON / WebSocket upgrades / 30x
+// redirects, so a deny-by-default policy is safe — no inline scripts,
+// no external resources, no iframes. Closes #54 for the API tier.
+//
+// Why the explicit `'none'` everywhere:
+//   - default-src 'none' blocks scripts/styles/images/fonts/connect/etc.
+//     If a future bug causes the gateway to serve attacker-controlled
+//     HTML, browsers refuse to load anything from it.
+//   - frame-ancestors 'none' is the modern equivalent of
+//     X-Frame-Options: DENY; both are sent because not every browser
+//     respects CSP's clickjacking control.
+//   - base-uri 'none' blocks <base href="..."> injection that would
+//     reroute relative URLs.
+//   - form-action 'none' blocks <form action="..."> POST exfiltration.
+//
+// The Svelte console is a separate origin (console.eurobase.app) and
+// needs its own, much looser CSP — that's a separate PR; CSP from the
+// console's nginx is the right venue, not this middleware.
+const apiCSP = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+
 // SecurityHeadersMiddleware sets a conservative set of response headers that
 // block common browser-side misuse of the API. These are global — every
 // response gets them, including error and preflight responses.
@@ -16,6 +37,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		h.Set("Content-Security-Policy", apiCSP)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/gateway/security_headers_test.go
+++ b/internal/gateway/security_headers_test.go
@@ -1,0 +1,66 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Closes #54. Every response leaving the gateway must carry the
+// deny-by-default headers, including error paths.
+
+func runSecurityHeaders(t *testing.T, downstreamStatus int) http.Header {
+	t.Helper()
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(downstreamStatus)
+	})
+	srv := httptest.NewServer(SecurityHeadersMiddleware(inner))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	return resp.Header
+}
+
+func TestSecurityHeaders_AllSetOnSuccess(t *testing.T) {
+	h := runSecurityHeaders(t, http.StatusOK)
+	for k, want := range map[string]string{
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Content-Security-Policy":   apiCSP,
+	} {
+		if got := h.Get(k); got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestSecurityHeaders_AllSetOnError(t *testing.T) {
+	// Defense-in-depth headers must also land on 4xx/5xx — those are
+	// exactly the responses an attacker is most likely to probe.
+	h := runSecurityHeaders(t, http.StatusInternalServerError)
+	if h.Get("Content-Security-Policy") == "" {
+		t.Error("CSP missing on 500 response")
+	}
+	if h.Get("X-Frame-Options") != "DENY" {
+		t.Error("X-Frame-Options missing on 500 response")
+	}
+}
+
+func TestApiCSP_DenyByDefault(t *testing.T) {
+	// Spot-check that the CSP string actually starts with default-src
+	// 'none' — a future edit that loosens this should fail the test.
+	if !strings.HasPrefix(apiCSP, "default-src 'none'") {
+		t.Errorf("apiCSP must start with default-src 'none'; got %q", apiCSP)
+	}
+	for _, must := range []string{"frame-ancestors 'none'", "base-uri 'none'", "form-action 'none'"} {
+		if !strings.Contains(apiCSP, must) {
+			t.Errorf("apiCSP missing %q; full policy: %q", must, apiCSP)
+		}
+	}
+}


### PR DESCRIPTION
Closes #54.

## Summary

The gateway already sends HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy. The audit flagged the missing **Content-Security-Policy** as a defence-in-depth gap — if any future bug causes the API to serve attacker-controlled HTML (template injection, content-type confusion, gzip-flush smuggling, etc.), browsers have no instructions to refuse loading anything from it.

## Policy

\`\`\`
default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'
\`\`\`

Safe for the API tier because the gateway only emits JSON, WebSocket upgrades, and 30x redirects — never HTML that needs to load scripts or styles. The Svelte console runs on a separate origin (\`console.eurobase.app\`) and gets its own, much looser CSP from its nginx config; that's intentionally out of scope here.

## Test plan
- [x] 3 new tests in \`security_headers_test.go\` — success path, error path (5xx still gets the headers), and a structural assertion that the policy keeps \`default-src 'none'\` as its first directive.
- [x] \`go test ./...\` clean.
- [ ] After deploy: \`curl -I https://api.eurobase.app/health\` → expect \`Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)