### PR TITLE
#70: observability for plan persistence + regression test + side-bug fix

### DIFF
--- a/console/src/routes/(app)/projects/+page.svelte
+++ b/console/src/routes/(app)/projects/+page.svelte
@@ -52,7 +52,7 @@
 			await api.createProject({
 				name: newName.trim(),
 				slug: newSlug,
-				region: 'eu-west-paris',
+				region: 'fr-par',
 				plan: newPlan
 			});
 			showNewModal = false;

--- a/internal/tenant/handler.go
+++ b/internal/tenant/handler.go
@@ -148,6 +148,18 @@ func HandleCreateProject(pool *pgxpool.Pool, svc *TenantService, limitsSvc ...*p
 			return
 		}
 
+		// #70 diagnostic: log the decoded plan/region so a repro of
+		// "Pro selected → plan=free in DB" can be pinned to either the
+		// HTTP body, the JSON decode, or somewhere downstream. Drop once
+		// the bug is closed.
+		slog.Info("create project: decoded body",
+			"name", req.Name,
+			"slug", req.Slug,
+			"region", req.Region,
+			"plan", req.Plan,
+			"owner_id", claims.Subject,
+		)
+
 		// Validate name.
 		if strings.TrimSpace(req.Name) == "" {
 			http.Error(w, `{"error":"name is required"}`, http.StatusBadRequest)
@@ -180,6 +192,9 @@ func HandleCreateProject(pool *pgxpool.Pool, svc *TenantService, limitsSvc ...*p
 			req.Plan = "free"
 		}
 
+		// #70 diagnostic: log right before the INSERT so we can see if
+		// anything between decode and CreateProject mutated req.Plan.
+		slog.Info("create project: handing to service", "plan", req.Plan, "name", req.Name)
 		project, err := svc.CreateProject(r.Context(), claims.Subject, claims.Email, req)
 		if err != nil {
 			slog.Error("failed to create project", "error", err, "user_id", claims.Subject)

--- a/internal/tenant/service_test.go
+++ b/internal/tenant/service_test.go
@@ -95,6 +95,42 @@ func insertTestPlatformUser(t *testing.T, pool *pgxpool.Pool, email string) stri
 	return id
 }
 
+// TestCreateProject_PlanPersisted is the regression test for #70.
+// Asserts that a Pro plan in the request body survives the INSERT and is
+// readable back from the DB row — not just echoed from the in-memory req.
+func TestCreateProject_PlanPersisted(t *testing.T) {
+	pool := setupTestDB(t)
+	ctx := context.Background()
+	svc := &TenantService{pool: pool}
+
+	for _, plan := range []string{"free", "pro"} {
+		t.Run(plan, func(t *testing.T) {
+			uid := insertTestPlatformUser(t, pool, "plan-"+plan+"@test.eurobase.local")
+			project, err := svc.CreateProject(ctx, uid, "plan-"+plan+"@test.eurobase.local", CreateProjectRequest{
+				Name:   "Plan " + plan,
+				Slug:   "plan-test-" + plan,
+				Region: "fr-par",
+				Plan:   plan,
+			})
+			if err != nil {
+				t.Fatalf("CreateProject(plan=%q): %v", plan, err)
+			}
+			t.Cleanup(func() { cleanupProject(t, pool, project.ID) })
+
+			// Read back from the DB — don't trust the returned struct
+			// since it echoes req.Plan rather than re-SELECTing.
+			var dbPlan string
+			if err := pool.QueryRow(ctx,
+				`SELECT plan FROM projects WHERE id = $1`, project.ID).Scan(&dbPlan); err != nil {
+				t.Fatalf("read back plan: %v", err)
+			}
+			if dbPlan != plan {
+				t.Errorf("DB row has plan=%q, want %q (issue #70)", dbPlan, plan)
+			}
+		})
+	}
+}
+
 func TestCreateProject(t *testing.T) {
 	pool := setupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
Triage for #70 — \"Selecting Pro at project creation persists plan as free.\"

## What I traced

Every path that touches `projects.plan`:

- Handler defaults only when `req.Plan == \"\"` — frontend always sends.
- Service `INSERT INTO projects (..., plan) VALUES (..., \$7)` with `req.Plan` directly.
- `provision_tenant(p_plan)` declares the parameter but never uses it.
- No CHECK, no trigger, no subsequent `UPDATE plan` anywhere in the codebase.
- `CheckProjectLimit` is pure read; doesn't downgrade.
- No Mollie/subscription code (deferred per CLAUDE.md).

Net: the reported bug is **not reproducible from the code**. Rather than guess a fix, this PR adds the instrumentation needed to pin the next repro.

## What lands

1. **Two diagnostic `slog.Info` calls** in `HandleCreateProject`: one right after JSON decode, one right before the service call. The next time someone selects Pro and the row ends up free, the logs show whether `req.Plan` was `\"pro\"` or `\"free\"` at each point — pinning the bug to the HTTP body, the JSON decode, or somewhere downstream. Annotated with `#70 diagnostic` so they're easy to remove once closed.

2. **`TestCreateProject_PlanPersisted`** — table-driven regression test over `free` / `pro` that reads the plan back **from the DB row** (not the returned struct, which echoes `req.Plan` and would have hidden the bug). Integration-test style, skips in `-short` mode.

3. **Side-bug fix** the issue noted in passing: `console/src/routes/(app)/projects/+page.svelte` sent `region: 'eu-west-paris'` which the backend rejects (only `fr-par` is accepted). Modal now matches the onboarding flow.

## Test plan

- [ ] Merge + deploy
- [ ] Reproduce: create a project, select Pro
- [ ] `kubectl logs deployment/gateway -n eurobase | grep \"create project\"` — note the `plan=` values in both log lines
- [ ] If both say `pro`: bug is downstream of the service call (something in `provision_tenant` or a constraint I missed). File follow-up.
- [ ] If first says `pro`, second says `free`: bug is in some middleware between decode and service. Unlikely but possible.
- [ ] If first says `free` (request body claims pro but server saw free): bug is in browser→server transit. Check service worker, CORS, content-type encoding.
- [ ] Workaround for affected projects: `UPDATE projects SET plan='pro' WHERE id=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)