### PR TITLE
Migration History: cleanup buggy backfill timestamps + NULL-aware code

### DIFF
--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -1476,7 +1476,10 @@ export interface SchemaChange {
 	column_name: string | null;
 	detail: any;
 	sql_text: string | null;
-	created_at: string;
+	/** Null for legacy backfill rows whose synthesised timestamps were
+	 *  swept by migration 000054 (#120 follow-up). Renders as
+	 *  "existed before tracking". */
+	created_at: string | null;
 }
 
 export interface RLSAuditEntry {

--- a/console/src/routes/(app)/p/[id]/database/history/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/database/history/+page.svelte
@@ -17,13 +17,30 @@
 		loading = false;
 	});
 
-	function actionLabel(action: string): string {
-		switch (action) {
+	function isBackfill(change: SchemaChange): boolean {
+		return change.detail?.source === 'backfill' || change.created_at === null;
+	}
+
+	function actionLabel(change: SchemaChange): string {
+		// Backfill rows are synthetic discoveries (table already existed
+		// when tracking began), not real DDL events. Migration 000054
+		// stripped their bogus timestamps; we surface them as detections
+		// rather than fake creates.
+		if (isBackfill(change)) return 'Detected table';
+		switch (change.action) {
 			case 'create_table': return 'Created table';
 			case 'drop_table': return 'Dropped table';
 			case 'add_column': return 'Added column';
 			case 'drop_column': return 'Dropped column';
-			default: return action;
+			case 'alter_column': return 'Altered column';
+			case 'rename_table': return 'Renamed table';
+			case 'create_index': return 'Created index';
+			case 'drop_index': return 'Dropped index';
+			case 'add_foreign_key': return 'Added foreign key';
+			case 'drop_foreign_key': return 'Dropped foreign key';
+			case 'add_unique_constraint': return 'Added unique constraint';
+			case 'drop_unique_constraint': return 'Dropped unique constraint';
+			default: return change.action;
 		}
 	}
 
@@ -103,15 +120,19 @@
 									{actionIcon(change.action)}
 								</span>
 								<span class="text-sm font-medium text-gray-900">
-									{actionLabel(change.action)}
+									{actionLabel(change)}
 								</span>
 								<code class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-700">{change.table_name}</code>
 								{#if change.column_name && change.action.includes('column')}
 									<span class="text-xs text-gray-400">.</span>
 									<code class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-700">{change.column_name}</code>
 								{/if}
-								<span class="ml-auto text-[11px] text-gray-400">
-									{new Date(change.created_at).toLocaleString('en-GB', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+								<span class="ml-auto text-[11px] text-gray-400" title={isBackfill(change) ? 'Discovered via information_schema — table existed before tracking began' : ''}>
+									{#if change.created_at}
+										{new Date(change.created_at).toLocaleString('en-GB', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' })}
+									{:else}
+										existed before tracking
+									{/if}
 								</span>
 							</div>
 							{#if formatDetail(change)}

--- a/internal/query/ddl_handler.go
+++ b/internal/query/ddl_handler.go
@@ -43,16 +43,20 @@ type AddColumnRequest struct {
 	DefaultValue string `json:"default_value,omitempty"`
 }
 
-// SchemaChange represents a logged DDL operation.
+// SchemaChange represents a logged DDL operation. CreatedAt is nullable
+// for historical backfill rows: migration 000054 swept the synthesised
+// page-load timestamps from the (now-removed in #123) backfill to NULL,
+// because they were never real DDL events. The console renders NULL as
+// "existed before tracking".
 type SchemaChange struct {
-	ID         string    `json:"id"`
-	ProjectID  string    `json:"project_id"`
-	Action     string    `json:"action"`
-	TableName  string    `json:"table_name"`
-	ColumnName *string   `json:"column_name"`
-	Detail     any       `json:"detail"`
-	SQLText    *string   `json:"sql_text"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         string     `json:"id"`
+	ProjectID  string     `json:"project_id"`
+	Action     string     `json:"action"`
+	TableName  string     `json:"table_name"`
+	ColumnName *string    `json:"column_name"`
+	Detail     any        `json:"detail"`
+	SQLText    *string    `json:"sql_text"`
+	CreatedAt  *time.Time `json:"created_at"`
 }
 
 // RenameTableRequest is the JSON body for PATCH /schema/tables/{table}.

--- a/migrations/000054_null_backfill_timestamps.down.sql
+++ b/migrations/000054_null_backfill_timestamps.down.sql
@@ -1,0 +1,9 @@
+-- We can't recover the original creation times (they never existed —
+-- the rows were synthesised by the buggy backfill). On rollback we
+-- stamp them with the unix epoch so the column is non-NULL again
+-- without claiming a current-day timestamp.
+
+UPDATE public.schema_changes
+SET created_at = to_timestamp(0)
+WHERE detail->>'source' = 'backfill'
+  AND created_at IS NULL;

--- a/migrations/000054_null_backfill_timestamps.up.sql
+++ b/migrations/000054_null_backfill_timestamps.up.sql
@@ -1,0 +1,16 @@
+-- Migration History was stamping every pre-existing tenant table with
+-- the current page-load time via the (since-removed) backfillUnloggedTables
+-- function. Those rows are still in schema_changes with their fake
+-- "freshly created" timestamps. Cleanup pass: any row tagged
+-- detail.source = 'backfill' loses its bogus created_at. The console UI
+-- already renders NULL created_at as "existed before tracking", and
+-- under ORDER BY created_at DESC NULL sorts to the bottom (Postgres
+-- default NULLS LAST), so the timeline ends up correct.
+--
+-- Idempotent: re-running NULLs already-NULL rows (no-op) and matches
+-- any new backfill rows that snuck in between deploys.
+
+UPDATE public.schema_changes
+SET created_at = NULL
+WHERE detail->>'source' = 'backfill'
+  AND created_at IS NOT NULL;


### PR DESCRIPTION
Production is currently 500-ing on Database → Migration History because I ran the cleanup UPDATE (NULLing the bogus backfill timestamps) before this code change was in place. The current gateway scans \`created_at\` into a non-nullable \`time.Time\` and pgx errors. This PR fixes both the data and the code so the page reads cleanly.

## What's in the diff

### Migration 000054 — null bogus backfill timestamps

The (since-removed in #123) \`backfillUnloggedTables\` stamped every discovered tenant table with the *current page-load time*, leaving rows like \"Created table \`session_images\` at 13 May 2026, 21:26\" that never actually happened. 43 such rows across 8 projects.

This migration NULLs \`created_at\` for every row where \`detail->>'source' = 'backfill'\`. Idempotent — re-runs match nothing.

### Code support for NULL \`created_at\`

\`SchemaChange.CreatedAt\` becomes \`*time.Time\` so pgx scan handles the NULLs. Frontend types match (\`string | null\`). History page:

- \`isBackfill(change)\` detects backfill rows (either by \`detail.source\` or by NULL timestamp).
- Backfill rows render as **\"Detected table\"** instead of \"Created table\" — they're synthetic discoveries, not real DDL events.
- NULL timestamps render as **\"existed before tracking\"** with a tooltip explaining the discovery-vs-event distinction.
- Real rows still render their timestamp normally. NULLs sort to the bottom under \`ORDER BY created_at DESC\` (Postgres NULLS LAST default).
- \`actionLabel\` expanded to cover the new action vocabulary the SQL-runner detector from #123 emits (\`alter_column\`, \`rename_table\`, \`create_index\`, \`drop_index\`, FK / unique-constraint variants).

## Recovery sequence

1. **Already done**: manual UPDATE applied to production via MCP \`runSQL\`, NULLing 43 backfill rows. Migration History currently 500s because the gateway doesn't know about NULL yet.
2. **Merging this PR**: deploy ships the gateway code that scans NULL + the migration that idempotently re-applies the cleanup. Page comes back. Existing rows render \"existed before tracking\".

## Test plan

- [x] \`go build ./... && go test ./internal/query/...\` clean
- [x] \`npm run build\` (console) clean
- [ ] Merge + deploy
- [ ] Open Database → Migration History on LiveStylist → page loads, 4 phantom 21:26 rows now read \"Detected table … existed before tracking\" and are sorted to the bottom
- [ ] Open the same page on any other project with backfill rows → same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)