### PR TITLE
Migration History: stop stamping backfill rows with now()

### DIFF
--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -1476,7 +1476,9 @@ export interface SchemaChange {
 	column_name: string | null;
 	detail: any;
 	sql_text: string | null;
-	created_at: string;
+	/** Null for backfill rows: tables discovered via information_schema
+	 *  that we have no actual creation timestamp for. */
+	created_at: string | null;
 }
 
 export interface RLSAuditEntry {

--- a/console/src/routes/(app)/p/[id]/database/history/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/database/history/+page.svelte
@@ -17,14 +17,23 @@
 		loading = false;
 	});
 
-	function actionLabel(action: string): string {
-		switch (action) {
+	function actionLabel(change: SchemaChange): string {
+		// Backfill rows are synthetic — we discovered the table existed
+		// via information_schema, we didn't observe its creation. Label
+		// them differently so the timeline doesn't claim they were
+		// created at the moment we found them.
+		if (isBackfill(change)) return 'Detected table';
+		switch (change.action) {
 			case 'create_table': return 'Created table';
 			case 'drop_table': return 'Dropped table';
 			case 'add_column': return 'Added column';
 			case 'drop_column': return 'Dropped column';
-			default: return action;
+			default: return change.action;
 		}
+	}
+
+	function isBackfill(change: SchemaChange): boolean {
+		return change.detail?.source === 'backfill' || change.created_at === null;
 	}
 
 	function actionColor(action: string): string {
@@ -103,15 +112,19 @@
 									{actionIcon(change.action)}
 								</span>
 								<span class="text-sm font-medium text-gray-900">
-									{actionLabel(change.action)}
+									{actionLabel(change)}
 								</span>
 								<code class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-700">{change.table_name}</code>
 								{#if change.column_name && change.action.includes('column')}
 									<span class="text-xs text-gray-400">.</span>
 									<code class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-700">{change.column_name}</code>
 								{/if}
-								<span class="ml-auto text-[11px] text-gray-400">
-									{new Date(change.created_at).toLocaleString('en-GB', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+								<span class="ml-auto text-[11px] text-gray-400" title={isBackfill(change) ? 'Discovered via information_schema — table existed before tracking began' : ''}>
+									{#if change.created_at}
+										{new Date(change.created_at).toLocaleString('en-GB', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+									{:else}
+										existed before tracking
+									{/if}
 								</span>
 							</div>
 							{#if formatDetail(change)}

--- a/internal/query/ddl_handler.go
+++ b/internal/query/ddl_handler.go
@@ -43,16 +43,19 @@ type AddColumnRequest struct {
 	DefaultValue string `json:"default_value,omitempty"`
 }
 
-// SchemaChange represents a logged DDL operation.
+// SchemaChange represents a logged DDL operation. CreatedAt is nullable
+// because backfill rows (synthetic "we discovered this table existed"
+// entries) have no real creation timestamp; the column carries NULL for
+// those and the console UI renders them as "Detected".
 type SchemaChange struct {
-	ID         string    `json:"id"`
-	ProjectID  string    `json:"project_id"`
-	Action     string    `json:"action"`
-	TableName  string    `json:"table_name"`
-	ColumnName *string   `json:"column_name"`
-	Detail     any       `json:"detail"`
-	SQLText    *string   `json:"sql_text"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         string     `json:"id"`
+	ProjectID  string     `json:"project_id"`
+	Action     string     `json:"action"`
+	TableName  string     `json:"table_name"`
+	ColumnName *string    `json:"column_name"`
+	Detail     any        `json:"detail"`
+	SQLText    *string    `json:"sql_text"`
+	CreatedAt  *time.Time `json:"created_at"`
 }
 
 // RenameTableRequest is the JSON body for PATCH /schema/tables/{table}.
@@ -230,10 +233,16 @@ func backfillUnloggedTables(ctx context.Context, pool *pgxpool.Pool, projectID, 
 		if platformTables[tableName] {
 			continue
 		}
-		// Insert a backfilled create_table entry.
+		// Insert a backfilled entry with NULL created_at — these rows
+		// represent tables we *discovered* in information_schema, not
+		// tables we observed being created. Defaulting created_at to
+		// now() makes every page load look like a fresh DDL event,
+		// which is the bug. Frontend renders NULL as "Detected
+		// (existed before tracking)" with no specific timestamp; NULL
+		// also sorts to the bottom under `ORDER BY created_at DESC`.
 		_, _ = pool.Exec(ctx,
-			`INSERT INTO schema_changes (project_id, action, table_name, detail)
-			 VALUES ($1, 'create_table', $2, '{"source":"backfill"}'::jsonb)`,
+			`INSERT INTO schema_changes (project_id, action, table_name, detail, created_at)
+			 VALUES ($1, 'create_table', $2, '{"source":"backfill"}'::jsonb, NULL)`,
 			projectID, tableName)
 		slog.Info("backfilled schema change", "project_id", projectID, "table", tableName)
 	}

--- a/migrations/000054_schema_changes_null_backfill_timestamps.down.sql
+++ b/migrations/000054_schema_changes_null_backfill_timestamps.down.sql
@@ -1,0 +1,10 @@
+-- Restore a timestamp on backfill rows. We can't recover the original
+-- (since there never was one — the rows were synthesised), but using
+-- `to_timestamp(0)` (1970-01-01) at least keeps the column non-NULL if
+-- something downstream relied on that, while making the "this is fake"
+-- nature obvious.
+
+UPDATE public.schema_changes
+SET created_at = to_timestamp(0)
+WHERE detail->>'source' = 'backfill'
+  AND created_at IS NULL;

--- a/migrations/000054_schema_changes_null_backfill_timestamps.up.sql
+++ b/migrations/000054_schema_changes_null_backfill_timestamps.up.sql
@@ -1,0 +1,21 @@
+-- Migration History was showing "Created table X" with TODAY's timestamp
+-- for any pre-existing table that landed via SQL runner / MCP / direct DDL
+-- (anything outside the platform's logged DDL handlers). Reason:
+-- `backfillUnloggedTables` (internal/query/ddl_handler.go) runs on every
+-- page load, inserts a stub `create_table` row for any table in
+-- information_schema with no matching log entry, and lets `created_at`
+-- default to `now()` — turning every page open into a false ledger entry.
+--
+-- The accompanying code change inserts NULL for `created_at` on
+-- backfill rows going forward. This migration cleans up the bogus
+-- "today at X:XX" stamps already in the table so existing rows render
+-- as "Detected (existed before tracking)" instead of pretending to
+-- have been created moments ago.
+--
+-- Identifies backfill rows via the existing detail marker
+-- (`{"source":"backfill"}`) — that flag has been written since the
+-- backfill was introduced, so this is precise and reversible.
+
+UPDATE public.schema_changes
+SET created_at = NULL
+WHERE detail->>'source' = 'backfill';


### PR DESCRIPTION
## Bug

Opening **Database → Migration History** after any out-of-band DDL (SQL runner, MCP \`runSQL\`, etc.) makes pre-existing tables appear as freshly \"Created today\". Reported via LiveStylist: a single \`ALTER TABLE app_users ADD COLUMN stable_device_id\` produced four phantom \"Created table\" rows (\`blocks\`, \`vault_secrets\`, \`session_images\`, \`follows\`) stamped at the exact minute the page was opened.

## Root cause

\`backfillUnloggedTables\` (\`internal/query/ddl_handler.go:207\`) runs on every page load. For each table in \`information_schema\` with no matching log entry, it inserts a synthetic \`create_table\` row — but omits \`created_at\`, so the column defaults to \`now()\`. Every page open fabricates audit-trail entries with the visit timestamp.

The \`detail\` JSON already carries \`{\"source\":\"backfill\"}\`, but the UI ignores it and just renders \`created_at\`.

## Fix

- **Backend** — backfill INSERT now explicitly sets \`created_at = NULL\`. \`SchemaChange.CreatedAt\` is \`*time.Time\` so NULL round-trips. Pre-existing tables sort to the bottom under \`ORDER BY created_at DESC\` (Postgres NULLS LAST default for DESC).
- **Frontend** — \`history/+page.svelte\` renders rows where \`detail.source === 'backfill'\` (or \`created_at === null\`) as **\"Detected table … existed before tracking\"** with a tooltip explaining the discovery-vs-event distinction.
- **Migration 000054** — NULLs out \`created_at\` on backfill rows already in the DB so deployed projects render correctly immediately, not just for fresh discoveries.

## Out of scope

DDL that lands via SQL runner / MCP \`runSQL\` (like the actual \`ALTER TABLE app_users\` that triggered this report) still bypasses the \`schema_changes\` hook entirely — the backfill only stub-detects tables, never columns or alters. That's a separate gap worth filing if it bites.

## Test plan

- [x] \`go build ./... && go test ./internal/query/...\` clean
- [x] \`npm run build\` (console) clean
- [ ] Merge + deploy
- [ ] Open LiveStylist → Database → Migration History → the four 13 May 21:26 entries now read \"Detected table … existed before tracking\" (no timestamp)
- [ ] Create a real table via the console → still shows \"Created table\" with the correct timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)