### PR TITLE
Quick wins: CI Node 24 + DSAR audit + UUID check + CSV JSONB (closes #96 #100 #102 #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ on:
 env:
   REGISTRY: rg.fr-par.scw.cloud
   REGISTRY_NS: eurobase-app
+  # Closes #96. actions/checkout@v4, setup-go@v5, setup-node@v4
+  # are pinned on Node 20 which GitHub deprecates on 2026-06-02
+  # (auto-upgraded to Node 24) and removes on 2026-09-16. Opting
+  # in to Node 24 now surfaces any incompatibility on CI runs
+  # before the platform-wide cutover. Bump the action major
+  # versions when each maintainer ships a Node-24-native release;
+  # the env var becomes a no-op then.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # -------------------------------------------------------------------------

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -33,6 +33,13 @@ const (
 	ActionAllowlistAdded     = "allowlist.added"
 	ActionAllowlistRemoved   = "allowlist.removed"
 	ActionAllowlistEmailed   = "allowlist.emailed"
+	// Compliance / DSAR export lifecycle. Closes #100. Tenant +
+	// per-user exports run on the platform admin path; self-serve
+	// is an end-user-initiated export of their own data.
+	ActionExportRequested     = "compliance.export.requested"
+	ActionExportSelfRequested = "compliance.export.self_requested"
+	ActionExportCompleted     = "compliance.export.completed"
+	ActionExportFailed        = "compliance.export.failed"
 )
 
 // Entry represents a single audit log row.

--- a/internal/compliance/export.go
+++ b/internal/compliance/export.go
@@ -99,6 +99,33 @@ func (s *ExportService) CreateExportRequest(ctx context.Context, projectID strin
 	return &req, nil
 }
 
+// UserExistsInTenant reports whether the given user_id exists in the
+// tenant's `users` table. Closes #102: HandleRequestUserExport used
+// to accept any UUID and enqueue a worker even if the user wasn't in
+// the tenant — producing a useless near-empty zip and burning compute.
+//
+// schema_name is resolved from projects in one round-trip; we use a
+// single QueryRow with EXISTS so the call is cheap (~1ms on hot path).
+// quoteIdent guards the schema name even though it comes from a
+// platform-controlled column, on the principle that defence in depth
+// for identifier interpolation is free.
+func (s *ExportService) UserExistsInTenant(ctx context.Context, projectID, userID string) (bool, error) {
+	var schemaName string
+	err := s.Pool.QueryRow(ctx,
+		`SELECT schema_name FROM projects WHERE id = $1`, projectID,
+	).Scan(&schemaName)
+	if err != nil {
+		return false, fmt.Errorf("resolve project schema: %w", err)
+	}
+
+	var exists bool
+	q := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s.users WHERE id = $1)`, quoteIdent(schemaName))
+	if err := s.Pool.QueryRow(ctx, q, userID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check user existence: %w", err)
+	}
+	return exists, nil
+}
+
 // GetExportRequest retrieves an export request by ID, scoped to a project.
 func (s *ExportService) GetExportRequest(ctx context.Context, exportID, projectID string) (*ExportRequest, error) {
 	var req ExportRequest
@@ -592,10 +619,51 @@ func writeCSV(w io.Writer, rows []map[string]interface{}) (int, error) {
 	for _, row := range rows {
 		record := make([]string, len(cols))
 		for i, col := range cols {
-			record[i] = fmt.Sprintf("%v", row[col])
+			record[i] = formatCSVCell(row[col])
 		}
 		_ = cw.Write(record)
 	}
 	cw.Flush()
 	return len(rows), cw.Error()
+}
+
+// formatCSVCell renders one column value for the DSAR CSV export.
+//
+// Closes #103. The previous fmt.Sprintf("%v", …) path mangled jsonb
+// and array columns into Go's map[k:v] / [a b c] string forms, which
+// is neither valid JSON nor parseable back into anything useful. The
+// DSAR recipient needed those columns intact to satisfy GDPR's
+// "machine readable, structured format" obligation.
+//
+// Behaviour by type:
+//   - nil               → empty string (CSV null)
+//   - map / slice / any composite → json.Marshal so jsonb /
+//                         text[] / row arrays round-trip
+//   - time.Time          → RFC3339Nano (matches what pgx emits and
+//                         what most spreadsheet apps recognise)
+//   - []byte             → string conversion (Postgres bytea
+//                         literal; if it happens to be UTF-8 text,
+//                         the cell is human-readable, otherwise
+//                         the recipient gets the raw bytes the
+//                         pg driver returned)
+//   - everything else    → fmt.Sprint, same as before
+func formatCSVCell(v any) string {
+	switch v := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case time.Time:
+		return v.Format(time.RFC3339Nano)
+	case []byte:
+		return string(v)
+	case map[string]interface{}, []interface{}:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
+	default:
+		return fmt.Sprint(v)
+	}
 }

--- a/internal/compliance/export_handler.go
+++ b/internal/compliance/export_handler.go
@@ -73,6 +73,21 @@ func HandleRequestTenantExport(exportSvc *ExportService) http.HandlerFunc {
 			return
 		}
 
+		// Closes #100. Defence-in-depth audit trail: a malicious
+		// admin who exfiltrates project data via DSAR shouldn't be
+		// able to operate without leaving a trace beyond the
+		// (deletable-with-DB-access) export_requests row.
+		if svc := audit.FromContext(r.Context()); svc != nil {
+			svc.Log(r.Context(), projectID, claims.Subject, claims.Email,
+				audit.ActionExportRequested,
+				audit.WithTarget("export", req.ID),
+				audit.WithMetadata(map[string]any{
+					"format": body.Format,
+					"scope":  "tenant",
+				}),
+				audit.WithIP(r.RemoteAddr))
+		}
+
 		writeExportJSON(w, req, http.StatusAccepted)
 	}
 }
@@ -104,6 +119,22 @@ func HandleRequestUserExport(exportSvc *ExportService) http.HandlerFunc {
 			return
 		}
 
+		// Closes #102: verify the user actually exists in this tenant
+		// before enqueueing. Skipping this lets a typo'd UUID burn
+		// worker time and produce an almost-empty zip; worse, no real
+		// data leaks but the export looks legitimate to the requester.
+		// We check before the rate limit so a 404 doesn't consume the
+		// daily slot.
+		exists, err := exportSvc.UserExistsInTenant(r.Context(), projectID, body.UserID)
+		if err != nil {
+			writeExportError(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !exists {
+			writeExportError(w, "user not found", http.StatusNotFound)
+			return
+		}
+
 		limited, err := exportSvc.CheckRateLimit(r.Context(), projectID, &body.UserID)
 		if err != nil {
 			writeExportError(w, "internal error", http.StatusInternalServerError)
@@ -124,6 +155,21 @@ func HandleRequestUserExport(exportSvc *ExportService) http.HandlerFunc {
 			_ = exportSvc.MarkFailed(r.Context(), req.ID, "failed to enqueue job")
 			writeExportError(w, "failed to enqueue export", http.StatusInternalServerError)
 			return
+		}
+
+		// Closes #100, per-user variant. target_id is the export
+		// request UUID; the affected end-user goes into metadata so
+		// the audit log can answer "who was exported, when, by whom".
+		if svc := audit.FromContext(r.Context()); svc != nil {
+			svc.Log(r.Context(), projectID, claims.Subject, claims.Email,
+				audit.ActionExportRequested,
+				audit.WithTarget("export", req.ID),
+				audit.WithMetadata(map[string]any{
+					"format":         body.Format,
+					"scope":          "user",
+					"target_user_id": body.UserID,
+				}),
+				audit.WithIP(r.RemoteAddr))
 		}
 
 		writeExportJSON(w, req, http.StatusAccepted)
@@ -260,6 +306,26 @@ func HandleSelfServeExport(pool *pgxpool.Pool, s3 *storage.S3Client, auditSvc *a
 			_ = exportSvc.MarkFailed(r.Context(), req.ID, "failed to enqueue job")
 			writeExportError(w, "failed to enqueue export", http.StatusInternalServerError)
 			return
+		}
+
+		// Closes #100, self-serve variant. End-user-initiated rather
+		// than admin-initiated: actor = the end-user themselves, no
+		// platform user. The action constant distinguishes it from
+		// the platform-admin DSAR exports so the audit feed can be
+		// filtered cleanly.
+		if auditSvc != nil {
+			email := ""
+			if endUserClaims != nil {
+				email = endUserClaims.Email
+			}
+			auditSvc.Log(r.Context(), pc.ProjectID, userID, email,
+				audit.ActionExportSelfRequested,
+				audit.WithTarget("export", req.ID),
+				audit.WithMetadata(map[string]any{
+					"format": body.Format,
+					"scope":  "user",
+				}),
+				audit.WithIP(r.RemoteAddr))
 		}
 
 		writeExportJSON(w, req, http.StatusAccepted)

--- a/internal/workers/export.go
+++ b/internal/workers/export.go
@@ -56,6 +56,24 @@ func (w *TenantExportWorker) Work(ctx context.Context, job *river.Job[jobs.Tenan
 		return fmt.Errorf("mark completed: %w", err)
 	}
 
+	// Closes #100. The request-time audit row was written by the
+	// HTTP handler; here we close the loop with the completion
+	// event. Workers have no http.Request so we pass an empty
+	// actor (the request audit already records who initiated it)
+	// and put the matching export_id in target_id so the two rows
+	// link cleanly.
+	if w.AuditSvc != nil {
+		w.AuditSvc.Log(ctx, args.ProjectID, "", "",
+			audit.ActionExportCompleted,
+			audit.WithTarget("export", args.ExportID),
+			audit.WithMetadata(map[string]any{
+				"s3_key":    s3Key,
+				"file_size": buf.Len(),
+				"rows":      totalRows,
+				"scope":     "tenant",
+			}))
+	}
+
 	logger.Info("tenant export completed", "size", buf.Len(), "rows", totalRows)
 	return nil
 }
@@ -100,6 +118,20 @@ func (w *UserExportWorker) Work(ctx context.Context, job *river.Job[jobs.UserExp
 
 	if err := exportSvc.MarkCompleted(ctx, args.ExportID, s3Key, int64(buf.Len())); err != nil {
 		return fmt.Errorf("mark completed: %w", err)
+	}
+
+	// Closes #100, per-user / self-serve variant.
+	if w.AuditSvc != nil {
+		w.AuditSvc.Log(ctx, args.ProjectID, "", "",
+			audit.ActionExportCompleted,
+			audit.WithTarget("export", args.ExportID),
+			audit.WithMetadata(map[string]any{
+				"s3_key":         s3Key,
+				"file_size":      buf.Len(),
+				"rows":           totalRows,
+				"scope":          "user",
+				"target_user_id": args.UserID,
+			}))
 	}
 
 	logger.Info("user export completed", "size", buf.Len(), "rows", totalRows)


### PR DESCRIPTION
Four small fixes off the backlog, bundled because each is too short to PR alone.

## #96 — CI: opt in to Node 24 now

\`actions/checkout@v4\`, \`setup-go@v5\`, \`setup-node@v4\` are pinned on Node 20 which GitHub auto-upgrades to Node 24 on **2026-06-02** and removes outright on **2026-09-16**. One-line workflow env (\`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\`) flips CI to Node 24 now so any incompat surfaces on a normal run, not the cutover day. The env becomes a no-op once each action ships a Node-24-native major; we can drop it then.

## #100 — DSAR export: audit_log entries on request + completion

A malicious admin who exfiltrates project data via DSAR used to leave **only** a row in \`export_requests\` as evidence — deletable with DB access. Now every export emits two audit rows: one at request time (handler) and one at completion (worker after \`MarkCompleted\`).

Four new constants in \`internal/audit\`:
- \`compliance.export.requested\`
- \`compliance.export.self_requested\` (end-user-initiated)
- \`compliance.export.completed\`
- \`compliance.export.failed\` (reserved for failure-path follow-up)

Wired into \`HandleRequestTenantExport\`, \`HandleRequestUserExport\`, \`HandleSelfServeExport\`, plus \`TenantExportWorker\` and \`UserExportWorker\`.

## #102 — DSAR user export: verify user exists before enqueueing

\`HandleRequestUserExport\` used to accept any UUID. If it didn't match a tenant user, the worker ran zero-row queries to completion and produced an almost-empty zip — useless to the recipient, billable compute, and the admin's \"export ran fine\" message was indistinguishable from success.

New \`ExportService.UserExistsInTenant\` does a one-round-trip \`SELECT EXISTS\` against \`<schema>.users\`. Runs **before** the rate limit so a typo doesn't consume the daily slot. 404 if the user isn't there.

## #103 — DSAR CSV: JSONB / array columns round-trip via json.Marshal

\`writeCSV\` previously rendered every cell via \`fmt.Sprintf(\"%v\", v)\`. For jsonb (\`metadata\`, \`identity_data\`, \`auth_config\`) and arrays, that produces Go's \`map[k:v]\` / \`[a b c]\` form, which is neither valid JSON nor CSV-importable. Recipients couldn't actually use the export.

New \`formatCSVCell\` type-switch:

| Type | Format |
|---|---|
| \`nil\` | \`\"\"\" |
| \`string\` | as-is |
| \`time.Time\` | RFC3339Nano |
| \`[]byte\` | \`string(v)\` |
| \`map\` / \`slice\` (jsonb, array) | \`json.Marshal\` |
| default | \`fmt.Sprint\` |

GDPR's \"machine-readable structured format\" obligation now actually produces parseable output.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`go build ./...\` clean
- [ ] Merge + deploy
- [ ] Trigger a tenant DSAR export → \`compliance.export.requested\` + \`compliance.export.completed\` rows appear in Compliance → Audit Log
- [ ] Trigger a user DSAR export with a non-existent UUID → 404
- [ ] Open a previous DSAR export CSV with jsonb columns → fields parse as JSON
- [ ] Next CI run shows no Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)