### PR TITLE
Pricing: add to dashboard sidebar + back-to-dashboard on the marketing page

### DIFF
--- a/console/src/routes/(app)/+layout.svelte
+++ b/console/src/routes/(app)/+layout.svelte
@@ -28,6 +28,7 @@
 		[
 			{ label: 'Projects', href: '/projects', icon: 'projects' },
 			{ label: 'Account', href: '/account', icon: 'account' },
+			{ label: 'Pricing', href: '/pricing', icon: 'pricing' },
 			{ label: 'Documentation', href: '/docs', icon: 'docs' },
 			...(isSuperadmin ? [{ label: 'Admin', href: '/admin', icon: 'admin' }] : [])
 		]
@@ -73,6 +74,10 @@
 						{:else if item.icon === 'docs'}
 							<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+							</svg>
+						{:else if item.icon === 'pricing'}
+							<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
 							</svg>
 						{:else if item.icon === 'admin'}
 							<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">

--- a/console/src/routes/pricing/+page.svelte
+++ b/console/src/routes/pricing/+page.svelte
@@ -4,6 +4,7 @@
 
 	let limits: PlanLimits[] = $state([]);
 	let loading = $state(true);
+	let signedIn = $state(false);
 
 	onMount(async () => {
 		// Only fetch live limits when the visitor is already signed in.
@@ -11,7 +12,8 @@
 		// would 401 and the api wrapper's 401 handler force-redirects
 		// to /login — fatal on a public marketing page. Anonymous
 		// visitors see the static defaults inline below.
-		if (!api.getToken()) {
+		signedIn = !!api.getToken();
+		if (!signedIn) {
 			loading = false;
 			return;
 		}
@@ -85,8 +87,12 @@
 		<div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
 			<a href="/" class="text-lg font-bold text-gray-900">Eurobase</a>
 			<div class="flex items-center gap-3 text-sm">
-				<a href="/login" class="text-gray-600 hover:text-gray-900">Sign in</a>
-				<a href="/login" class="rounded-lg bg-eurobase-600 px-4 py-2 font-semibold text-white shadow-sm hover:bg-eurobase-700 transition-colors">Get started</a>
+				{#if signedIn}
+					<a href="/projects" class="rounded-lg bg-eurobase-600 px-4 py-2 font-semibold text-white shadow-sm hover:bg-eurobase-700 transition-colors">Back to dashboard</a>
+				{:else}
+					<a href="/login" class="text-gray-600 hover:text-gray-900">Sign in</a>
+					<a href="/login" class="rounded-lg bg-eurobase-600 px-4 py-2 font-semibold text-white shadow-sm hover:bg-eurobase-700 transition-colors">Get started</a>
+				{/if}
 			</div>
 		</div>
 	</header>


### PR DESCRIPTION
Follow-up to #133. The public \`/pricing\` page existed but had no entry point from inside the signed-in dashboard, and clicking through bounced through the landing page to get back.

## Changes

- **Sidebar nav** (\`(app)/+layout.svelte\`): new \"Pricing\" item between Account and Documentation, credit-card-style icon. Same hover / active-path styling as the other items.
- **Pricing top bar**: detects auth state via \`api.getToken()\` on mount. Signed-in visitors see a single \"Back to dashboard\" button; anonymous visitors keep the \"Sign in\" + \"Get started\" pair from #133.

The \`/pricing\` route stays outside the \`(app)/\` group — it's a marketing-style page, so the sidebar correctly disappears when the user navigates to it. The \"Back to dashboard\" button is the bridge back.

## Test plan

- [x] \`npm run build\` (console) clean
- [ ] Merge + deploy
- [ ] Sign in → sidebar shows Pricing → click → /pricing renders with \"Back to dashboard\" button
- [ ] Sign out → /pricing renders with \"Sign in\" / \"Get started\" pair (anonymous path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)