### PR TITLE
Schedules: SDK control-plane for cron jobs (closes #112)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eurobase/euroback/internal/cron"
 	"github.com/eurobase/euroback/internal/db"
+	"github.com/eurobase/euroback/internal/functions"
 	"github.com/eurobase/euroback/internal/storage"
 	"github.com/eurobase/euroback/internal/workers"
 	"github.com/riverqueue/river"
@@ -122,6 +123,30 @@ func main() {
 	// ── Start cron executor ──
 	cronSvc := cron.NewCronService(pool)
 	cronExec := cron.NewExecutor(cronSvc, pool)
+
+	// Wire the function-runner invoker so schedules with action_type
+	// `function` (issue #112) can fire deployed edge functions. Optional
+	// — without it, function schedules fail-fast with a clear message,
+	// SQL/RPC schedules keep working. Same env vars as the gateway.
+	fnRunnerURL := os.Getenv("FUNCTION_RUNNER_URL")
+	if fnRunnerURL != "" {
+		var signer *functions.Signer
+		if secret := os.Getenv("FUNCTIONS_RUNNER_HMAC_SECRET"); secret != "" {
+			s, err := functions.NewSigner(secret)
+			if err != nil {
+				slog.Error("FUNCTIONS_RUNNER_HMAC_SECRET invalid for worker", "error", err)
+				os.Exit(1)
+			}
+			signer = s
+		}
+		cronExec = cronExec.WithFunctionInvoker(cron.FunctionInvoker{
+			RunnerURL: fnRunnerURL,
+			Signer:    signer,
+		})
+		slog.Info("cron executor wired to functions runner", "url", fnRunnerURL, "signed", signer != nil)
+	} else {
+		slog.Warn("FUNCTION_RUNNER_URL not set on worker — `function` schedules will fail-fast")
+	}
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
 		defer ticker.Stop()

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -265,7 +265,11 @@ func (e *Executor) executeFunctionJob(ctx context.Context, job DueJob) error {
 	req.Header.Set("X-Schema-Name", job.SchemaName)
 	req.Header.Set("X-Function-Name", job.Action)
 	req.Header.Set("X-Function-ID", fnID)
-	req.Header.Set("X-Plan", "free") // schedule-fired invocations don't carry plan; runner uses for limits only
+	plan := job.Plan
+	if plan == "" {
+		plan = "free"
+	}
+	req.Header.Set("X-Plan", plan)
 	req.Header.Set("X-Cron-Job-ID", job.ID)
 	if req.Header.Get("Content-Type") == "" && len(job.Payload) > 0 {
 		req.Header.Set("Content-Type", "application/json")
@@ -283,6 +287,8 @@ func (e *Executor) executeFunctionJob(ctx context.Context, job DueJob) error {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("function returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
+	// Drain so the connection can be reused by http.Client's transport pool.
+	io.Copy(io.Discard, resp.Body)
 	return nil
 }
 

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -1,39 +1,80 @@
 package cron
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/eurobase/euroback/internal/functions"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// FunctionInvoker wires the cron executor to the function-runner HTTP
+// service so an `action_type='function'` schedule fires the named Deno
+// function with the schedule's `payload` and `headers`. Both fields are
+// optional — pass nil to disable function-typed schedules (they will be
+// recorded as failures with a clear message).
+type FunctionInvoker struct {
+	RunnerURL string
+	Signer    *functions.Signer
+	Client    *http.Client
+}
+
 // Executor runs due cron jobs on a schedule.
 type Executor struct {
-	svc  *CronService
-	pool *pgxpool.Pool
+	svc      *CronService
+	pool     *pgxpool.Pool
+	invoker  *FunctionInvoker
+	location *time.Location // fallback timezone when a job's tz fails to load
 }
 
 // NewExecutor creates a new cron job executor.
 func NewExecutor(svc *CronService, pool *pgxpool.Pool) *Executor {
-	return &Executor{svc: svc, pool: pool}
+	return &Executor{svc: svc, pool: pool, location: time.UTC}
+}
+
+// WithFunctionInvoker enables `action_type='function'` schedules by
+// configuring the HTTP path to the function runner. Pass a Signer from
+// the gateway/runner shared secret so the runner accepts the call. Safe
+// to call zero times — function schedules then fail-fast with a clear
+// message.
+func (e *Executor) WithFunctionInvoker(inv FunctionInvoker) *Executor {
+	if inv.Client == nil {
+		inv.Client = &http.Client{Timeout: 65 * time.Second}
+	}
+	e.invoker = &inv
+	return e
 }
 
 // RunDueJobs checks all enabled cron jobs and executes those whose schedule
-// matches the current time (truncated to the minute).
+// matches the current time (truncated to the minute, evaluated in the
+// job's configured timezone).
 func (e *Executor) RunDueJobs(ctx context.Context) error {
 	jobs, err := e.svc.GetDueJobs(ctx)
 	if err != nil {
 		return fmt.Errorf("get due jobs: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := time.Now()
 	for _, job := range jobs {
-		if !shouldRun(job.Schedule, now) {
+		loc := e.location
+		if job.Timezone != "" {
+			if l, err := time.LoadLocation(job.Timezone); err == nil {
+				loc = l
+			} else {
+				slog.Warn("cron job has invalid timezone, falling back to UTC",
+					"job_id", job.ID, "timezone", job.Timezone, "error", err)
+			}
+		}
+		if !shouldRun(job.Schedule, now.In(loc)) {
 			continue
 		}
 
@@ -135,6 +176,10 @@ func (e *Executor) RunDueJobs(ctx context.Context) error {
 //  4. Executes the action via `tx.Exec` — the extended query protocol,
 //     which runs only the first statement (defence-in-depth on top of
 //     the multi-statement rejection).
+//
+// `function` action_type is dispatched out-of-band to the Deno runner
+// over HTTP (same HMAC-signed path the SDK uses), so SQL-injection
+// concerns don't apply there — the action is the function name.
 func (e *Executor) executeJob(ctx context.Context, job DueJob) error {
 	switch job.ActionType {
 	case "sql":
@@ -158,9 +203,87 @@ func (e *Executor) executeJob(ctx context.Context, job DueJob) error {
 			}
 			return nil
 		})
+	case "function":
+		return e.executeFunctionJob(ctx, job)
 	default:
 		return fmt.Errorf("unknown action_type: %s", job.ActionType)
 	}
+}
+
+// executeFunctionJob POSTs to the function runner's /invoke endpoint with
+// the same identity headers + HMAC signature the gateway uses for direct
+// invocations. The runner enforces tenant isolation via X-Schema-Name on
+// its side. Headers + payload from the schedule row are merged with the
+// reserved identity headers — reserved keys win.
+func (e *Executor) executeFunctionJob(ctx context.Context, job DueJob) error {
+	if err := validateFunctionName(job.Action); err != nil {
+		return err
+	}
+	if e.invoker == nil || e.invoker.RunnerURL == "" {
+		return fmt.Errorf("function action_type requires functions runner to be configured")
+	}
+
+	// Look up function row for X-Function-ID + verify it's active.
+	var fnID, fnStatus string
+	err := e.pool.QueryRow(ctx,
+		`SELECT id, status FROM edge_functions WHERE project_id = $1 AND name = $2`,
+		job.ProjectID, job.Action).Scan(&fnID, &fnStatus)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return fmt.Errorf("function %q is not deployed", job.Action)
+		}
+		return fmt.Errorf("look up function: %w", err)
+	}
+	if fnStatus != "active" {
+		return fmt.Errorf("function %q is disabled", job.Action)
+	}
+
+	var body io.Reader
+	if len(job.Payload) > 0 {
+		body = bytes.NewReader(job.Payload)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, e.invoker.RunnerURL+"/invoke", body)
+	if err != nil {
+		return fmt.Errorf("build runner request: %w", err)
+	}
+
+	// Caller-supplied headers go on first; reserved identity headers
+	// overwrite so a malicious schedule can't spoof project_id.
+	if len(job.Headers) > 0 {
+		var hdrs map[string]string
+		if err := json.Unmarshal(job.Headers, &hdrs); err == nil {
+			for k, v := range hdrs {
+				req.Header.Set(k, v)
+			}
+		}
+	}
+	req.Header.Set("X-Project-ID", job.ProjectID)
+	req.Header.Set("X-Schema-Name", job.SchemaName)
+	req.Header.Set("X-Function-Name", job.Action)
+	req.Header.Set("X-Function-ID", fnID)
+	req.Header.Set("X-Plan", "free") // schedule-fired invocations don't carry plan; runner uses for limits only
+	req.Header.Set("X-Cron-Job-ID", job.ID)
+	if req.Header.Get("Content-Type") == "" && len(job.Payload) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if e.invoker.Signer != nil {
+		e.invoker.Signer.Sign(req.Header, time.Now())
+	}
+
+	resp, err := e.invoker.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("invoke function: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("function returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
 }
 
 // runInTenantTx wraps a cron action in a transaction with `SET LOCAL

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -13,6 +13,10 @@ import (
 const (
 	// freePlanCronLimit is the max number of cron jobs on the free plan.
 	freePlanCronLimit = 2
+	// maxScheduleBodyBytes caps SDK schedule create/update bodies.
+	// Schedule rows are small (cron + name + optional payload/headers)
+	// — 1 MB is plenty and stops a leaked secret key from posting GBs.
+	maxScheduleBodyBytes = 1 << 20
 )
 
 // Routes returns a chi.Router for cron job CRUD operations.
@@ -217,6 +221,7 @@ func handleSDKCreate(svc *CronService) http.HandlerFunc {
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, maxScheduleBodyBytes)
 		var req CreateCronJobRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, "invalid request body", http.StatusBadRequest)
@@ -257,6 +262,7 @@ func handleSDKUpdate(svc *CronService) http.HandlerFunc {
 		}
 		name := chi.URLParam(r, "name")
 
+		r.Body = http.MaxBytesReader(w, r.Body, maxScheduleBodyBytes)
 		var req UpdateCronJobRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, "invalid request body", http.StatusBadRequest)

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -2,9 +2,11 @@ package cron
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 
+	"github.com/eurobase/euroback/internal/auth"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -22,6 +24,24 @@ func Routes(svc *CronService) chi.Router {
 	r.Patch("/{jobId}", handleUpdate(svc))
 	r.Delete("/{jobId}", handleDelete(svc))
 	r.Get("/{jobId}/runs", handleListRuns(svc))
+	return r
+}
+
+// SDKRoutes returns a chi.Router exposing the schedule surface to the JS
+// SDK (`eb.functions.schedules.*`). Mounted at /v1/schedules under the
+// API-key middleware. Schedules are addressed by their stable name, not
+// by server-allocated UUID — see #112.
+//
+// Service-key gating is done by the route wrapper (see router.go), since
+// editing schedules is a control-plane operation and public keys must
+// not have write access.
+func SDKRoutes(svc *CronService) chi.Router {
+	r := chi.NewRouter()
+	r.Get("/", handleSDKList(svc))
+	r.Post("/", handleSDKCreate(svc))
+	r.Get("/{name}", handleSDKGet(svc))
+	r.Patch("/{name}", handleSDKUpdate(svc))
+	r.Delete("/{name}", handleSDKDelete(svc))
 	return r
 }
 
@@ -44,43 +64,28 @@ func handleCreate(svc *CronService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projectID := chi.URLParam(r, "id")
 
-		// Parse and validate request body first.
 		var req CreateCronJobRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
 
-		// Validate fields before checking plan limits.
 		if err := req.Validate(); err != nil {
 			jsonError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		// Enforce plan limit: free plan gets 2 cron jobs.
-		count, err := svc.Count(r.Context(), projectID)
-		if err != nil {
-			slog.Error("count cron jobs failed", "error", err, "project_id", projectID)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		var plan string
-		err = svc.pool.QueryRow(r.Context(),
-			`SELECT COALESCE(plan, 'free') FROM projects WHERE id = $1`, projectID).Scan(&plan)
-		if err != nil {
-			slog.Error("get project plan failed", "error", err, "project_id", projectID)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		if plan == "free" && count >= freePlanCronLimit {
-			jsonError(w, "free plan is limited to 2 scheduled jobs — upgrade to pro for unlimited", http.StatusForbidden)
+		if err := enforcePlanLimit(r, svc, projectID); err != nil {
+			jsonError(w, err.message, err.status)
 			return
 		}
 
 		job, err := svc.Create(r.Context(), projectID, req)
 		if err != nil {
+			if errors.Is(err, ErrNameAlreadyExists) {
+				jsonError(w, err.Error(), http.StatusConflict)
+				return
+			}
 			slog.Error("create cron job failed", "error", err, "project_id", projectID)
 			jsonError(w, err.Error(), http.StatusBadRequest)
 			return
@@ -103,7 +108,7 @@ func handleUpdate(svc *CronService) http.HandlerFunc {
 
 		job, err := svc.Update(r.Context(), projectID, jobID, req)
 		if err != nil {
-			if err.Error() == "cron job not found" {
+			if errors.Is(err, ErrNotFound) {
 				jsonError(w, "cron job not found", http.StatusNotFound)
 				return
 			}
@@ -123,7 +128,7 @@ func handleDelete(svc *CronService) http.HandlerFunc {
 
 		err := svc.Delete(r.Context(), projectID, jobID)
 		if err != nil {
-			if err.Error() == "cron job not found" {
+			if errors.Is(err, ErrNotFound) {
 				jsonError(w, "cron job not found", http.StatusNotFound)
 				return
 			}
@@ -153,6 +158,169 @@ func handleListRuns(svc *CronService) http.HandlerFunc {
 
 		jsonResponse(w, runs, http.StatusOK)
 	}
+}
+
+// ── SDK handlers (addressed by name, project from API-key context) ──
+
+func projectIDFromAPIKey(r *http.Request) (string, bool) {
+	pc, ok := auth.ProjectFromContext(r.Context())
+	if !ok || pc == nil {
+		return "", false
+	}
+	return pc.ProjectID, true
+}
+
+func handleSDKList(svc *CronService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, ok := projectIDFromAPIKey(r)
+		if !ok {
+			jsonError(w, "missing project context", http.StatusUnauthorized)
+			return
+		}
+		jobs, err := svc.List(r.Context(), projectID)
+		if err != nil {
+			slog.Error("sdk list schedules failed", "error", err, "project_id", projectID)
+			jsonError(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		jsonResponse(w, jobs, http.StatusOK)
+	}
+}
+
+func handleSDKGet(svc *CronService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, ok := projectIDFromAPIKey(r)
+		if !ok {
+			jsonError(w, "missing project context", http.StatusUnauthorized)
+			return
+		}
+		name := chi.URLParam(r, "name")
+		job, err := svc.GetByName(r.Context(), projectID, name)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				jsonError(w, "schedule not found", http.StatusNotFound)
+				return
+			}
+			slog.Error("sdk get schedule failed", "error", err, "project_id", projectID, "name", name)
+			jsonError(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		jsonResponse(w, job, http.StatusOK)
+	}
+}
+
+func handleSDKCreate(svc *CronService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, ok := projectIDFromAPIKey(r)
+		if !ok {
+			jsonError(w, "missing project context", http.StatusUnauthorized)
+			return
+		}
+
+		var req CreateCronJobRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		if err := req.Validate(); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := enforcePlanLimit(r, svc, projectID); err != nil {
+			jsonError(w, err.message, err.status)
+			return
+		}
+
+		job, err := svc.Create(r.Context(), projectID, req)
+		if err != nil {
+			if errors.Is(err, ErrNameAlreadyExists) {
+				// 409 lets the SDK surface this as `already_exists`
+				// per #112 — callers should retry with update().
+				jsonError(w, err.Error(), http.StatusConflict)
+				return
+			}
+			slog.Error("sdk create schedule failed", "error", err, "project_id", projectID)
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		jsonResponse(w, job, http.StatusCreated)
+	}
+}
+
+func handleSDKUpdate(svc *CronService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, ok := projectIDFromAPIKey(r)
+		if !ok {
+			jsonError(w, "missing project context", http.StatusUnauthorized)
+			return
+		}
+		name := chi.URLParam(r, "name")
+
+		var req UpdateCronJobRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		job, err := svc.UpdateByName(r.Context(), projectID, name, req)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				jsonError(w, "schedule not found", http.StatusNotFound)
+				return
+			}
+			slog.Error("sdk update schedule failed", "error", err, "project_id", projectID, "name", name)
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		jsonResponse(w, job, http.StatusOK)
+	}
+}
+
+func handleSDKDelete(svc *CronService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, ok := projectIDFromAPIKey(r)
+		if !ok {
+			jsonError(w, "missing project context", http.StatusUnauthorized)
+			return
+		}
+		name := chi.URLParam(r, "name")
+		if err := svc.DeleteByName(r.Context(), projectID, name); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				jsonError(w, "schedule not found", http.StatusNotFound)
+				return
+			}
+			slog.Error("sdk delete schedule failed", "error", err, "project_id", projectID, "name", name)
+			jsonError(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// httpErr is a small bag for plan-limit failures so create handlers can
+// surface either 403 (over limit) or 500 (DB error) with a single check.
+type httpErr struct {
+	status  int
+	message string
+}
+
+func enforcePlanLimit(r *http.Request, svc *CronService, projectID string) *httpErr {
+	count, err := svc.Count(r.Context(), projectID)
+	if err != nil {
+		slog.Error("count cron jobs failed", "error", err, "project_id", projectID)
+		return &httpErr{status: http.StatusInternalServerError, message: "internal server error"}
+	}
+	var plan string
+	if err := svc.pool.QueryRow(r.Context(),
+		`SELECT COALESCE(plan, 'free') FROM projects WHERE id = $1`, projectID).Scan(&plan); err != nil {
+		slog.Error("get project plan failed", "error", err, "project_id", projectID)
+		return &httpErr{status: http.StatusInternalServerError, message: "internal server error"}
+	}
+	if plan == "free" && count >= freePlanCronLimit {
+		return &httpErr{status: http.StatusForbidden, message: "free plan is limited to 2 scheduled jobs — upgrade to pro for unlimited"}
+	}
+	return nil
 }
 
 func jsonResponse(w http.ResponseWriter, data any, status int) {

--- a/internal/cron/service.go
+++ b/internal/cron/service.go
@@ -3,6 +3,8 @@ package cron
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -12,20 +14,32 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// ErrNotFound is returned when a cron job lookup misses.
+var ErrNotFound = errors.New("cron job not found")
+
+// ErrNameAlreadyExists is returned by Create when (project_id, name) is
+// already taken. The SDK surfaces this as an `already_exists` discriminator
+// per #112 — callers should `update()` to change an existing schedule.
+var ErrNameAlreadyExists = errors.New("schedule with this name already exists")
+
 // CronJob represents a scheduled job configured by a project owner.
 type CronJob struct {
-	ID         string     `json:"id"`
-	ProjectID  string     `json:"project_id"`
-	Name       string     `json:"name"`
-	Schedule   string     `json:"schedule"`
-	ActionType string     `json:"action_type"`
-	Action     string     `json:"action"`
-	Enabled    bool       `json:"enabled"`
-	LastRunAt  *time.Time `json:"last_run_at"`
-	LastError  *string    `json:"last_error"`
-	RunCount   int        `json:"run_count"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID          string          `json:"id"`
+	ProjectID   string          `json:"project_id"`
+	Name        string          `json:"name"`
+	Schedule    string          `json:"schedule"`
+	Timezone    string          `json:"timezone"`
+	ActionType  string          `json:"action_type"`
+	Action      string          `json:"action"`
+	Description *string         `json:"description"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Headers     json.RawMessage `json:"headers,omitempty"`
+	Enabled     bool            `json:"enabled"`
+	LastRunAt   *time.Time      `json:"last_run_at"`
+	LastError   *string         `json:"last_error"`
+	RunCount    int             `json:"run_count"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
 }
 
 // DueJob extends CronJob with the tenant schema name for execution.
@@ -36,10 +50,15 @@ type DueJob struct {
 
 // CreateCronJobRequest is the payload for creating a new cron job.
 type CreateCronJobRequest struct {
-	Name       string `json:"name"`
-	Schedule   string `json:"schedule"`
-	ActionType string `json:"action_type"`
-	Action     string `json:"action"`
+	Name        string          `json:"name"`
+	Schedule    string          `json:"schedule"`
+	Timezone    string          `json:"timezone,omitempty"`
+	ActionType  string          `json:"action_type"`
+	Action      string          `json:"action"`
+	Description *string         `json:"description,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Headers     json.RawMessage `json:"headers,omitempty"`
+	Enabled     *bool           `json:"enabled,omitempty"`
 }
 
 // Validate checks that all required fields are present and valid.
@@ -50,19 +69,28 @@ func (r *CreateCronJobRequest) Validate() error {
 	if strings.TrimSpace(r.Action) == "" {
 		return fmt.Errorf("action is required")
 	}
-	if r.ActionType != "sql" && r.ActionType != "rpc" {
-		return fmt.Errorf("action_type must be 'sql' or 'rpc'")
+	if r.ActionType != "sql" && r.ActionType != "rpc" && r.ActionType != "function" {
+		return fmt.Errorf("action_type must be 'sql', 'rpc', or 'function'")
+	}
+	if r.Timezone != "" {
+		if _, err := time.LoadLocation(r.Timezone); err != nil {
+			return fmt.Errorf("invalid timezone %q: %w", r.Timezone, err)
+		}
 	}
 	return validateCronSchedule(r.Schedule)
 }
 
 // UpdateCronJobRequest is the payload for updating a cron job.
 type UpdateCronJobRequest struct {
-	Name       *string `json:"name,omitempty"`
-	Schedule   *string `json:"schedule,omitempty"`
-	ActionType *string `json:"action_type,omitempty"`
-	Action     *string `json:"action,omitempty"`
-	Enabled    *bool   `json:"enabled,omitempty"`
+	Name        *string         `json:"name,omitempty"`
+	Schedule    *string         `json:"schedule,omitempty"`
+	Timezone    *string         `json:"timezone,omitempty"`
+	ActionType  *string         `json:"action_type,omitempty"`
+	Action      *string         `json:"action,omitempty"`
+	Description *string         `json:"description,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
+	Headers     json.RawMessage `json:"headers,omitempty"`
+	Enabled     *bool           `json:"enabled,omitempty"`
 }
 
 // CronService handles CRUD operations for cron jobs.
@@ -75,11 +103,21 @@ func NewCronService(pool *pgxpool.Pool) *CronService {
 	return &CronService{pool: pool}
 }
 
+const cronJobColumns = `id, project_id, name, schedule, timezone, action_type, action,
+		description, payload, headers, enabled,
+		last_run_at, last_error, run_count, created_at, updated_at`
+
+func scanCronJob(row pgx.Row, j *CronJob) error {
+	return row.Scan(&j.ID, &j.ProjectID, &j.Name, &j.Schedule, &j.Timezone,
+		&j.ActionType, &j.Action, &j.Description, &j.Payload, &j.Headers,
+		&j.Enabled, &j.LastRunAt, &j.LastError, &j.RunCount,
+		&j.CreatedAt, &j.UpdatedAt)
+}
+
 // List returns all cron jobs for a project.
 func (s *CronService) List(ctx context.Context, projectID string) ([]CronJob, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, project_id, name, schedule, action_type, action, enabled,
-		        last_run_at, last_error, run_count, created_at, updated_at
+		`SELECT `+cronJobColumns+`
 		 FROM cron_jobs WHERE project_id = $1 ORDER BY created_at DESC`, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("query cron jobs: %w", err)
@@ -89,9 +127,7 @@ func (s *CronService) List(ctx context.Context, projectID string) ([]CronJob, er
 	jobs := make([]CronJob, 0)
 	for rows.Next() {
 		var j CronJob
-		if err := rows.Scan(&j.ID, &j.ProjectID, &j.Name, &j.Schedule, &j.ActionType,
-			&j.Action, &j.Enabled, &j.LastRunAt, &j.LastError, &j.RunCount,
-			&j.CreatedAt, &j.UpdatedAt); err != nil {
+		if err := scanCronJob(rows, &j); err != nil {
 			return nil, fmt.Errorf("scan cron job: %w", err)
 		}
 		jobs = append(jobs, j)
@@ -99,33 +135,60 @@ func (s *CronService) List(ctx context.Context, projectID string) ([]CronJob, er
 	return jobs, nil
 }
 
-// Create inserts a new cron job for a project.
+// GetByName looks up a cron job by its (project_id, name) pair. The SDK
+// addresses schedules by their stable name; the UUID is server-allocated
+// and opaque.
+func (s *CronService) GetByName(ctx context.Context, projectID, name string) (*CronJob, error) {
+	var j CronJob
+	err := scanCronJob(s.pool.QueryRow(ctx,
+		`SELECT `+cronJobColumns+`
+		 FROM cron_jobs WHERE project_id = $1 AND name = $2`,
+		projectID, name), &j)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get cron job by name: %w", err)
+	}
+	return &j, nil
+}
+
+// Create inserts a new cron job for a project. Returns ErrNameAlreadyExists
+// if (project_id, name) collides — callers are expected to use UpdateByName
+// instead. Idempotency contract per #112.
 func (s *CronService) Create(ctx context.Context, projectID string, req CreateCronJobRequest) (*CronJob, error) {
-	// Validate inputs.
-	if strings.TrimSpace(req.Name) == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-	if strings.TrimSpace(req.Action) == "" {
-		return nil, fmt.Errorf("action is required")
-	}
-	if req.ActionType != "sql" && req.ActionType != "rpc" {
-		return nil, fmt.Errorf("action_type must be 'sql' or 'rpc'")
-	}
-	if err := validateCronSchedule(req.Schedule); err != nil {
+	if err := req.Validate(); err != nil {
 		return nil, err
+	}
+	if req.ActionType == "function" {
+		if err := validateFunctionName(req.Action); err != nil {
+			return nil, err
+		}
+	}
+
+	tz := req.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
 	}
 
 	var j CronJob
-	err := s.pool.QueryRow(ctx,
-		`INSERT INTO cron_jobs (project_id, name, schedule, action_type, action)
-		 VALUES ($1, $2, $3, $4, $5)
-		 RETURNING id, project_id, name, schedule, action_type, action, enabled,
-		           last_run_at, last_error, run_count, created_at, updated_at`,
-		projectID, req.Name, req.Schedule, req.ActionType, req.Action,
-	).Scan(&j.ID, &j.ProjectID, &j.Name, &j.Schedule, &j.ActionType,
-		&j.Action, &j.Enabled, &j.LastRunAt, &j.LastError, &j.RunCount,
-		&j.CreatedAt, &j.UpdatedAt)
+	err := scanCronJob(s.pool.QueryRow(ctx,
+		`INSERT INTO cron_jobs (project_id, name, schedule, timezone, action_type, action,
+		                        description, payload, headers, enabled)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		 RETURNING `+cronJobColumns,
+		projectID, req.Name, req.Schedule, tz, req.ActionType, req.Action,
+		req.Description, nullableJSON(req.Payload), nullableJSON(req.Headers), enabled,
+	), &j)
 	if err != nil {
+		// 23505 is unique_violation — fires on cron_jobs_project_name_uq.
+		if isUniqueViolation(err) {
+			return nil, ErrNameAlreadyExists
+		}
 		return nil, fmt.Errorf("insert cron job: %w", err)
 	}
 
@@ -133,46 +196,61 @@ func (s *CronService) Create(ctx context.Context, projectID string, req CreateCr
 	return &j, nil
 }
 
-// Update modifies an existing cron job.
+// Update modifies an existing cron job by its UUID.
 func (s *CronService) Update(ctx context.Context, projectID, jobID string, req UpdateCronJobRequest) (*CronJob, error) {
-	// Validate schedule if provided.
+	return s.updateBy(ctx, "id = $1 AND project_id = $2", []any{jobID, projectID}, req)
+}
+
+// UpdateByName modifies an existing cron job by its (project_id, name) pair.
+func (s *CronService) UpdateByName(ctx context.Context, projectID, name string, req UpdateCronJobRequest) (*CronJob, error) {
+	return s.updateBy(ctx, "name = $1 AND project_id = $2", []any{name, projectID}, req)
+}
+
+func (s *CronService) updateBy(ctx context.Context, whereClause string, whereArgs []any, req UpdateCronJobRequest) (*CronJob, error) {
 	if req.Schedule != nil {
 		if err := validateCronSchedule(*req.Schedule); err != nil {
 			return nil, err
 		}
 	}
-	if req.ActionType != nil && *req.ActionType != "sql" && *req.ActionType != "rpc" {
-		return nil, fmt.Errorf("action_type must be 'sql' or 'rpc'")
+	if req.Timezone != nil && *req.Timezone != "" {
+		if _, err := time.LoadLocation(*req.Timezone); err != nil {
+			return nil, fmt.Errorf("invalid timezone %q: %w", *req.Timezone, err)
+		}
+	}
+	if req.ActionType != nil && *req.ActionType != "sql" && *req.ActionType != "rpc" && *req.ActionType != "function" {
+		return nil, fmt.Errorf("action_type must be 'sql', 'rpc', or 'function'")
 	}
 
-	var j CronJob
-	err := s.pool.QueryRow(ctx,
-		`UPDATE cron_jobs SET
+	args := append([]any{}, whereArgs...)
+	args = append(args,
+		req.Name, req.Schedule, req.Timezone, req.ActionType, req.Action,
+		req.Description, nullableJSON(req.Payload), nullableJSON(req.Headers), req.Enabled,
+	)
+	q := `UPDATE cron_jobs SET
 			name        = COALESCE($3, name),
 			schedule    = COALESCE($4, schedule),
-			action_type = COALESCE($5, action_type),
-			action      = COALESCE($6, action),
-			enabled     = COALESCE($7, enabled),
+			timezone    = COALESCE($5, timezone),
+			action_type = COALESCE($6, action_type),
+			action      = COALESCE($7, action),
+			description = COALESCE($8, description),
+			payload     = COALESCE($9, payload),
+			headers     = COALESCE($10, headers),
+			enabled     = COALESCE($11, enabled),
 			updated_at  = now()
-		 WHERE id = $1 AND project_id = $2
-		 RETURNING id, project_id, name, schedule, action_type, action, enabled,
-		           last_run_at, last_error, run_count, created_at, updated_at`,
-		jobID, projectID, req.Name, req.Schedule, req.ActionType, req.Action, req.Enabled,
-	).Scan(&j.ID, &j.ProjectID, &j.Name, &j.Schedule, &j.ActionType,
-		&j.Action, &j.Enabled, &j.LastRunAt, &j.LastError, &j.RunCount,
-		&j.CreatedAt, &j.UpdatedAt)
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, fmt.Errorf("cron job not found")
+		 WHERE ` + whereClause + `
+		 RETURNING ` + cronJobColumns
+	var j CronJob
+	if err := scanCronJob(s.pool.QueryRow(ctx, q, args...), &j); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("update cron job: %w", err)
 	}
-
-	slog.Info("cron job updated", "job_id", jobID, "project_id", projectID)
+	slog.Info("cron job updated", "job_id", j.ID, "project_id", j.ProjectID, "name", j.Name)
 	return &j, nil
 }
 
-// Delete removes a cron job.
+// Delete removes a cron job by UUID.
 func (s *CronService) Delete(ctx context.Context, projectID, jobID string) error {
 	tag, err := s.pool.Exec(ctx,
 		`DELETE FROM cron_jobs WHERE id = $1 AND project_id = $2`, jobID, projectID)
@@ -180,17 +258,32 @@ func (s *CronService) Delete(ctx context.Context, projectID, jobID string) error
 		return fmt.Errorf("delete cron job: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("cron job not found")
+		return ErrNotFound
 	}
 	slog.Info("cron job deleted", "job_id", jobID, "project_id", projectID)
+	return nil
+}
+
+// DeleteByName removes a cron job by (project_id, name).
+func (s *CronService) DeleteByName(ctx context.Context, projectID, name string) error {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM cron_jobs WHERE name = $1 AND project_id = $2`, name, projectID)
+	if err != nil {
+		return fmt.Errorf("delete cron job by name: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	slog.Info("cron job deleted", "name", name, "project_id", projectID)
 	return nil
 }
 
 // GetDueJobs returns all enabled cron jobs for active projects, including the schema name.
 func (s *CronService) GetDueJobs(ctx context.Context) ([]DueJob, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT cj.id, cj.project_id, cj.name, cj.schedule, cj.action_type, cj.action,
-		        cj.enabled, cj.last_run_at, cj.last_error, cj.run_count,
+		`SELECT cj.id, cj.project_id, cj.name, cj.schedule, cj.timezone, cj.action_type,
+		        cj.action, cj.description, cj.payload, cj.headers, cj.enabled,
+		        cj.last_run_at, cj.last_error, cj.run_count,
 		        cj.created_at, cj.updated_at, p.schema_name
 		 FROM cron_jobs cj
 		 JOIN projects p ON cj.project_id = p.id
@@ -203,8 +296,9 @@ func (s *CronService) GetDueJobs(ctx context.Context) ([]DueJob, error) {
 	var jobs []DueJob
 	for rows.Next() {
 		var d DueJob
-		if err := rows.Scan(&d.ID, &d.ProjectID, &d.Name, &d.Schedule, &d.ActionType,
-			&d.Action, &d.Enabled, &d.LastRunAt, &d.LastError, &d.RunCount,
+		if err := rows.Scan(&d.ID, &d.ProjectID, &d.Name, &d.Schedule, &d.Timezone,
+			&d.ActionType, &d.Action, &d.Description, &d.Payload, &d.Headers,
+			&d.Enabled, &d.LastRunAt, &d.LastError, &d.RunCount,
 			&d.CreatedAt, &d.UpdatedAt, &d.SchemaName); err != nil {
 			return nil, fmt.Errorf("scan due job: %w", err)
 		}
@@ -290,4 +384,45 @@ func validateCronSchedule(schedule string) error {
 		return fmt.Errorf("invalid cron schedule: must have 5 fields (minute hour day-of-month month day-of-week)")
 	}
 	return nil
+}
+
+// validateFunctionName mirrors validateCronRPCName — function names are
+// safe identifiers so they can be used in the runner URL path. The
+// function service does its own DB-side lookup, so this is just shape
+// guard, not auth. Hyphens are allowed (`purge-expired-images`) since
+// edge functions follow kebab-case.
+func validateFunctionName(name string) error {
+	if !validFunctionNameRe.MatchString(strings.TrimSpace(name)) {
+		return errors.New("invalid function name (use letters, digits, underscores, hyphens)")
+	}
+	return nil
+}
+
+// nullableJSON returns nil for empty raw JSON so the COALESCE in
+// updateBy() preserves the existing column value instead of overwriting
+// it with the literal JSON null.
+func nullableJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}
+
+// isUniqueViolation reports whether err is a pg unique_violation (23505).
+// Wrapped errors are unwrapped one level (we use fmt.Errorf("%w") above).
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	type pgErr interface {
+		SQLState() string
+	}
+	if pe, ok := err.(pgErr); ok {
+		return pe.SQLState() == "23505"
+	}
+	var pe pgErr
+	if errors.As(err, &pe) {
+		return pe.SQLState() == "23505"
+	}
+	return false
 }

--- a/internal/cron/service.go
+++ b/internal/cron/service.go
@@ -42,10 +42,14 @@ type CronJob struct {
 	UpdatedAt   time.Time       `json:"updated_at"`
 }
 
-// DueJob extends CronJob with the tenant schema name for execution.
+// DueJob extends CronJob with the tenant schema name + plan needed for
+// execution. Plan flows through to the runner's X-Plan header so
+// pro-plan projects get pro-tier limits on schedule-fired invocations
+// (review feedback on PR #113).
 type DueJob struct {
 	CronJob
 	SchemaName string
+	Plan       string
 }
 
 // CreateCronJobRequest is the payload for creating a new cron job.
@@ -278,13 +282,15 @@ func (s *CronService) DeleteByName(ctx context.Context, projectID, name string) 
 	return nil
 }
 
-// GetDueJobs returns all enabled cron jobs for active projects, including the schema name.
+// GetDueJobs returns all enabled cron jobs for active projects, including
+// the schema name and plan. Plan is needed so the executor can pass the
+// correct X-Plan to the function runner for pro-tier limits.
 func (s *CronService) GetDueJobs(ctx context.Context) ([]DueJob, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT cj.id, cj.project_id, cj.name, cj.schedule, cj.timezone, cj.action_type,
 		        cj.action, cj.description, cj.payload, cj.headers, cj.enabled,
 		        cj.last_run_at, cj.last_error, cj.run_count,
-		        cj.created_at, cj.updated_at, p.schema_name
+		        cj.created_at, cj.updated_at, p.schema_name, COALESCE(p.plan, 'free')
 		 FROM cron_jobs cj
 		 JOIN projects p ON cj.project_id = p.id
 		 WHERE cj.enabled = true AND p.status = 'active'`)
@@ -299,7 +305,7 @@ func (s *CronService) GetDueJobs(ctx context.Context) ([]DueJob, error) {
 		if err := rows.Scan(&d.ID, &d.ProjectID, &d.Name, &d.Schedule, &d.Timezone,
 			&d.ActionType, &d.Action, &d.Description, &d.Payload, &d.Headers,
 			&d.Enabled, &d.LastRunAt, &d.LastError, &d.RunCount,
-			&d.CreatedAt, &d.UpdatedAt, &d.SchemaName); err != nil {
+			&d.CreatedAt, &d.UpdatedAt, &d.SchemaName, &d.Plan); err != nil {
 			return nil, fmt.Errorf("scan due job: %w", err)
 		}
 		jobs = append(jobs, d)

--- a/internal/cron/validate.go
+++ b/internal/cron/validate.go
@@ -12,6 +12,11 @@ import (
 // validator uses elsewhere).
 var validRPCNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// validFunctionNameRe matches safe edge-function names. Edge functions
+// use kebab-case (`purge-expired-images`) so we allow hyphens here. The
+// expression is reused via validateFunctionName in service.go.
+var validFunctionNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
 // forbiddenSchemaRe matches qualified references to schemas that a tenant
 // cron job has no legitimate need to touch. The list:
 //

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -583,6 +583,16 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			r.Use(endUserMw.Handler)
 			r.HandleFunc("/{name}", functions.HandleInvoke(pool, sdkFnSvc, fnRunnerURL, fnSigner))
 		})
+
+		// Schedules — SDK control-plane for cron jobs. Closes #112.
+		// Service-key only: editing schedules is destructive (writes to
+		// cron_jobs) and public keys live in client code.
+		r.Route("/schedules", func(r chi.Router) {
+			r.Use(apiKeyMw.Handler)
+			r.Use(requireSecretKeyForSchedules)
+			sdkCronSvc := cron.NewCronService(pool)
+			r.Mount("/", cron.SDKRoutes(sdkCronSvc))
+		})
 	})
 
 	return r
@@ -666,6 +676,26 @@ func superadminMiddleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 func withDeveloperRole(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r.WithContext(query.WithDeveloperRole(r.Context())))
+	})
+}
+
+// requireSecretKeyForSchedules gates SDK `/v1/schedules` to secret API
+// keys only. Schedules are control-plane state — they fire arbitrary
+// edge-function invocations on a recurring cadence. Public keys live in
+// client-side code and a leaked public key must not be able to install
+// or remove a schedule.
+func requireSecretKeyForSchedules(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pc, ok := auth.ProjectFromContext(r.Context())
+		if !ok {
+			http.Error(w, `{"error":"missing project context"}`, http.StatusUnauthorized)
+			return
+		}
+		if pc.KeyType != "secret" {
+			http.Error(w, `{"error":"managing schedules requires a secret API key (eb_sk_*)"}`, http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/migrations/000053_cron_schedules_sdk.down.sql
+++ b/migrations/000053_cron_schedules_sdk.down.sql
@@ -1,0 +1,13 @@
+DROP INDEX IF EXISTS cron_jobs_project_name_uq;
+
+ALTER TABLE public.cron_jobs
+    DROP COLUMN IF EXISTS headers,
+    DROP COLUMN IF EXISTS payload,
+    DROP COLUMN IF EXISTS description,
+    DROP COLUMN IF EXISTS timezone;
+
+ALTER TABLE public.cron_jobs
+    DROP CONSTRAINT IF EXISTS cron_jobs_action_type_check;
+ALTER TABLE public.cron_jobs
+    ADD CONSTRAINT cron_jobs_action_type_check
+    CHECK (action_type IN ('sql', 'rpc'));

--- a/migrations/000053_cron_schedules_sdk.up.sql
+++ b/migrations/000053_cron_schedules_sdk.up.sql
@@ -1,0 +1,28 @@
+-- Closes #112. Adds the columns the SDK `eb.functions.schedules` surface needs
+-- on top of the existing cron_jobs table, and a unique (project_id, name)
+-- index so schedules can be addressed idempotently by their stable name.
+--
+-- Action type `function` is added so a schedule can target a deployed edge
+-- function (Deno runner). The executor maps this to an HTTP invocation
+-- against the function runner. `sql` and `rpc` keep their existing semantics.
+
+-- Allow `function` as a third action_type.
+ALTER TABLE public.cron_jobs
+    DROP CONSTRAINT IF EXISTS cron_jobs_action_type_check;
+ALTER TABLE public.cron_jobs
+    ADD CONSTRAINT cron_jobs_action_type_check
+    CHECK (action_type IN ('sql', 'rpc', 'function'));
+
+-- Schedule metadata. NULL/default-friendly so the executor can run without
+-- these fields set — existing rows keep working.
+ALTER TABLE public.cron_jobs
+    ADD COLUMN IF NOT EXISTS timezone    TEXT NOT NULL DEFAULT 'UTC',
+    ADD COLUMN IF NOT EXISTS description TEXT,
+    ADD COLUMN IF NOT EXISTS payload     JSONB,
+    ADD COLUMN IF NOT EXISTS headers     JSONB;
+
+-- Idempotent provisioning by name: `eb.functions.schedules.create('foo', ...)`
+-- needs (project_id, name) to be unique so a second call with the same name
+-- can be detected and rejected as a conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS cron_jobs_project_name_uq
+    ON public.cron_jobs (project_id, name);

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eurobase/sdk",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Eurobase TypeScript SDK — EU-sovereign Backend-as-a-Service. Auth, database, storage, realtime, functions, vault, and schema DDL.",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc && node test/fix-dist-imports.mjs",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node test/token-propagation.mjs && node test/realtime-url.mjs"
+    "test": "npm run build && node test/token-propagation.mjs && node test/realtime-url.mjs && node test/schedules.mjs"
   },
   "keywords": [
     "eurobase",

--- a/sdk/js/src/functions.ts
+++ b/sdk/js/src/functions.ts
@@ -6,6 +6,9 @@
  */
 
 import type { EurobaseConfig, HttpClient } from './http'
+import { SchedulesClient } from './schedules'
+
+export type { ScheduleSpec, ScheduleRow, ScheduleError } from './schedules'
 
 export interface FunctionInvokeOptions {
   /** Request body (will be JSON-stringified). */
@@ -24,8 +27,15 @@ export interface FunctionError {
 export class FunctionsClient {
   private http: HttpClient
 
+  /**
+   * Cron schedules for deployed functions. See `schedules.ts`. Requires
+   * an `eb_sk_*` secret key. Closes #112.
+   */
+  readonly schedules: SchedulesClient
+
   constructor(config: EurobaseConfig, http: HttpClient) {
     this.http = http
+    this.schedules = new SchedulesClient(http)
   }
 
   /**

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -27,7 +27,14 @@ export type {
 } from './realtime'
 export { AuthClient } from './auth'
 export { FunctionsClient } from './functions'
-export type { FunctionInvokeOptions, FunctionError } from './functions'
+export type {
+  FunctionInvokeOptions,
+  FunctionError,
+  ScheduleSpec,
+  ScheduleRow,
+  ScheduleError,
+} from './functions'
+export { SchedulesClient } from './schedules'
 export { VaultClient } from './vault'
 export type { VaultSecret, VaultSecretMeta } from './vault'
 export { SchemaClient } from './ddl'

--- a/sdk/js/src/schedules.ts
+++ b/sdk/js/src/schedules.ts
@@ -1,0 +1,248 @@
+/**
+ * Schedules client — scheduled function triggers (cron jobs).
+ *
+ * Closes #112. Exposed as `eb.functions.schedules` so a deployed edge
+ * function can declare its own cron alongside the deploy:
+ *
+ * ```ts
+ * await eb.functions.schedules.create('purge-expired-images', {
+ *   functionName: 'purge-expired-images',
+ *   cron: '0 4 * * *',
+ *   timezone: 'UTC',
+ *   description: 'Daily purge of session_images past 24h TTL',
+ * })
+ * ```
+ *
+ * Requires an `eb_sk_*` secret key — public keys live in client code and
+ * must not be able to install or remove a schedule.
+ *
+ * Semantics (locked-in defaults; see issue #112):
+ *   - `create()` is NOT an upsert. Calling it twice with the same name
+ *     returns `already_exists` (HTTP 409). Use `update()` to change an
+ *     existing schedule. A separate `createOrUpdate` helper is provided
+ *     for provisioning scripts that don't want to branch on the error.
+ *   - Missed ticks during platform downtime are dropped (no backfill).
+ *   - Each tick is independent — no overlap protection in v1.
+ *   - Cron grammar is POSIX 5-field (minute hour day-of-month month
+ *     day-of-week), evaluated in the schedule's `timezone` (defaults to
+ *     UTC). `@daily` / `@hourly` aliases are not supported.
+ */
+
+import type { HttpClient } from './http'
+
+export interface ScheduleSpec {
+  /** Function to invoke. Must already be deployed. */
+  functionName: string
+  /** Standard 5-field cron expression, evaluated in `timezone`. */
+  cron: string
+  /** Optional IANA timezone. Defaults to UTC. */
+  timezone?: string
+  /** Optional JSON body passed to the function on each tick. */
+  payload?: unknown
+  /** Optional headers added to the function invocation. */
+  headers?: Record<string, string>
+  /** Optional human-readable label that surfaces in the dashboard. */
+  description?: string
+  /** Whether the schedule is currently active. Defaults to true. */
+  enabled?: boolean
+}
+
+export interface ScheduleRow {
+  id: string
+  projectId: string
+  name: string
+  functionName: string
+  cron: string
+  timezone: string
+  payload?: unknown
+  headers?: Record<string, string>
+  description?: string | null
+  enabled: boolean
+  lastRunAt: string | null
+  lastError: string | null
+  runCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** Discriminated error so callers can distinguish "name collision" from
+ *  validation / auth failures without parsing strings. */
+export interface ScheduleError {
+  status: number
+  message: string
+  /** `already_exists` is set on create() when the name is in use. */
+  code?: 'already_exists' | 'not_found' | 'forbidden' | 'invalid' | 'unknown'
+}
+
+interface ServerScheduleRow {
+  id: string
+  project_id: string
+  name: string
+  schedule: string
+  timezone: string
+  action_type: string
+  action: string
+  description: string | null
+  payload?: unknown
+  headers?: Record<string, string>
+  enabled: boolean
+  last_run_at: string | null
+  last_error: string | null
+  run_count: number
+  created_at: string
+  updated_at: string
+}
+
+function fromServer(row: ServerScheduleRow): ScheduleRow {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    name: row.name,
+    // action_type is always 'function' for schedules created via this
+    // client; legacy sql/rpc schedules created via the platform UI
+    // surface their action verbatim so callers can at least see them.
+    functionName: row.action,
+    cron: row.schedule,
+    timezone: row.timezone,
+    payload: row.payload,
+    headers: row.headers,
+    description: row.description,
+    enabled: row.enabled,
+    lastRunAt: row.last_run_at,
+    lastError: row.last_error,
+    runCount: row.run_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/** Build the create/update payload the gateway expects (action_type
+ *  defaults to 'function' since that's the only thing the SDK creates). */
+function toServerCreate(name: string, spec: ScheduleSpec) {
+  return {
+    name,
+    schedule: spec.cron,
+    timezone: spec.timezone,
+    action_type: 'function',
+    action: spec.functionName,
+    description: spec.description,
+    payload: spec.payload,
+    headers: spec.headers,
+    enabled: spec.enabled,
+  }
+}
+
+function toServerUpdate(spec: Partial<ScheduleSpec>) {
+  const body: Record<string, unknown> = {}
+  if (spec.cron !== undefined) body.schedule = spec.cron
+  if (spec.timezone !== undefined) body.timezone = spec.timezone
+  if (spec.functionName !== undefined) {
+    body.action_type = 'function'
+    body.action = spec.functionName
+  }
+  if (spec.description !== undefined) body.description = spec.description
+  if (spec.payload !== undefined) body.payload = spec.payload
+  if (spec.headers !== undefined) body.headers = spec.headers
+  if (spec.enabled !== undefined) body.enabled = spec.enabled
+  return body
+}
+
+function classifyError(result: any): ScheduleError {
+  const msg = typeof result?.error === 'string' ? result.error : 'request failed'
+  // Status code is embedded in the message by http.ts when the response
+  // is not JSON (`HTTP 409: Conflict`). Best-effort parse — the server
+  // also sends JSON-shaped {"error":"…"} bodies which lose the status.
+  const m = msg.match(/^HTTP (\d+):/)
+  const status = m ? Number(m[1]) : 0
+  let code: ScheduleError['code'] = 'unknown'
+  if (status === 409 || /already exists/i.test(msg)) code = 'already_exists'
+  else if (status === 404 || /not found/i.test(msg)) code = 'not_found'
+  else if (status === 401 || status === 403) code = 'forbidden'
+  else if (status === 400) code = 'invalid'
+  return { status, message: msg, code }
+}
+
+export class SchedulesClient {
+  private http: HttpClient
+
+  constructor(http: HttpClient) {
+    this.http = http
+  }
+
+  /**
+   * Create a new schedule. Returns `{ error: { code: 'already_exists' } }`
+   * if a schedule with this name is already configured — use `update()`
+   * to change an existing schedule, or `createOrUpdate()` for idempotent
+   * provisioning.
+   */
+  async create(
+    name: string,
+    spec: ScheduleSpec,
+  ): Promise<{ data: ScheduleRow | null; error: ScheduleError | null }> {
+    const result = await this.http.post('/v1/schedules', toServerCreate(name, spec))
+    if (result?.error) {
+      return { data: null, error: classifyError(result) }
+    }
+    return { data: fromServer(result as ServerScheduleRow), error: null }
+  }
+
+  /** Update an existing schedule by name. */
+  async update(
+    name: string,
+    spec: Partial<ScheduleSpec>,
+  ): Promise<{ data: ScheduleRow | null; error: ScheduleError | null }> {
+    const result = await this.http.patch(
+      `/v1/schedules/${encodeURIComponent(name)}`,
+      toServerUpdate(spec),
+    )
+    if (result?.error) {
+      return { data: null, error: classifyError(result) }
+    }
+    return { data: fromServer(result as ServerScheduleRow), error: null }
+  }
+
+  /** Get a schedule by name. */
+  async get(
+    name: string,
+  ): Promise<{ data: ScheduleRow | null; error: ScheduleError | null }> {
+    const result = await this.http.get(`/v1/schedules/${encodeURIComponent(name)}`)
+    if (result?.error) {
+      return { data: null, error: classifyError(result) }
+    }
+    return { data: fromServer(result as ServerScheduleRow), error: null }
+  }
+
+  /** List all schedules for the project. */
+  async list(): Promise<{ data: ScheduleRow[]; error: ScheduleError | null }> {
+    const result = await this.http.get('/v1/schedules')
+    if (result?.error) {
+      return { data: [], error: classifyError(result) }
+    }
+    return { data: (result as ServerScheduleRow[]).map(fromServer), error: null }
+  }
+
+  /** Delete a schedule by name. */
+  async delete(name: string): Promise<{ error: ScheduleError | null }> {
+    const result = await this.http.del(`/v1/schedules/${encodeURIComponent(name)}`)
+    if (result?.error) {
+      return { error: classifyError(result) }
+    }
+    return { error: null }
+  }
+
+  /**
+   * Idempotent: create the schedule if missing, update it if present.
+   * Useful for provisioning scripts that want a single declaration.
+   */
+  async createOrUpdate(
+    name: string,
+    spec: ScheduleSpec,
+  ): Promise<{ data: ScheduleRow | null; error: ScheduleError | null }> {
+    const created = await this.create(name, spec)
+    if (!created.error) return created
+    if (created.error.code === 'already_exists') {
+      return this.update(name, spec)
+    }
+    return created
+  }
+}

--- a/sdk/js/test/schedules.mjs
+++ b/sdk/js/test/schedules.mjs
@@ -1,0 +1,196 @@
+// Closes #112. Asserts the SDK builds the right URL + payload shape for
+// eb.functions.schedules.{create,update,get,delete,list,createOrUpdate}.
+// Uses a stubbed global fetch so the test runs without a real gateway.
+//
+// Run via: npm run build && node test/schedules.mjs
+
+import { createClient } from '../dist/index.js'
+import assert from 'node:assert/strict'
+
+const API_KEY = 'eb_sk_secret_test'
+const URL_BASE = 'https://newtek2.eurobase.app'
+
+let captured = null
+let nextResponse = null
+
+function reset(response) {
+  captured = null
+  nextResponse = response
+}
+
+// Stub global fetch. The SDK uses native fetch in http.ts.
+globalThis.fetch = async (url, init) => {
+  let bodyJson
+  if (init && typeof init.body === 'string') {
+    try { bodyJson = JSON.parse(init.body) } catch { bodyJson = init.body }
+  }
+  captured = {
+    url,
+    method: init?.method ?? 'GET',
+    headers: init?.headers ?? {},
+    body: bodyJson,
+  }
+  const { status = 200, body = {}, headers = { 'content-type': 'application/json' } } = nextResponse ?? {}
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `HTTP ${status}`,
+    headers: {
+      get: (k) => headers[k.toLowerCase()] ?? null,
+    },
+    async json() { return body },
+  }
+}
+
+const eb = createClient({ url: URL_BASE, apiKey: API_KEY })
+
+const sampleServerRow = {
+  id: 'sched-1',
+  project_id: 'proj-1',
+  name: 'purge-expired-images',
+  schedule: '0 4 * * *',
+  timezone: 'UTC',
+  action_type: 'function',
+  action: 'purge-expired-images',
+  description: 'daily purge',
+  payload: { mode: 'soft' },
+  headers: { 'X-Internal': '1' },
+  enabled: true,
+  last_run_at: null,
+  last_error: null,
+  run_count: 0,
+  created_at: '2026-05-08T00:00:00Z',
+  updated_at: '2026-05-08T00:00:00Z',
+}
+
+// ── 1. create() — POST /v1/schedules with the right body shape ─────
+{
+  reset({ status: 201, body: sampleServerRow })
+  const res = await eb.functions.schedules.create('purge-expired-images', {
+    functionName: 'purge-expired-images',
+    cron: '0 4 * * *',
+    timezone: 'UTC',
+    description: 'daily purge',
+    payload: { mode: 'soft' },
+    headers: { 'X-Internal': '1' },
+  })
+  assert.equal(captured.method, 'POST')
+  assert.equal(captured.url, `${URL_BASE}/v1/schedules`)
+  assert.deepEqual(captured.body, {
+    name: 'purge-expired-images',
+    schedule: '0 4 * * *',
+    timezone: 'UTC',
+    action_type: 'function',
+    action: 'purge-expired-images',
+    description: 'daily purge',
+    payload: { mode: 'soft' },
+    headers: { 'X-Internal': '1' },
+  })
+  assert.equal(res.error, null)
+  assert.equal(res.data.functionName, 'purge-expired-images')
+  assert.equal(res.data.cron, '0 4 * * *')
+  assert.equal(res.data.projectId, 'proj-1')
+  console.log('✓ create: posts to /v1/schedules with action_type=function')
+}
+
+// ── 2. create() collision surfaces code=already_exists ────────────
+{
+  reset({ status: 409, body: { error: 'schedule with this name already exists' } })
+  const res = await eb.functions.schedules.create('purge-expired-images', {
+    functionName: 'purge-expired-images',
+    cron: '0 4 * * *',
+  })
+  assert.equal(res.data, null)
+  assert.equal(res.error.code, 'already_exists')
+  console.log('✓ create: 409 → error.code=already_exists')
+}
+
+// ── 3. update() — PATCH /v1/schedules/:name with partial body ─────
+{
+  reset({ status: 200, body: { ...sampleServerRow, enabled: false } })
+  const res = await eb.functions.schedules.update('purge-expired-images', {
+    enabled: false,
+    cron: '0 5 * * *',
+  })
+  assert.equal(captured.method, 'PATCH')
+  assert.equal(captured.url, `${URL_BASE}/v1/schedules/purge-expired-images`)
+  assert.deepEqual(captured.body, { schedule: '0 5 * * *', enabled: false })
+  assert.equal(res.error, null)
+  assert.equal(res.data.enabled, false)
+  console.log('✓ update: maps cron→schedule, sends only changed fields')
+}
+
+// ── 4. get() — GET /v1/schedules/:name ────────────────────────────
+{
+  reset({ status: 200, body: sampleServerRow })
+  const res = await eb.functions.schedules.get('purge-expired-images')
+  assert.equal(captured.method, 'GET')
+  assert.equal(captured.url, `${URL_BASE}/v1/schedules/purge-expired-images`)
+  assert.equal(res.data.name, 'purge-expired-images')
+  console.log('✓ get: GET /v1/schedules/:name')
+}
+
+// ── 5. list() — GET /v1/schedules, returns array ──────────────────
+{
+  reset({ status: 200, body: [sampleServerRow] })
+  const res = await eb.functions.schedules.list()
+  assert.equal(captured.method, 'GET')
+  assert.equal(captured.url, `${URL_BASE}/v1/schedules`)
+  assert.equal(res.error, null)
+  assert.equal(res.data.length, 1)
+  assert.equal(res.data[0].functionName, 'purge-expired-images')
+  console.log('✓ list: GET /v1/schedules → ScheduleRow[]')
+}
+
+// ── 6. delete() — DELETE /v1/schedules/:name ──────────────────────
+{
+  reset({ status: 204, body: {}, headers: {} })
+  const res = await eb.functions.schedules.delete('purge-expired-images')
+  assert.equal(captured.method, 'DELETE')
+  assert.equal(captured.url, `${URL_BASE}/v1/schedules/purge-expired-images`)
+  assert.equal(res.error, null)
+  console.log('✓ delete: DELETE /v1/schedules/:name')
+}
+
+// ── 7. URL encoding: schedule name with special chars is encoded ──
+{
+  reset({ status: 200, body: sampleServerRow })
+  await eb.functions.schedules.get('weird name/with/slashes')
+  assert.equal(
+    captured.url,
+    `${URL_BASE}/v1/schedules/${encodeURIComponent('weird name/with/slashes')}`,
+  )
+  console.log('✓ get: schedule name is URL-encoded')
+}
+
+// ── 8. createOrUpdate(): create succeeds first time, updates on conflict ──
+{
+  // First call: 409 → triggers update.
+  let calls = 0
+  globalThis.fetch = async (url, init) => {
+    calls++
+    captured = { url, method: init?.method ?? 'GET', body: init?.body && JSON.parse(init.body) }
+    if (calls === 1) {
+      return {
+        ok: false, status: 409, statusText: 'HTTP 409',
+        headers: { get: (k) => k.toLowerCase() === 'content-type' ? 'application/json' : null },
+        async json() { return { error: 'schedule with this name already exists' } },
+      }
+    }
+    return {
+      ok: true, status: 200, statusText: 'HTTP 200',
+      headers: { get: (k) => k.toLowerCase() === 'content-type' ? 'application/json' : null },
+      async json() { return sampleServerRow },
+    }
+  }
+  const res = await eb.functions.schedules.createOrUpdate('purge-expired-images', {
+    functionName: 'purge-expired-images',
+    cron: '0 4 * * *',
+  })
+  assert.equal(calls, 2, 'expected two calls: create then update')
+  assert.equal(captured.method, 'PATCH')
+  assert.equal(res.error, null)
+  console.log('✓ createOrUpdate: 409 on create falls through to update')
+}
+
+console.log('\nAll schedules SDK tests passed.')


### PR DESCRIPTION
## Summary

Closes #112. Adds `eb.functions.schedules.{create,update,get,list,delete,createOrUpdate}` so deployed edge functions can declare their own cron schedule in code instead of via the dashboard.

- Service-key (`eb_sk_*`) only — schedules are control-plane state.
- Mounted at `/v1/schedules` behind a new `requireSecretKeyForSchedules` gate.
- Worker's cron executor now invokes edge functions over the same HMAC-signed runner path the SDK uses; `shouldRun` evaluates cron in the schedule's timezone.

## Locked-in semantics (per #112 open questions)

- **Idempotency**: `create()` returns **409 / `already_exists`** on name collision (not upsert). `createOrUpdate()` is a separate helper for provisioning scripts.
- **Missed ticks**: dropped during downtime, no backfill.
- **Concurrency**: independent ticks; no overlap protection in v1.
- **Cron grammar**: POSIX 5-field only; no `@daily` / `@hourly` aliases.

## What's in the diff

**Server**
- `migrations/000053`: `function` action_type, `(project_id, name)` unique index, `timezone`/`payload`/`headers`/`description` columns.
- `internal/cron/service.go`: `GetByName`/`UpdateByName`/`DeleteByName`, `ErrNotFound` + `ErrNameAlreadyExists` sentinels.
- `internal/cron/executor.go`: new `function` action_type dispatch.
- `internal/cron/handler.go`: `SDKRoutes` using API-key project context.
- `internal/gateway/router.go`: mounts at `/v1/schedules`.
- `cmd/worker/main.go`: wires `FUNCTION_RUNNER_URL` + `FUNCTIONS_RUNNER_HMAC_SECRET` into the executor.

**SDK** (`@eurobase/sdk@0.3.0`)
- `src/schedules.ts` — `SchedulesClient` with discriminated `ScheduleError` codes.
- `src/functions.ts` — `eb.functions.schedules` sub-client.
- `test/schedules.mjs` — 8 tests over URL/payload shape, 409 → `already_exists`, name URL-encoding, `createOrUpdate` fall-through.

Migration renumbered to **000053** to avoid colliding with #111's open `000052_auth_email_live_lookup`.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`npm run build && node test/schedules.mjs\` clean
- [ ] After merge: deploy succeeds, migration 000053 applies
- [ ] Smoke test from a tenant project: \`eb.functions.schedules.create('purge', { functionName: 'purge', cron: '0 4 * * *' })\` returns the row; a second call returns \`error.code === 'already_exists'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)