### PR TITLE
Sec: auth.email() reads live from users table (closes #55)

### DIFF
--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -48,11 +48,11 @@ func (e *QueryEngine) applyRLSContext(ctx context.Context, tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, "SELECT set_config('app.end_user_role', 'authenticated', true)"); err != nil {
 			return fmt.Errorf("set end_user_role: %w", err)
 		}
-		if email := EndUserEmailFromContext(ctx); email != "" {
-			if _, err := tx.Exec(ctx, "SELECT set_config('app.end_user_email', $1, true)", email); err != nil {
-				return fmt.Errorf("set end_user_email: %w", err)
-			}
-		}
+		// app.end_user_email is no longer set — auth.email() and
+		// auth_email() now look up live from <schema>.users in
+		// migration 000052 (closes #55). The end-user email on the
+		// context is still used elsewhere (audit, logging) so the
+		// EndUserEmailFromContext getter stays.
 	}
 	return nil
 }

--- a/migrations/000052_auth_email_live_lookup.down.sql
+++ b/migrations/000052_auth_email_live_lookup.down.sql
@@ -4,8 +4,8 @@
 -- app.end_user_email GUC. Policies that started depending on the live
 -- lookup will silently revert to stale-JWT behaviour after this runs;
 -- check call sites before using.
-
-BEGIN;
+--
+-- No explicit BEGIN/COMMIT — golang-migrate wraps the file.
 
 CREATE OR REPLACE FUNCTION auth.email() RETURNS text
     LANGUAGE sql STABLE AS $$
@@ -25,5 +25,3 @@ BEGIN
         );
     END LOOP;
 END$$;
-
-COMMIT;

--- a/migrations/000052_auth_email_live_lookup.down.sql
+++ b/migrations/000052_auth_email_live_lookup.down.sql
@@ -1,0 +1,29 @@
+-- 000052_auth_email_live_lookup.down.sql
+--
+-- Revert auth.email() and per-tenant auth_email() back to reading the
+-- app.end_user_email GUC. Policies that started depending on the live
+-- lookup will silently revert to stale-JWT behaviour after this runs;
+-- check call sites before using.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION auth.email() RETURNS text
+    LANGUAGE sql STABLE AS $$
+    SELECT NULLIF(current_setting('app.end_user_email', true), '')
+$$;
+
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL LOOP
+        EXECUTE format(
+            'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+             LANGUAGE sql STABLE AS $_$
+               SELECT current_setting(''app.end_user_email'', true);
+             $_$', rec.schema_name
+        );
+    END LOOP;
+END$$;
+
+COMMIT;

--- a/migrations/000052_auth_email_live_lookup.up.sql
+++ b/migrations/000052_auth_email_live_lookup.up.sql
@@ -17,8 +17,10 @@
 -- using `auth.email()` were already doing schema reads, so this is
 -- an extra row read per policy evaluation — acceptable for the
 -- correctness gain.
-
-BEGIN;
+--
+-- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its
+-- own transaction by default, and an explicit COMMIT inside would
+-- commit the runner's outer tx prematurely (same footgun as #121).
 
 -- ── 1. Global auth.email() (added by 000048) ─────────────────────────
 -- search_path is set per-request to the tenant schema + public, so
@@ -279,5 +281,3 @@ END;
 $fn$;
 
 ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;
-
-COMMIT;

--- a/migrations/000052_auth_email_live_lookup.up.sql
+++ b/migrations/000052_auth_email_live_lookup.up.sql
@@ -1,0 +1,283 @@
+-- 000052_auth_email_live_lookup.up.sql
+--
+-- Closes #55. The `auth.email()` and per-tenant `auth_email()` helpers
+-- used to read from the `app.end_user_email` session GUC, which the
+-- gateway populates from the JWT at request time. If a user changed
+-- their email in the tenant DB, the GUC still reflected the stale JWT
+-- value until token expiry — RLS policies gated by email diverged from
+-- the source of truth.
+--
+-- Both functions now read live from the current tenant schema's
+-- `users` table, keyed on `public.current_end_user_id()`. The lookup
+-- uses an unqualified `users` reference so search_path picks the
+-- right tenant schema; that path is set by the engine before every
+-- query (`SET LOCAL search_path TO %I, public`).
+--
+-- Per-row cost: one indexed PK lookup on `users(id)`. RLS policies
+-- using `auth.email()` were already doing schema reads, so this is
+-- an extra row read per policy evaluation — acceptable for the
+-- correctness gain.
+
+BEGIN;
+
+-- ── 1. Global auth.email() (added by 000048) ─────────────────────────
+-- search_path is set per-request to the tenant schema + public, so
+-- the unqualified `users` reference resolves to the caller's tenant.
+CREATE OR REPLACE FUNCTION auth.email() RETURNS text
+    LANGUAGE sql STABLE AS $$
+    SELECT email FROM users WHERE id = public.current_end_user_id()
+$$;
+
+ALTER FUNCTION auth.email() OWNER TO eurobase_migrator;
+GRANT EXECUTE ON FUNCTION auth.email() TO eurobase_gateway, eurobase_function_runner;
+
+-- ── 2. Backfill per-tenant auth_email() to do the same ──────────────
+-- Each tenant has its own schema-qualified auth_email() (created by
+-- earlier provision_tenant rev). Rewrite each one to do the live
+-- lookup against the tenant's own users table — that schema-qualifies
+-- naturally because we generate inside %I.
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL LOOP
+        EXECUTE format(
+            'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+             LANGUAGE sql STABLE AS $_$
+               SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+             $_$', rec.schema_name, rec.schema_name
+        );
+    END LOOP;
+END$$;
+
+-- ── 3. provision_tenant: new tenants get the live-lookup form ────────
+-- Same body as 000050 except the auth_email() block now reads from
+-- users instead of the GUC.
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+    v_func_role   TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+    v_func_role   := v_schema_name || '_func';
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL UNIQUE,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_service_role())
+         WITH CHECK (public.is_service_role())',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    -- CHANGED FROM 000050: read live from users(id) instead of the
+    -- stale app.end_user_email GUC. Closes #55.
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+         $_$', v_schema_name, v_schema_name
+    );
+
+    -- Grant the gateway runtime role access to this tenant schema.
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    -- ── Per-tenant function-runner role ──
+    EXECUTE format('CREATE ROLE %I NOLOGIN INHERIT', v_func_role);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT USAGE, SELECT ON SEQUENCES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format('GRANT %I TO eurobase_function_runner', v_func_role);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;
+
+COMMIT;


### PR DESCRIPTION
Closes #55.

## Problem

\`auth.email()\` and per-tenant \`auth_email()\` returned the value of the \`app.end_user_email\` session GUC, populated from the JWT at request time. If a user changed their email in the tenant DB, the GUC still reflected the stale JWT value until token expiry — RLS policies gated by email diverged from the source of truth.

Severity: low (per the audit). But policies that email-gate sensitive ops (e.g. admin-by-email patterns) silently misbehave for the JWT TTL window.

## Fix

Migration 000052:
- Global \`auth.email()\` (added by #48) now does:
  \`SELECT email FROM users WHERE id = public.current_end_user_id()\`
  The unqualified \`users\` reference resolves via search_path to the caller's tenant schema (the engine sets that per request).
- Backfill loop rewrites each existing tenant's \`<schema>.auth_email()\` to the same shape (schema-qualified inside the format()).
- \`provision_tenant\` updated so freshly provisioned tenants are correct from creation.

Engine side: dropped the \`SET set_config('app.end_user_email', …)\` call — nothing reads the GUC anymore. The \`EndUserEmailFromContext\` getter stays since audit/logging still use the parsed-JWT email.

## Cost

One indexed PK lookup on \`users(id)\` per \`auth.email()\` evaluation. Acceptable for the correctness gain — policies gated by email now reflect current state instead of stale-token state.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [ ] Smoke after deploy: sign in as Alice, change her email via \`/v1/auth/user\`, call any endpoint with an RLS policy that uses \`auth.email()\` — should match the new email immediately, not the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)