### PR TITLE
Cost: in-cluster Redis + replicas=1 during beta (~€60-90/mo saved)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,12 @@ jobs:
           # CVE-2026-31431 mitigation must land before any pod restart so newly
           # scheduled pods can't briefly run on a node with algif_aead loaded.
           kubectl apply -f deploy/k8s/security/disable-algif-aead.yaml
+          # In-cluster Redis replaces managed RED1-micro to cut the
+          # beta-stage bill (~€59/mo). Apply before the gateway/worker
+          # rollout so REDIS_URL=redis://redis.eurobase.svc.cluster.local
+          # resolves the first time those pods start. See
+          # docs/runbooks/cost-tier.md.
+          kubectl apply -f deploy/k8s/redis.yaml
           kubectl apply -f deploy/k8s/ingress.yaml
           kubectl apply -f deploy/k8s/functions.yaml
           # NetworkPolicy must apply BEFORE the pod rollout so the new
@@ -258,6 +264,11 @@ jobs:
 
       - name: Verify rollout
         run: |
+          # In-cluster Redis goes first so rate-limiting + realtime fan-out
+          # connect cleanly on gateway startup. Failure here is non-blocking
+          # for the gateway (it logs a warning and disables those features),
+          # but a clean roll keeps the failure paths out of the deploy log.
+          kubectl rollout status statefulset/redis -n eurobase --timeout=120s
           kubectl rollout status deployment/gateway -n eurobase --timeout=120s
           kubectl rollout status deployment/worker -n eurobase --timeout=120s
           kubectl rollout status deployment/console -n eurobase --timeout=120s

--- a/deploy/k8s/functions.yaml
+++ b/deploy/k8s/functions.yaml
@@ -10,7 +10,9 @@ metadata:
     app: functions
     component: runtime
 spec:
-  replicas: 2
+  # Single replica during beta. The HPA below has minReplicas=1 to
+  # match. See docs/runbooks/cost-tier.md.
+  replicas: 1
   selector:
     matchLabels:
       app: functions
@@ -98,7 +100,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: functions
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 10
   metrics:
     - type: Resource

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -10,7 +10,10 @@ metadata:
     app: gateway
     component: api
 spec:
-  replicas: 2
+  # Single replica during beta to keep the bill on one Kapsule node.
+  # See docs/runbooks/cost-tier.md — bump back to 2 when the first
+  # paying customer lands.
+  replicas: 1
   selector:
     matchLabels:
       app: gateway

--- a/deploy/k8s/mcp-server.yaml
+++ b/deploy/k8s/mcp-server.yaml
@@ -10,7 +10,8 @@ metadata:
     app: mcp-server
     component: mcp
 spec:
-  replicas: 2
+  # Single replica during beta. See docs/runbooks/cost-tier.md.
+  replicas: 1
   selector:
     matchLabels:
       app: mcp-server

--- a/deploy/k8s/redis.yaml
+++ b/deploy/k8s/redis.yaml
@@ -1,0 +1,89 @@
+##############################################################################
+# In-cluster Redis — replaces Scaleway Managed Redis (RED1-micro, ~€59/mo).
+#
+# Used by the gateway for rate-limit counters and realtime cross-instance
+# fan-out. Both consumers fall back gracefully when REDIS_URL is unset
+# (cmd/gateway/main.go:124 and :210) — restarts here lose ephemeral state
+# but never corrupt anything persistent.
+#
+# Configuration is intentionally bare:
+#   --save ""         — disable RDB snapshots, no disk writes
+#   --appendonly no   — disable AOF, pure in-memory
+#   resources         — small enough to fit alongside everything else on
+#                       a single DEV1-M Kapsule node (3 vCPU / 4 GB)
+#
+# When we add a paying customer and need cross-AZ realtime or a more
+# durable rate-limit counter, swap REDIS_URL back to a Scaleway managed
+# instance and delete this StatefulSet. See docs/runbooks/cost-tier.md.
+##############################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: eurobase
+  labels:
+    app: redis
+spec:
+  # Headless service — the StatefulSet's `redis-0` pod gets a stable
+  # DNS name (`redis-0.redis.eurobase.svc.cluster.local`). We expose
+  # the short form too (`redis.eurobase.svc.cluster.local`) which
+  # resolves to the same single pod.
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: eurobase
+  labels:
+    app: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--save"
+            - ""
+            - "--appendonly"
+            - "no"
+            - "--maxmemory"
+            - "192mb"
+            - "--maxmemory-policy"
+            - "allkeys-lru"
+          ports:
+            - containerPort: 6379
+              name: redis
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 10
+            periodSeconds: 15

--- a/docs/runbooks/cost-tier.md
+++ b/docs/runbooks/cost-tier.md
@@ -1,0 +1,129 @@
+# Cost-tier runbook — beta vs production
+
+Eurobase has two configurations:
+
+- **Beta** — single Kapsule node, replicas=1 across the gateway / mcp-server / functions, in-cluster Redis. Runs at ~€45/mo on Scaleway.
+- **Production** — two Kapsule nodes, replicas=2 on the public-path deployments, managed Redis. Runs at ~€127/mo on Scaleway and tolerates a node restart without downtime.
+
+We're on **beta** today. Bump to production when the first paying Pro customer signs up (issue #135).
+
+## Beta → production (when revenue justifies it)
+
+Do these in order. Each step is independently reversible.
+
+### Step 1 — bump Kapsule pool to 2 nodes (~€28/mo)
+
+Restores redundancy on the gateway path. Do this **first** — paying users get HA before they get faster scaling.
+
+```bash
+# Pick the pool ID from the console: Kubernetes → eurobase-cluster → Node pools
+scw k8s pool update <pool-id> autoscaler.min-size=1 autoscaler.max-size=2
+
+# Or, via the console: Kapsule → cluster → pool → Edit → Autoscaler:
+#   Min size: 1   Max size: 2
+```
+
+Kapsule's autoscaler will provision the second DEV1-M when the next pod pressure event happens (e.g. when you scale a Deployment to 2 — step 2 below). For an immediate roll, manually scale the pool:
+
+```bash
+scw k8s pool update <pool-id> size=2
+```
+
+The new node picks up an IPv4 Flexible IP automatically — no extra config.
+
+### Step 2 — restore replicas=2 on public-path deployments (no extra cost)
+
+Once a second node exists, schedule a second replica of the gateway and mcp-server. CPU/memory requests are small (250m/256Mi total per pair) — both fit on the second DEV1-M.
+
+```bash
+kubectl scale deployment/gateway    --replicas=2 -n eurobase
+kubectl scale deployment/mcp-server --replicas=2 -n eurobase
+```
+
+Update the manifests so the next deploy doesn't regress:
+
+- `deploy/k8s/gateway.yaml` → `replicas: 2`
+- `deploy/k8s/mcp-server.yaml` → `replicas: 2`
+- `deploy/k8s/functions.yaml` → `replicas: 2` AND HPA `minReplicas: 2`
+
+Commit + PR. The deploy script applies cleanly.
+
+### Step 3 — switch to managed Redis (~€34-59/mo)
+
+In-cluster Redis is fine indefinitely for **single-AZ** deploys. Switch to managed when you need:
+
+- Cross-AZ realtime fan-out (you've added a second Kapsule pool in another zone)
+- Durable rate-limit counters across node reboots
+- Automated backups / monitoring
+- Sub-millisecond SLAs
+
+To switch:
+
+1. Scaleway console → Databases → Redis → Create instance → RED1-micro (or the size you need)
+2. Note the connection URL: `redis://default:<password>@<host>:6379`
+3. Update the `REDIS_URL` value in the `eurobase-secrets` Kubernetes Secret:
+   ```bash
+   kubectl edit secret eurobase-secrets -n eurobase
+   # Replace REDIS_URL value (it's base64-encoded — `echo -n "redis://..." | base64`)
+   ```
+4. Roll the gateway + worker so they pick up the new URL:
+   ```bash
+   kubectl rollout restart deployment/gateway deployment/worker -n eurobase
+   ```
+5. Verify gateway logs say `rate limiter connected to redis` and `realtime redis bridge connected`.
+6. Once stable, remove the in-cluster Redis:
+   ```bash
+   kubectl delete -f deploy/k8s/redis.yaml
+   ```
+7. Update `deploy/create-secrets.sh` so a fresh environment bootstraps with the managed-Redis URL.
+
+## Production → beta (cost-cutting)
+
+The reverse direction — what we just did to get here. Documented so you can recover the savings on a quiet weekend.
+
+### Step 1 — apply the in-cluster Redis manifest
+
+```bash
+kubectl apply -f deploy/k8s/redis.yaml
+kubectl rollout status statefulset/redis -n eurobase --timeout=120s
+```
+
+Update the `REDIS_URL` Secret value to `redis://redis.eurobase.svc.cluster.local:6379` (no auth, internal-only):
+
+```bash
+NEW_URL=$(echo -n "redis://redis.eurobase.svc.cluster.local:6379" | base64)
+kubectl patch secret eurobase-secrets -n eurobase \
+  -p "{\"data\":{\"REDIS_URL\":\"$NEW_URL\"}}"
+kubectl rollout restart deployment/gateway deployment/worker -n eurobase
+```
+
+Wait for gateway logs to show `rate limiter connected to redis`. Then in the Scaleway console → Databases → Redis → delete the managed RED1-micro instance.
+
+### Step 2 — scale replicas down + pool to 1 node
+
+```bash
+kubectl scale deployment/gateway    --replicas=1 -n eurobase
+kubectl scale deployment/mcp-server --replicas=1 -n eurobase
+# Patch the HPA to allow min=1 (functions Deployment will follow)
+kubectl patch hpa functions -n eurobase --type=merge -p '{"spec":{"minReplicas":1}}'
+
+scw k8s pool update <pool-id> autoscaler.min-size=1 autoscaler.max-size=1
+scw k8s pool update <pool-id> size=1
+```
+
+The autoscaler will drain and remove the second node within ~5 minutes. The freed IPv4 Flexible IP releases automatically (verify in Network → Public IPs that count is back to 1).
+
+## Cost monitoring
+
+Scaleway sends a monthly invoice. Two budget alerts worth setting in the console:
+
+- **€50/mo** — anchor for beta. Anything above this needs explanation.
+- **€150/mo** — anchor for production. Anything above suggests data-egress overage or autoscaler runaway.
+
+Set via Scaleway console → Billing → Cost alerts.
+
+## Things to never cut
+
+- **Managed Postgres backups** (€0.06/mo). Trivial cost, every tenant's data is on it.
+- **EU jurisdiction** (Scaleway fr-par). Moving to a US provider saves nothing and breaks the sovereignty pitch.
+- **Audit log retention** in `public.audit_log`. Compliance pack is the Pro upsell.


### PR DESCRIPTION
April Scaleway bill was ~€97; May was tracking ~€127. Two changes cut the recurring cost to ~€45/mo with no functional regression at our current beta scale.

| Change | Saving |
|---|---|
| In-cluster Redis (replaces Managed RED1-micro) | €34-59/mo |
| Kapsule pool 2 → 1 nodes + replicas=1 across the public-path deployments | ~€28/mo (after the operator follow-up) |
| **Total** | **~€60-90/mo** |

## What lands in this PR

### \`deploy/k8s/redis.yaml\` — in-cluster Redis StatefulSet + Service

Single-replica \`redis:7-alpine\` with \`--save \"\" --appendonly no\` (pure in-memory), 192 MB max with \`allkeys-lru\` eviction, 25m/64Mi requests / 200m/256Mi limits. Headless Service so the gateway resolves \`redis.eurobase.svc.cluster.local\`.

The existing consumers in the codebase already log \`REDIS_URL not set, X disabled\` graceful fallbacks (\`cmd/gateway/main.go:124\` for rate limiting, \`:210\` for realtime cross-instance fan-out), so the failure mode is well-understood.

### \`deploy/k8s/{gateway,mcp-server,functions}.yaml\` — replicas: 2 → 1

Total pod requests across the cluster sum to ~1.1 CPU / 1.3 GB — fits on one DEV1-M (3 vCPU / 4 GB) with > 50% headroom. The HPA on functions follows (\`minReplicas: 2 → 1\`, max stays at 10).

**Trade-off:** no redundancy. A node reboot = ~3 min outage. Consistent with the \"beta test system, no uptime guarantees\" disclaimer in the invitation email.

### \`.github/workflows/ci.yml\` — wire Redis into the deploy

- Apply \`redis.yaml\` before the gateway rollout so the new URL resolves on first start.
- Add \`kubectl rollout status statefulset/redis\` to the verify step.

### \`docs/runbooks/cost-tier.md\` — beta vs production cost-tier

Documents both directions:
- **Beta → production**: when the first paying Pro customer signs up (tracked in #135), three reversible steps in fixed order: pool autoscaler → replicas → managed Redis.
- **Production → beta**: today's PR, written down so we can repeat it on a quiet weekend.

## Operator follow-up (after merge — not automated)

The PR ships the manifests + CI wiring. The actual cutover requires two operator commands:

1. **Update REDIS_URL in the Secret** (the deploy applies the StatefulSet but doesn't change the Secret value pointing at the old managed Redis):
   \`\`\`bash
   NEW_URL=\$(echo -n \"redis://redis.eurobase.svc.cluster.local:6379\" | base64)
   kubectl patch secret eurobase-secrets -n eurobase \\
     -p \"{\\\"data\\\":{\\\"REDIS_URL\\\":\\\"\$NEW_URL\\\"}}\"
   kubectl rollout restart deployment/gateway deployment/worker -n eurobase
   \`\`\`
   Verify gateway logs say \`rate limiter connected to redis\` and \`realtime redis bridge connected\`.

2. **Shrink the Kapsule pool + delete managed Redis**:
   \`\`\`bash
   scw k8s pool update <pool-id> autoscaler.max-size=1 size=1
   \`\`\`
   Then Scaleway console → Databases → Redis → delete the RED1-micro instance.

The runbook has the full sequence.

## Test plan

- [x] \`kubectl apply --dry-run=client -f deploy/k8s/redis.yaml\` validates
- [ ] Merge + deploy → \`kubectl get statefulset redis -n eurobase\` shows 1/1 ready
- [ ] Operator updates REDIS_URL and rolls gateway+worker
- [ ] Gateway logs show \`rate limiter connected to redis\` (not the \"disabled\" warning)
- [ ] Operator shrinks pool to 1 node; \`kubectl get nodes\` shows just one
- [ ] Verify a SDK request still rate-limits (\`for i in {1..200}; do curl ...; done\` hits 429 around the 100-rps threshold)
- [ ] Verify the realtime websocket still fan-outs (single-replica gateway, but check the realtime channel survives a pod restart)

## Reversible

Issue #135 tracks the scale-back-up plan. Each step is independently reversible in minutes:
- Pool autoscaler back to \`min=1, max=2\` → restores HA on the gateway path
- Re-enable Managed Redis when cross-AZ becomes a need
- Postgres tier was untouched — already minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)