### PR TITLE
SDK 0.2.3: pass project_id on realtime WS (companion to #107)

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eurobase/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Eurobase TypeScript SDK — EU-sovereign Backend-as-a-Service. Auth, database, storage, realtime, functions, vault, and schema DDL.",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc && node test/fix-dist-imports.mjs",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node test/token-propagation.mjs"
+    "test": "npm run build && node test/token-propagation.mjs && node test/realtime-url.mjs"
   },
   "keywords": [
     "eurobase",

--- a/sdk/js/src/client.ts
+++ b/sdk/js/src/client.ts
@@ -20,6 +20,18 @@ export interface EurobaseConfig {
   url: string
   /** Project API key used for authentication. */
   apiKey: string
+  /**
+   * Project UUID. Only required if you call `realtime.*` with an
+   * end-user access token (e.g. after `auth.signIn`) — the gateway
+   * needs the project ID up front to validate the JWT against the
+   * project's secret. For API-key-only realtime usage it can be
+   * omitted; the gateway derives the project from the key.
+   *
+   * Connection strings of the form
+   * `eurobase://API_KEY@SLUG.eurobase.app` do NOT populate this — set
+   * it explicitly if you need end-user JWT realtime.
+   */
+  projectId?: string
 }
 
 /** The top-level Eurobase client with database, storage, realtime, and auth access. */

--- a/sdk/js/src/http.ts
+++ b/sdk/js/src/http.ts
@@ -6,6 +6,9 @@
 export interface EurobaseConfig {
   url: string
   apiKey: string
+  /** Project UUID (optional; required for end-user JWT realtime). See
+   * client.ts for the user-facing docs. */
+  projectId?: string
 }
 
 export interface HttpClient {

--- a/sdk/js/src/realtime.ts
+++ b/sdk/js/src/realtime.ts
@@ -108,12 +108,37 @@ export class RealtimeClient {
     this.connect()
   }
 
-  private connect(): void {
+  /**
+   * Build the WebSocket URL for the realtime endpoint.
+   *
+   * Token precedence: the end-user access token (if signed in) wins over
+   * the project API key. Either form is accepted by /v1/realtime:
+   *
+   *   - **API key** (`eb_pk_…` / `eb_sk_…`) — the gateway resolves the
+   *     project server-side, no `project_id` needed.
+   *   - **End-user JWT** — `project_id` must be supplied so the gateway
+   *     can look up the project's `jwt_secret` to verify. Provided via
+   *     `EurobaseConfig.projectId` when the SDK is bootstrapped.
+   *
+   * Exposed as a method (rather than inlined) so unit tests can assert
+   * the URL shape without spinning up a real WebSocket.
+   */
+  buildWebSocketURL(): string {
     const baseUrl = this.config.url.replace(/\/+$/, '').replace(/^http/, 'ws')
-    const token = this.http.getAccessToken() || this.config.apiKey
-    const url = `${baseUrl}/v1/realtime?token=${encodeURIComponent(token)}`
+    const accessToken = this.http.getAccessToken()
+    const token = accessToken || this.config.apiKey
+    const params = new URLSearchParams({ token })
+    // The end-user JWT path needs project_id to find the right
+    // jwt_secret. The apikey path doesn't, but adding it costs nothing
+    // — the gateway cross-checks it against the apikey's project.
+    if (this.config.projectId) {
+      params.set('project_id', this.config.projectId)
+    }
+    return `${baseUrl}/v1/realtime?${params.toString()}`
+  }
 
-    this.ws = new WebSocket(url)
+  private connect(): void {
+    this.ws = new WebSocket(this.buildWebSocketURL())
 
     this.ws.onopen = () => {
       this.reconnectAttempts = 0

--- a/sdk/js/test/realtime-url.mjs
+++ b/sdk/js/test/realtime-url.mjs
@@ -1,0 +1,98 @@
+// Regression test for #62: the realtime WebSocket URL must carry the
+// project_id query parameter so the gateway can route events to the
+// correct project. The earlier SDK sent only ?token=… and got 400 from
+// the post-#62 gateway. The apikey path doesn't strictly require
+// project_id (the gateway resolves it from the key), but we include it
+// when available so end-user JWT realtime works too.
+//
+// Run via: npm run build && node test/realtime-url.mjs
+
+import { createClient } from '../dist/index.js'
+import assert from 'node:assert/strict'
+
+const API_KEY = 'eb_pk_abc123'
+const URL_BASE = 'https://newtek2.eurobase.app'
+const PROJECT_ID = '1ac63ce5-1dd0-49a3-bcfe-559fcb4d8506'
+const ACCESS_TOKEN = 'eyJ-fake-end-user-jwt'
+
+// ── 1. API key only, no projectId ──────────────────────────────────
+{
+  const client = createClient({ url: URL_BASE, apiKey: API_KEY })
+  const url = client.realtime.buildWebSocketURL()
+  const parsed = new URL(url)
+
+  assert.equal(parsed.protocol, 'wss:', `expected wss:// scheme, got ${parsed.protocol}`)
+  assert.equal(parsed.pathname, '/v1/realtime')
+  assert.equal(parsed.searchParams.get('token'), API_KEY)
+  assert.equal(
+    parsed.searchParams.get('project_id'),
+    null,
+    'project_id should be absent when no projectId is configured',
+  )
+  console.log('✓ apikey-only URL: only token query param')
+}
+
+// ── 2. API key + explicit projectId ────────────────────────────────
+{
+  const client = createClient({ url: URL_BASE, apiKey: API_KEY, projectId: PROJECT_ID })
+  const url = client.realtime.buildWebSocketURL()
+  const parsed = new URL(url)
+
+  assert.equal(parsed.searchParams.get('token'), API_KEY)
+  assert.equal(parsed.searchParams.get('project_id'), PROJECT_ID)
+  console.log('✓ apikey + projectId URL: both query params')
+}
+
+// ── 3. End-user signed in: access token wins over apikey ───────────
+{
+  const client = createClient({ url: URL_BASE, apiKey: API_KEY, projectId: PROJECT_ID })
+  // Simulate a signed-in user — sets the access token on the shared
+  // HttpClient that the realtime client reads.
+  client.auth.setSession({
+    access_token: ACCESS_TOKEN,
+    token_type: 'bearer',
+    expires_in: 3600,
+    refresh_token: 'rt-fake',
+    user: { id: 'u1', email: 'a@b.c', created_at: '', updated_at: '' },
+  })
+
+  const url = client.realtime.buildWebSocketURL()
+  const parsed = new URL(url)
+
+  assert.equal(
+    parsed.searchParams.get('token'),
+    ACCESS_TOKEN,
+    'end-user access token should take precedence over apikey',
+  )
+  assert.equal(parsed.searchParams.get('project_id'), PROJECT_ID)
+  console.log('✓ signed-in URL: end-user JWT plus projectId')
+}
+
+// ── 4. http base URL rewrites to ws, https rewrites to wss ─────────
+{
+  for (const [base, expectScheme] of [
+    ['http://localhost:8080', 'ws:'],
+    ['https://api.eurobase.app', 'wss:'],
+    ['http://api.eurobase.app/', 'ws:'],
+  ]) {
+    const client = createClient({ url: base, apiKey: API_KEY })
+    const url = client.realtime.buildWebSocketURL()
+    const parsed = new URL(url)
+    assert.equal(parsed.protocol, expectScheme, `${base} → ${parsed.protocol}, want ${expectScheme}`)
+  }
+  console.log('✓ scheme rewrite: http/https → ws/wss')
+}
+
+// ── 5. Trailing slashes on base URL are trimmed ───────────────────
+{
+  const client = createClient({ url: 'https://api.eurobase.app///', apiKey: API_KEY })
+  const url = client.realtime.buildWebSocketURL()
+  assert.equal(
+    url.startsWith('wss://api.eurobase.app/v1/realtime?'),
+    true,
+    `unexpected URL: ${url}`,
+  )
+  console.log('✓ trailing slashes trimmed')
+}
+
+console.log('\nAll realtime URL tests passed.')


### PR DESCRIPTION
Companion to #107. After that PR lands, the gateway's \`/v1/realtime\` requires \`?project_id=\` for JWT-shaped tokens (apikey path can omit it). The previous SDK only sent \`?token=…\`, so a signed-in user attempting realtime would have hit 400.

## Changes

- \`EurobaseConfig.projectId\` (optional) — explicit project UUID for end-user JWT realtime. Apikey-only callers can leave it unset; the gateway derives the project server-side. Connection-string config does not populate this — set explicitly when needed.
- Extracted \`RealtimeClient.buildWebSocketURL()\` so the URL shape is unit-testable without a live WebSocket.
- Token precedence unchanged: end-user access token (when signed in) wins over apikey.

## Test plan
- [x] 5 new tests in \`test/realtime-url.mjs\` (wired into \`npm test\`):
  - apikey only → token only, no project_id
  - apikey + projectId → both query params
  - signed-in user → JWT token + projectId
  - http/https base URL rewrites to ws/wss
  - trailing slashes trimmed
- [x] Existing \`token-propagation.mjs\` still passes
- [ ] After both #107 and this land: real-DB smoke — sign in via SDK, subscribe to a table, insert a row → event arrives

## Version

Bumped to **0.2.3**. Additive change — \`projectId\` is optional, existing apikey users are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)