### PR TITLE
Security: mitigate CVE-2026-43284 (Dirty Frag) on Kapsule nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,12 +283,15 @@ jobs:
       - name: Apply K8s manifests (security, ingress, functions, MCP server)
         if: steps.fresh.outputs.stale != 'true'
         run: |
-          # CVE-2026-31431 (Copy Fail) and CVE-2026-46333 (ssh-keysign-pwn)
-          # mitigations must land before any pod restart so newly scheduled
-          # pods can't briefly run on a node with algif_aead loaded or
-          # unprivileged ptrace enabled.
+          # CVE-2026-31431 (Copy Fail), CVE-2026-46333 (ssh-keysign-pwn),
+          # and CVE-2026-43284 (Dirty Frag) mitigations must land before any
+          # pod restart so newly scheduled pods can't briefly run on a node
+          # with algif_aead loaded, unprivileged ptrace enabled, or
+          # esp4 / esp6 / rxrpc loaded. All three DaemonSets also self-apply
+          # to autoscaler-brought-up nodes between rotations.
           kubectl apply -f deploy/k8s/security/disable-algif-aead.yaml
           kubectl apply -f deploy/k8s/security/disable-ptrace.yaml
+          kubectl apply -f deploy/k8s/security/disable-dirty-frag.yaml
           # In-cluster Redis replaces managed RED1-micro to cut the
           # beta-stage bill (~€59/mo). Apply before the gateway/worker
           # rollout so REDIS_URL=redis://redis.eurobase.svc.cluster.local

--- a/deploy/k8s/security/disable-dirty-frag.yaml
+++ b/deploy/k8s/security/disable-dirty-frag.yaml
@@ -1,0 +1,75 @@
+##############################################################################
+# CVE-2026-43284 ("Dirty Frag") mitigation.
+#
+# Linux kernel LPE via the ESP (esp4/esp6) IPsec transform modules and the
+# AF_RXRPC socket family (rxrpc). A local unprivileged user can escalate to
+# root or escape a container — same threat shape as CVE-2026-31431 (Copy
+# Fail). Disclosed by Scaleway 2026-05-12 alongside patched Debian/AlmaLinux/
+# Ubuntu node images.
+#
+# Eurobase runs untrusted tenant JS in the functions-runner pods on shared
+# Kapsule nodes, so the LPE → container escape path is in scope until every
+# node is on a patched kernel. This DaemonSet is the in-cluster block that
+# keeps us safe between disclosure and the node-pool roll; it also self-
+# applies to any node the autoscaler brings up between rotations.
+#
+# Risk: none of esp4 / esp6 / rxrpc are on the hot path for the Go stack,
+# pgx, gorilla/websocket, Deno, or V8 crypto. esp4/esp6 are IPsec transforms
+# (we terminate TLS at the LB, not IPsec); rxrpc is AF_RXRPC (AFS), unused.
+#
+# Rollback: kubectl delete -f this file, then `modprobe esp4 esp6 rxrpc` on
+# each node.
+##############################################################################
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disable-dirty-frag
+  namespace: kube-system
+  labels:
+    app: disable-dirty-frag
+spec:
+  selector:
+    matchLabels:
+      app: disable-dirty-frag
+  template:
+    metadata:
+      labels:
+        app: disable-dirty-frag
+    spec:
+      hostPID: true
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      initContainers:
+        - name: disable-dirty-frag
+          image: alpine:3.23
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {
+                echo "install esp4 /bin/false"
+                echo "install esp6 /bin/false"
+                echo "install rxrpc /bin/false"
+              } > /etc/modprobe.d/disable-dirty-frag.conf
+              rmmod esp4 2>/dev/null || true
+              rmmod esp6 2>/dev/null || true
+              rmmod rxrpc 2>/dev/null || true
+          volumeMounts:
+            - name: modprobe-d
+              mountPath: /etc/modprobe.d
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            limits:
+              cpu: 1m
+              memory: 8Mi
+      volumes:
+        - name: modprobe-d
+          hostPath:
+            path: /etc/modprobe.d

--- a/deploy/k8s/security/disable-dirty-frag.yaml
+++ b/deploy/k8s/security/disable-dirty-frag.yaml
@@ -44,18 +44,33 @@ spec:
           effect: NoExecute
       initContainers:
         - name: disable-dirty-frag
-          image: alpine:3.23
+          # Pinned to digest: this init container runs privileged with
+          # host filesystem access, so it's a high-value supply chain
+          # target. Bump by re-resolving `docker manifest inspect
+          # alpine:3.23` if the tag is rolled forward.
+          image: alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
           securityContext:
             privileged: true
           command:
             - /bin/sh
             - -c
             - |
+              # Block both the base modules and their *_offload variants.
+              # The offload modules depend on esp4/esp6, so leaving them
+              # loaded (a) keeps `rmmod esp4` failing with EBUSY, and
+              # (b) lets a userspace `modprobe esp4_offload` auto-load
+              # esp4 back in even after this init runs.
               {
                 echo "install esp4 /bin/false"
                 echo "install esp6 /bin/false"
+                echo "install esp4_offload /bin/false"
+                echo "install esp6_offload /bin/false"
                 echo "install rxrpc /bin/false"
               } > /etc/modprobe.d/disable-dirty-frag.conf
+              # Order matters: unload offload (dependent) before the
+              # base esp{4,6} modules, or rmmod returns EBUSY.
+              rmmod esp4_offload 2>/dev/null || true
+              rmmod esp6_offload 2>/dev/null || true
               rmmod esp4 2>/dev/null || true
               rmmod esp6 2>/dev/null || true
               rmmod rxrpc 2>/dev/null || true


### PR DESCRIPTION
Scaleway advisory 2026-05-12: Linux kernel LPE via the ESP IPsec transform modules (`esp4`/`esp6`) and the AF_RXRPC socket family (`rxrpc`). Same threat shape as CVE-2026-31431 (Copy Fail) — local unprivileged user can escalate to root or escape a container. The functions-runner pods execute untrusted tenant JS on shared Kapsule nodes, so the LPE → escape path is in scope.

## What lands

- **`deploy/k8s/security/disable-dirty-frag.yaml`** — DaemonSet mirror of the existing `disable-algif-aead.yaml`. Writes `install esp4 / esp6 / rxrpc /bin/false` into `/etc/modprobe.d/` on every node and `rmmod`s any already-loaded modules. Tolerates all taints so the autoscaler-brought-up nodes are also hardened on first boot.
- **`.github/workflows/ci.yml`** — one extra `kubectl apply -f` line in the security apply block (before any pod restart, same rationale as Copy Fail).

## Risk check

None of `esp4`, `esp6`, `rxrpc` are on the gateway / worker / functions-runner hot path:
- `esp4` / `esp6` are IPsec ESP transforms — we terminate TLS at the LB, not IPsec.
- `rxrpc` is the AF_RXRPC socket family (Linux AFS). No code in this tree opens AF_RXRPC sockets; pgx, gorilla/websocket, Deno, V8 crypto don't touch it.

Rollback: \`kubectl delete -f deploy/k8s/security/disable-dirty-frag.yaml\`, then \`modprobe esp4 esp6 rxrpc\` on each node.

## Operator follow-up (not in this PR)

The proper fix is a patched kernel. Roll the Kapsule node pool through the Scaleway console once the patched image is selected:

\`\`\`
scw k8s pool upgrade <pool-id>
\`\`\`

Rolling drain — \`kubectl rollout status\` gates in CI cover availability. After the roll, both DaemonSets self-apply to the fresh nodes; verify with \`kubectl get ds -n kube-system disable-algif-aead disable-dirty-frag\`.

This same Kapsule node-pool roll also closes the parallel **CrackArmor** AppArmor advisory (kernel patches only).

## Test plan

- [ ] Merge + deploy
- [ ] \`kubectl get ds -n kube-system disable-dirty-frag\` shows DESIRED == CURRENT == READY across all nodes
- [ ] On any node: \`lsmod | grep -E 'esp4|esp6|rxrpc'\` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)