### PR TITLE
DSAR export: presign download URLs in list + auto-poll while in flight

### DIFF
--- a/console/src/routes/(app)/p/[id]/compliance/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/compliance/+page.svelte
@@ -22,7 +22,16 @@
 	let auditActionFilter = $state('');
 	const auditPageSize = 50;
 
-	onMount(() => { loadReport(); });
+	onMount(() => {
+		loadReport();
+		// Stop the export poll loop when the page unmounts.
+		return () => {
+			if (pollTimer !== null) {
+				clearInterval(pollTimer);
+				pollTimer = null;
+			}
+		};
+	});
 
 	async function loadReport() {
 		loading = true;
@@ -140,12 +149,29 @@
 	let exportFormat = $state<'json' | 'csv'>('json');
 	let exportRequesting = $state(false);
 
+	// Auto-poll: when any export row is still pending or running, re-fetch
+	// the list every 3s until all rows have settled. Stops automatically
+	// to avoid a wake-lock when nothing is in flight. Cleared on unmount
+	// via the existing onMount cleanup (returned function).
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	function startPollIfNeeded() {
+		const anyInFlight = exports.some(e => e.status === 'pending' || e.status === 'running');
+		if (anyInFlight && pollTimer === null) {
+			pollTimer = setInterval(loadExports, 3000);
+		} else if (!anyInFlight && pollTimer !== null) {
+			clearInterval(pollTimer);
+			pollTimer = null;
+		}
+	}
+
 	async function loadExports() {
 		exportsLoading = true;
 		exportError = null;
 		try {
 			const data = await api.listExports(projectId);
 			exports = (data.exports ?? []) as unknown as ExportEntry[];
+			startPollIfNeeded();
 		} catch (err) {
 			exportError = err instanceof Error ? err.message : 'Failed to load exports';
 		} finally {
@@ -173,6 +199,7 @@
 		try {
 			const updated = await api.getExport(projectId, exportId);
 			exports = exports.map(e => e.id === exportId ? (updated as unknown as ExportEntry) : e);
+			startPollIfNeeded();
 		} catch { /* ignore */ }
 	}
 

--- a/internal/compliance/export_handler.go
+++ b/internal/compliance/export_handler.go
@@ -132,6 +132,13 @@ func HandleRequestUserExport(exportSvc *ExportService) http.HandlerFunc {
 
 // HandleListExports returns paginated export history for a project.
 // GET /platform/projects/{id}/compliance/exports
+//
+// Completed rows are decorated with a fresh presigned download URL
+// (1h TTL) so the console can render a working "Download" link from
+// the list view alone — without it, the table shows "completed" but
+// no link, and the user has to click a per-row Refresh to call
+// HandleGetExport. The bucket lookup is one extra query per call;
+// the per-row presign is local-only (HMAC over the URL).
 func HandleListExports(exportSvc *ExportService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projectID := chi.URLParam(r, "id")
@@ -146,6 +153,25 @@ func HandleListExports(exportSvc *ExportService) http.HandlerFunc {
 		if exports == nil {
 			exports = []ExportRequest{}
 		}
+
+		// Resolve the bucket once for the project, then presign every
+		// completed row. If the bucket lookup fails the list still
+		// returns; the rows just won't have download_url set.
+		var bucket string
+		_ = exportSvc.Pool.QueryRow(r.Context(),
+			`SELECT s3_bucket FROM projects WHERE id = $1`, projectID,
+		).Scan(&bucket)
+		if bucket != "" {
+			for i := range exports {
+				if exports[i].Status == "completed" && exports[i].S3Key != nil {
+					url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, *exports[i].S3Key)
+					if err == nil {
+						exports[i].DownloadURL = url
+					}
+				}
+			}
+		}
+
 		writeExportJSON(w, map[string]interface{}{"exports": exports}, http.StatusOK)
 	}
 }


### PR DESCRIPTION
Two UX gaps reported live by the user on the Data Export tab right after #93 landed.

## 1. No Download link on completed rows

\`HandleListExports\` returned rows straight from the DB without generating presigned URLs — only \`HandleGetExport\` did the per-row presign. So the page rendered nothing for the \`{#if exp.status === 'completed' && exp.download_url}\` branch and the only way to obtain a link was to click a per-row Refresh button (which is only shown on pending/running rows).

**Fix:** \`HandleListExports\` now looks up the bucket once, then presigns every completed row. Adds one \`SELECT s3_bucket\` per list call + N local-only HMAC signs. Bounded by ~168 active rows at most (1/hour × 7-day TTL), trivial.

## 2. No auto-poll while exports are running

The page only refreshed history on manual click. A row stuck on \`pending\` or \`running\` stayed that way until the user remembered to press Refresh.

**Fix:** when \`loadExports\` / \`refreshExportStatus\` see at least one \`pending\` or \`running\` row, start a 3-second poll that re-fetches the list until every row has settled. Auto-stops when nothing is in flight (no permanent timer burning cycles). Cleared on page unmount via \`onMount\`'s return value.

## Test plan
- [x] \`go build ./...\` + console \`npm run build\` clean
- [ ] After deploy: trigger an export → row appears as \`pending\`, flips to \`running\` then \`completed\` within ~5s without any clicks; Download link is present on the completed row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)