### PR TITLE
CI: wait for migrate Job deletion before re-applying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,12 @@ jobs:
         run: |
           # Job specs are largely immutable — delete any prior instance so
           # this deploy's image gets picked up. --ignore-not-found covers the
-          # first-ever run. Then apply with this deploy's SHA pinned.
-          kubectl -n eurobase delete job migrate --ignore-not-found
+          # first-ever run. --cascade=foreground waits for the Job object
+          # (and its pods) to be fully removed from the API before the
+          # next command runs — without it, the subsequent `apply` raced
+          # the background reaper and hit `field is immutable` on the
+          # spec.template (PR #107's deploy failed that way).
+          kubectl -n eurobase delete job migrate --ignore-not-found --cascade=foreground
           sed "s|eurobase-app/migrations:latest|eurobase-app/migrations:${{ github.sha }}|" \
             deploy/k8s/migrate-job.yaml | kubectl apply -f -
           # Block the rollout on a successful migration. If it fails, bail


### PR DESCRIPTION
PR #107's deploy hit \`The Job \"migrate\" is invalid: spec.template: ... field is immutable\`. The script does:

\`\`\`
kubectl delete job migrate --ignore-not-found
kubectl apply -f -
\`\`\`

The default delete is foreground for the Job resource but background for its pods — the API kept the Job object visible for a few seconds after the command returned. The follow-up apply then tried to update \`spec.template\` (new image SHA) on the still-existing Job → 422 → deploy halted before the image rollout.

PR #109 a minute later happened to find the Job already gone (background reaper had finished), so it shipped both #107 and #109 to production. **Production is fine** — the realtime fix from #107 is live. But the race will bite the next back-to-back deploy.

## Fix

\`--cascade=foreground\` on the delete tells kubectl to wait for the Job AND its pods to be fully removed before returning. The follow-up apply then creates a fresh Job with no immutable-field conflict.

One-line change.

## Test plan
- [x] YAML lints
- [ ] Next deploy after merge: \`Run database migrations\` step succeeds without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)