### PR TITLE
Phase 0: surface existing Pro features + public /pricing page

### DIFF
--- a/console/src/routes/(app)/onboarding/+page.svelte
+++ b/console/src/routes/(app)/onboarding/+page.svelte
@@ -239,7 +239,7 @@ EUROBASE_SECRET_KEY=${secretKey}`);
 				<!-- Plan selector -->
 				<fieldset>
 					<legend class="block text-sm font-medium text-gray-700">Plan for this project</legend>
-					<p class="text-xs text-gray-400 mt-0.5">Each project is billed independently. You can mix Free and Pro projects.</p>
+					<p class="text-xs text-gray-400 mt-0.5">Each project is billed independently. You can mix Free and Pro projects. <a href="/pricing" class="text-eurobase-600 hover:text-eurobase-700 underline">See full comparison</a></p>
 					<div class="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
 						<label class="cursor-pointer">
 							<input type="radio" name="onb-plan" value="free" bind:group={plan} class="peer sr-only" />
@@ -248,18 +248,27 @@ EUROBASE_SECRET_KEY=${secretKey}`);
 									<p class="text-sm font-semibold text-gray-900">Free</p>
 									<span class="text-xs font-medium text-gray-400">$0/mo</span>
 								</div>
+								<p class="mt-1.5 text-xs text-gray-500">For prototypes &amp; side projects.</p>
 								<ul class="mt-2.5 space-y-1 text-xs text-gray-500">
 									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-										{freePlan ? formatLimit(freePlan.db_size_mb) : '500 MB'} database
+										<svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										{freePlan ? formatLimit(freePlan.db_size_mb) : '500 MB'} database, {freePlan ? formatLimit(freePlan.storage_mb) : '1 GB'} file storage
 									</li>
 									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-										{freePlan ? formatLimit(freePlan.storage_mb) : '1 GB'} file storage
-									</li>
-									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										<svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
 										{freePlan ? (freePlan.mau_limit / 1000).toFixed(0) + 'k' : '10k'} auth users
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										100 concurrent realtime connections
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										3 edge functions, 2 cron jobs, 3 webhooks
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										24h log retention
 									</li>
 								</ul>
 							</div>
@@ -271,18 +280,27 @@ EUROBASE_SECRET_KEY=${secretKey}`);
 									<p class="text-sm font-semibold text-gray-900">Pro</p>
 									<span class="text-sm font-semibold text-eurobase-700">&euro;19/mo per project</span>
 								</div>
+								<p class="mt-1.5 text-xs text-gray-500">For production workloads.</p>
 								<ul class="mt-2.5 space-y-1 text-xs text-gray-500">
 									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-eurobase-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-										{proPlan ? formatLimit(proPlan.db_size_mb) : '5 GB'} database
+										<svg class="h-3.5 w-3.5 text-eurobase-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										{proPlan ? formatLimit(proPlan.db_size_mb) : '5 GB'} database, {proPlan ? formatLimit(proPlan.storage_mb) : '50 GB'} file storage
 									</li>
 									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-eurobase-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-										{proPlan ? formatLimit(proPlan.storage_mb) : '50 GB'} file storage
-									</li>
-									<li class="flex items-center gap-1.5">
-										<svg class="h-3.5 w-3.5 text-eurobase-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										<svg class="h-3.5 w-3.5 text-eurobase-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
 										{proPlan ? (proPlan.mau_limit / 1000).toFixed(0) + 'k' : '100k'} auth users
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-eurobase-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										10,000 concurrent realtime connections
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-eurobase-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										25 edge functions, unlimited cron &amp; webhooks
+									</li>
+									<li class="flex items-center gap-1.5">
+										<svg class="h-3.5 w-3.5 text-eurobase-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+										30-day log retention, custom email templates
 									</li>
 								</ul>
 							</div>

--- a/console/src/routes/+page.svelte
+++ b/console/src/routes/+page.svelte
@@ -15,6 +15,12 @@
 				Sign In
 			</a>
 			<a
+				href="/pricing"
+				class="rounded-lg border border-gray-300 bg-white px-6 py-2.5 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
+			>
+				Pricing
+			</a>
+			<a
 				href="/projects"
 				class="rounded-lg border border-gray-300 bg-white px-6 py-2.5 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
 			>

--- a/console/src/routes/pricing/+page.svelte
+++ b/console/src/routes/pricing/+page.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api, type PlanLimits } from '$lib/api.js';
+
+	let limits: PlanLimits[] = $state([]);
+	let loading = $state(true);
+
+	onMount(async () => {
+		// Only fetch live limits when the visitor is already signed in.
+		// /platform/config/plans is auth-gated; calling it anonymously
+		// would 401 and the api wrapper's 401 handler force-redirects
+		// to /login — fatal on a public marketing page. Anonymous
+		// visitors see the static defaults inline below.
+		if (!api.getToken()) {
+			loading = false;
+			return;
+		}
+		try {
+			limits = await api.getPlans();
+		} catch {
+			// Falls back to the hard-coded defaults below.
+		} finally {
+			loading = false;
+		}
+	});
+
+	let freePlan = $derived(limits.find(p => p.plan === 'free'));
+	let proPlan = $derived(limits.find(p => p.plan === 'pro'));
+
+	function fmt(mb: number | undefined, fallback: string): string {
+		if (mb === undefined) return fallback;
+		if (mb >= 1024) return (mb / 1024).toFixed(0) + ' GB';
+		return mb + ' MB';
+	}
+
+	function kmau(n: number | undefined, fallback: string): string {
+		if (n === undefined) return fallback;
+		if (n >= 1000) return (n / 1000).toFixed(0) + 'k';
+		return String(n);
+	}
+
+	// Rows in the comparison table. `free` and `pro` are strings rendered
+	// verbatim so we can mix data-driven values (DB size, MAU, …) with
+	// fixed feature blurbs ("Custom email templates", "EU-sovereign").
+	// `category` groups consecutive rows under a sub-header.
+	let rows = $derived([
+		{ category: 'Database & storage' },
+		{ label: 'Database size', free: fmt(freePlan?.db_size_mb, '500 MB'), pro: fmt(proPlan?.db_size_mb, '5 GB') },
+		{ label: 'File storage', free: fmt(freePlan?.storage_mb, '1 GB'), pro: fmt(proPlan?.storage_mb, '50 GB') },
+		{ label: 'Egress bandwidth', free: fmt(freePlan?.bandwidth_mb, '5 GB') + '/mo', pro: fmt(proPlan?.bandwidth_mb, '100 GB') + '/mo' },
+		{ label: 'Upload size', free: (freePlan?.upload_size_mb ?? 10) + ' MB', pro: (proPlan?.upload_size_mb ?? 50) + ' MB' },
+
+		{ category: 'Auth & API' },
+		{ label: 'Monthly active users', free: kmau(freePlan?.mau_limit, '10k'), pro: kmau(proPlan?.mau_limit, '100k') },
+		{ label: 'API rate limit', free: (freePlan?.rate_limit_rps ?? 100) + ' rps', pro: (proPlan?.rate_limit_rps ?? 1000) + ' rps' },
+		{ label: 'Realtime concurrent connections', free: String(freePlan?.ws_connections ?? 100), pro: kmau(proPlan?.ws_connections, '10k') },
+
+		{ category: 'Automation & integrations' },
+		{ label: 'Edge functions', free: String(freePlan?.edge_function_limit ?? 3), pro: String(proPlan?.edge_function_limit ?? 25) },
+		{ label: 'Scheduled jobs (cron)', free: '2', pro: 'Unlimited' },
+		{ label: 'Webhooks', free: String(freePlan?.webhook_limit ?? 3), pro: 'Unlimited' },
+		{ label: 'Custom email templates', free: false, pro: true },
+
+		{ category: 'Operations' },
+		{ label: 'Log retention', free: (freePlan?.log_retention_days ?? 1) + ' day', pro: (proPlan?.log_retention_days ?? 30) + ' days' },
+		{ label: 'Projects per organisation', free: String(freePlan?.project_limit ?? 2), pro: String(proPlan?.project_limit ?? 10) },
+
+		{ category: 'Sovereignty & compliance' },
+		{ label: 'EU-hosted infrastructure (Scaleway, France)', free: true, pro: true },
+		{ label: 'GDPR by design', free: true, pro: true },
+		{ label: 'DPA report (PDF)', free: true, pro: true },
+		{ label: 'DSAR self-serve user export', free: true, pro: true },
+		{ label: 'Audit log', free: true, pro: true },
+	]);
+</script>
+
+<svelte:head>
+	<title>Pricing — Eurobase</title>
+	<meta name="description" content="Eurobase pricing — Free for prototypes, Pro for production. EU-sovereign Backend-as-a-Service, made in Berlin." />
+</svelte:head>
+
+<div class="min-h-screen bg-gray-50">
+	<!-- Top bar (minimal — no nav on this public page) -->
+	<header class="border-b border-gray-200 bg-white">
+		<div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+			<a href="/" class="text-lg font-bold text-gray-900">Eurobase</a>
+			<div class="flex items-center gap-3 text-sm">
+				<a href="/login" class="text-gray-600 hover:text-gray-900">Sign in</a>
+				<a href="/login" class="rounded-lg bg-eurobase-600 px-4 py-2 font-semibold text-white shadow-sm hover:bg-eurobase-700 transition-colors">Get started</a>
+			</div>
+		</div>
+	</header>
+
+	<!-- Hero -->
+	<section class="mx-auto max-w-6xl px-6 pt-16 pb-8 text-center">
+		<h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Simple, transparent pricing.</h1>
+		<p class="mt-4 text-lg text-gray-600">The EU-sovereign Backend-as-a-Service, made in Berlin. Free to start; €19/mo when you go to production.</p>
+	</section>
+
+	<!-- Tier cards -->
+	<section class="mx-auto max-w-5xl px-6 pb-12">
+		<div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+			<!-- Free -->
+			<div class="rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+				<h2 class="text-xl font-semibold text-gray-900">Free</h2>
+				<p class="mt-1 text-sm text-gray-500">For prototypes, side projects, and learning.</p>
+				<div class="mt-6 flex items-baseline gap-1">
+					<span class="text-4xl font-bold text-gray-900">€0</span>
+					<span class="text-sm text-gray-500">/mo</span>
+				</div>
+				<a href="/login" class="mt-6 block rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-center text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 transition-colors">Start free</a>
+				<ul class="mt-6 space-y-2 text-sm text-gray-700">
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{fmt(freePlan?.db_size_mb, '500 MB')} database, {fmt(freePlan?.storage_mb, '1 GB')} file storage</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{kmau(freePlan?.mau_limit, '10k')} monthly active users</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{freePlan?.ws_connections ?? 100} realtime connections</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>2 projects per organisation</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>EU-hosted, GDPR-by-design</span></li>
+				</ul>
+			</div>
+
+			<!-- Pro -->
+			<div class="relative rounded-2xl border-2 border-eurobase-600 bg-white p-8 shadow-lg">
+				<span class="absolute -top-3 right-6 rounded-full bg-eurobase-600 px-3 py-1 text-xs font-semibold text-white shadow">For production</span>
+				<h2 class="text-xl font-semibold text-gray-900">Pro</h2>
+				<p class="mt-1 text-sm text-gray-500">When your project ships to real users.</p>
+				<div class="mt-6 flex items-baseline gap-1">
+					<span class="text-4xl font-bold text-gray-900">€19</span>
+					<span class="text-sm text-gray-500">/mo per project</span>
+				</div>
+				<a href="/login" class="mt-6 block rounded-lg bg-eurobase-600 px-4 py-2.5 text-center text-sm font-semibold text-white shadow-sm hover:bg-eurobase-700 transition-colors">Get Pro</a>
+				<ul class="mt-6 space-y-2 text-sm text-gray-700">
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{fmt(proPlan?.db_size_mb, '5 GB')} database, {fmt(proPlan?.storage_mb, '50 GB')} file storage</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{kmau(proPlan?.mau_limit, '100k')} MAU, {(proPlan?.rate_limit_rps ?? 1000)} rps</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>10,000 realtime connections (100× Free)</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>Unlimited cron jobs &amp; webhooks</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>25 edge functions, custom email templates</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>30-day log retention</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>EU-hosted, GDPR-by-design</span></li>
+				</ul>
+			</div>
+		</div>
+	</section>
+
+	<!-- Comparison table -->
+	<section class="mx-auto max-w-5xl px-6 pb-16">
+		<h2 class="text-2xl font-semibold text-gray-900 mb-4">Full comparison</h2>
+		<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+			<table class="w-full text-sm">
+				<thead class="bg-gray-50">
+					<tr>
+						<th class="px-6 py-3 text-left font-medium text-gray-700"></th>
+						<th class="px-6 py-3 text-center font-medium text-gray-700 w-32">Free</th>
+						<th class="px-6 py-3 text-center font-medium text-gray-700 w-32">Pro</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-gray-200">
+					{#each rows as r}
+						{#if r.category}
+							<tr class="bg-gray-50">
+								<td colspan="3" class="px-6 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500">{r.category}</td>
+							</tr>
+						{:else}
+							<tr>
+								<td class="px-6 py-3 text-gray-700">{r.label}</td>
+								<td class="px-6 py-3 text-center text-gray-600">
+									{#if typeof r.free === 'boolean'}
+										{#if r.free}<span class="text-emerald-500">✓</span>{:else}<span class="text-gray-300">—</span>{/if}
+									{:else}
+										{r.free}
+									{/if}
+								</td>
+								<td class="px-6 py-3 text-center text-gray-900 font-medium">
+									{#if typeof r.pro === 'boolean'}
+										{#if r.pro}<span class="text-eurobase-600">✓</span>{:else}<span class="text-gray-300">—</span>{/if}
+									{:else}
+										{r.pro}
+									{/if}
+								</td>
+							</tr>
+						{/if}
+					{/each}
+				</tbody>
+			</table>
+		</div>
+		{#if loading}
+			<p class="mt-3 text-xs text-gray-400">Loading live limits…</p>
+		{/if}
+	</section>
+
+	<!-- Sovereignty footer -->
+	<section class="border-t border-gray-200 bg-white">
+		<div class="mx-auto max-w-5xl px-6 py-12 text-center">
+			<h2 class="text-2xl font-semibold text-gray-900">Made in Berlin. Hosted in France.</h2>
+			<p class="mt-3 text-sm text-gray-600 max-w-2xl mx-auto">All Eurobase data lives in EU jurisdiction (Scaleway, France). GDPR by design — DPA report, sub-processor list, and DSAR self-serve user export are built in. <a href="/docs" class="text-eurobase-600 hover:text-eurobase-700 underline">Read the docs</a>.</p>
+		</div>
+	</section>
+</div>

--- a/console/src/routes/pricing/+page.svelte
+++ b/console/src/routes/pricing/+page.svelte
@@ -113,7 +113,8 @@
 					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{fmt(freePlan?.db_size_mb, '500 MB')} database, {fmt(freePlan?.storage_mb, '1 GB')} file storage</span></li>
 					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{kmau(freePlan?.mau_limit, '10k')} monthly active users</span></li>
 					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{freePlan?.ws_connections ?? 100} realtime connections</span></li>
-					<li class="flex gap-2"><span class="text-gray-400">•</span><span>2 projects per organisation</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{freePlan?.edge_function_limit ?? 3} edge functions, {freePlan?.webhook_limit ?? 3} webhooks</span></li>
+					<li class="flex gap-2"><span class="text-gray-400">•</span><span>{freePlan?.project_limit ?? 2} projects per organisation</span></li>
 					<li class="flex gap-2"><span class="text-gray-400">•</span><span>EU-hosted, GDPR-by-design</span></li>
 				</ul>
 			</div>
@@ -131,10 +132,9 @@
 				<ul class="mt-6 space-y-2 text-sm text-gray-700">
 					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{fmt(proPlan?.db_size_mb, '5 GB')} database, {fmt(proPlan?.storage_mb, '50 GB')} file storage</span></li>
 					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{kmau(proPlan?.mau_limit, '100k')} MAU, {(proPlan?.rate_limit_rps ?? 1000)} rps</span></li>
-					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>10,000 realtime connections (100× Free)</span></li>
-					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>Unlimited cron jobs &amp; webhooks</span></li>
-					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>25 edge functions, custom email templates</span></li>
-					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>30-day log retention</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{kmau(proPlan?.ws_connections, '10k')} realtime connections</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{proPlan?.edge_function_limit ?? 25} edge functions, unlimited cron &amp; webhooks</span></li>
+					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>{proPlan?.log_retention_days ?? 30}-day log retention, custom email templates</span></li>
 					<li class="flex gap-2"><span class="text-eurobase-500">✓</span><span>EU-hosted, GDPR-by-design</span></li>
 				</ul>
 			</div>


### PR DESCRIPTION
First step of the pro-tier strategy (see \`~/.claude/plans/pro-tier-strategy.md\` and follow-up issues #126-#132). The diagnosis: half the Pro value is invisible in onboarding. The card shows DB / storage / MAU and that's it — never mentions 100× more realtime connections, unlimited cron + webhooks, custom email templates, 30-day log retention, or 25 edge functions. This PR is the surface-it-better pass; no backend changes.

## What lands

### Onboarding plan card (\`onboarding/+page.svelte\`)

Plan-card now lists what each tier actually gives you. Five bullets per side, parity with the pricing page.

| | Free | Pro |
|---|---|---|
| Database & files | 500 MB + 1 GB | 5 GB + 50 GB |
| MAU | 10k | 100k |
| Realtime concurrent | 100 | **10,000** |
| Functions / cron / webhooks | 3 / 2 / 3 | 25 / unlimited / unlimited |
| Logs / templates | 24h | 30 days + custom templates |

Plus a \"See full comparison\" link to the new pricing page.

### \`/pricing\` — new public page

Marketing-grade comparison: hero, side-by-side tier cards (Pro highlighted with \"For production\" badge), and a full feature-by-feature table grouped by category (Database & storage, Auth & API, Automation, Operations, **Sovereignty & compliance**). Sovereignty/GDPR appear in both columns — they're table stakes, not the upsell — but get a dedicated category so visitors see them.

Live-data when signed in (calls \`/platform/config/plans\` on mount if there's a token); static fallback values otherwise. The auth-gated API call is skipped for anonymous visitors so the \`401 → /login\` redirect doesn't fire on a public marketing page.

### Landing page

Added \`/pricing\` button next to Sign in / Dashboard.

## What's next

Filed for Phase 1+:

- **#126** — automated daily backups + 7-day PITR (biggest competitor gap)
- **#127** — Compliance Pack gating (audit log retention, DSAR rate limit, DPA PDF)
- **#128** — edge function invocation metering (Free 100k/mo, Pro 2M/mo)
- **#129** — DB branches (Phase 2, differentiator vs every other BaaS)
- **#130** — SSO (Phase 2 / Team tier)
- **#131** — per-org pricing + Team tier (Phase 3, blocked on Mollie)
- **#132** — pause Free projects after 7 days idle (Phase 3)

## Test plan

- [x] \`npm run build\` (console) clean
- [ ] Merge + deploy
- [ ] Anonymous visit to \`/pricing\` renders without errors and **doesn't redirect to /login**
- [ ] Signed-in visit shows live limit values from \`plan_limits\`
- [ ] Onboarding plan card shows the new bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)