### PR TITLE
DSAR exports: meaningful download filename via Content-Disposition

### DIFF
--- a/internal/compliance/export.go
+++ b/internal/compliance/export.go
@@ -251,8 +251,89 @@ func (s *ExportService) MarkFailed(ctx context.Context, exportID, errMsg string)
 }
 
 // GenerateDownloadURL creates a presigned S3 URL for a completed export.
-func (s *ExportService) GenerateDownloadURL(ctx context.Context, bucket, s3Key string) (string, error) {
-	return s.S3.GeneratePresignedDownloadURL(ctx, bucket, s3Key, 1*time.Hour)
+// The URL carries a `Content-Disposition: attachment; filename=…` directive
+// so the browser saves the zip with a recognisable name (project slug +
+// scope + date) instead of the export UUID. Falls back to the S3 key's
+// basename if the project lookup fails — the URL still works, only the
+// suggested filename is generic.
+func (s *ExportService) GenerateDownloadURL(ctx context.Context, bucket string, req *ExportRequest) (string, error) {
+	if req == nil || req.S3Key == nil || *req.S3Key == "" {
+		return "", fmt.Errorf("export request has no s3 key")
+	}
+	filename := s.buildExportFilename(ctx, req)
+	return s.S3.GeneratePresignedDownloadURLAs(ctx, bucket, *req.S3Key, 1*time.Hour, filename)
+}
+
+// buildExportFilename derives a human-readable filename for a DSAR
+// download. Format:
+//
+//	eurobase-<slug>-<scope>-<YYYY-MM-DD>.zip
+//
+// where <scope> is `project` for a tenant export or `user-<short>` for
+// a per-user export. The slug comes from public.projects; if the
+// lookup fails we use the project_id's first 8 chars as a fallback so
+// the file still has something distinctive in the name.
+func (s *ExportService) buildExportFilename(ctx context.Context, req *ExportRequest) string {
+	slug := s.lookupProjectSlug(ctx, req.ProjectID)
+	if slug == "" {
+		slug = shortID(req.ProjectID)
+	}
+
+	scope := "project"
+	if req.UserID != nil && *req.UserID != "" {
+		scope = "user-" + shortID(*req.UserID)
+	}
+
+	date := req.CreatedAt.UTC().Format("2006-01-02")
+	return fmt.Sprintf("eurobase-%s-%s-%s.zip", sanitiseFilenamePart(slug), scope, date)
+}
+
+// lookupProjectSlug fetches the slug for a project. Returns "" on any
+// error — the caller falls back to the project_id prefix. Best-effort:
+// the download URL itself still works regardless.
+func (s *ExportService) lookupProjectSlug(ctx context.Context, projectID string) string {
+	var slug string
+	err := s.Pool.QueryRow(ctx,
+		`SELECT slug FROM projects WHERE id = $1`, projectID,
+	).Scan(&slug)
+	if err != nil {
+		return ""
+	}
+	return slug
+}
+
+// shortID returns the first 8 characters of a UUID-shaped id, or the
+// full string if it's shorter. Used as a stable, recognisable handle
+// in the filename when we can't or don't want to leak the full UUID.
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// sanitiseFilenamePart strips characters that are awkward in a
+// filename or in a `Content-Disposition` header. Quotes, slashes,
+// backslashes, and control chars go. Whitespace collapses to '-'.
+// We're already starting from a slug, but defence-in-depth.
+func sanitiseFilenamePart(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '"' || r == '\\' || r == '/' || r < 0x20 || r == 0x7f:
+			// drop
+		case r == ' ' || r == '\t':
+			b.WriteRune('-')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if out == "" {
+		out = "project"
+	}
+	return out
 }
 
 // CleanupExpired deletes expired export records and their S3 objects.

--- a/internal/compliance/export_handler.go
+++ b/internal/compliance/export_handler.go
@@ -210,7 +210,7 @@ func HandleListExports(exportSvc *ExportService) http.HandlerFunc {
 		if bucket != "" {
 			for i := range exports {
 				if exports[i].Status == "completed" && exports[i].S3Key != nil {
-					url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, *exports[i].S3Key)
+					url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, &exports[i])
 					if err == nil {
 						exports[i].DownloadURL = url
 					}
@@ -239,7 +239,7 @@ func HandleGetExport(exportSvc *ExportService) http.HandlerFunc {
 			var bucket string
 			_ = exportSvc.Pool.QueryRow(r.Context(), `SELECT s3_bucket FROM projects WHERE id = $1`, projectID).Scan(&bucket)
 			if bucket != "" {
-				url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, *req.S3Key)
+				url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, req)
 				if err == nil {
 					req.DownloadURL = url
 				}
@@ -364,7 +364,7 @@ func HandleSelfServeExportStatus(pool *pgxpool.Pool, s3 *storage.S3Client, audit
 			var bucket string
 			_ = pool.QueryRow(r.Context(), `SELECT s3_bucket FROM projects WHERE id = $1`, pc.ProjectID).Scan(&bucket)
 			if bucket != "" {
-				url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, *req.S3Key)
+				url, err := exportSvc.GenerateDownloadURL(r.Context(), bucket, req)
 				if err == nil {
 					req.DownloadURL = url
 				}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -313,15 +313,34 @@ func (s *S3Client) GeneratePresignedUploadURL(ctx context.Context, bucketName, k
 // GeneratePresignedDownloadURL creates a pre-signed GET URL for direct client
 // downloads. Default expiry is 1 hour if expiry <= 0.
 func (s *S3Client) GeneratePresignedDownloadURL(ctx context.Context, bucketName, key string, expiry time.Duration) (string, error) {
+	return s.GeneratePresignedDownloadURLAs(ctx, bucketName, key, expiry, "")
+}
+
+// GeneratePresignedDownloadURLAs is like GeneratePresignedDownloadURL but
+// embeds a `Content-Disposition: attachment; filename="…"` directive in
+// the presigned URL via the `response-content-disposition` query
+// parameter. When the browser follows the link, S3 echoes the header
+// back and the user gets a download with the suggested name instead of
+// the opaque S3 key (which is the export's UUID for DSAR zips).
+//
+// suggestedFilename is set verbatim; callers are responsible for
+// sanitising any characters that would break a filename or HTTP header.
+// Pass "" to fall back to the S3 key's basename (browser default).
+func (s *S3Client) GeneratePresignedDownloadURLAs(ctx context.Context, bucketName, key string, expiry time.Duration, suggestedFilename string) (string, error) {
 	if expiry <= 0 {
 		expiry = 1 * time.Hour
 	}
 
-	slog.Info("generating presigned download URL", "bucket", bucketName, "key", key, "expiry", expiry)
+	slog.Info("generating presigned download URL", "bucket", bucketName, "key", key, "expiry", expiry, "filename", suggestedFilename)
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
+	}
+	if suggestedFilename != "" {
+		input.ResponseContentDisposition = aws.String(
+			fmt.Sprintf(`attachment; filename="%s"`, suggestedFilename),
+		)
 	}
 
 	presigned, err := s.presignClient.PresignGetObject(ctx, input, s3.WithPresignExpires(expiry))


### PR DESCRIPTION
Today the **Download** link on the Compliance → Data Export page saves the file as the raw export UUID (e.g. \`7b3c…fc1a.zip\`). After three or four exports across projects + dates, you have a Downloads folder full of indistinguishable GUIDs.

## Fix

Embed \`Content-Disposition: attachment; filename=\"…\"\` in the presigned S3 URL via the \`response-content-disposition\` query parameter. S3 echoes the header back at download time, so the browser saves the file with the suggested name regardless of the S3 key. No frontend changes needed.

## Filename format

\`eurobase-<slug>-<scope>-<YYYY-MM-DD>.zip\`

- \`<slug>\` — \`projects.slug\` (e.g. \`livestylist\`). Falls back to the first 8 chars of \`project_id\` if the slug lookup fails.
- \`<scope>\` — \`project\` for a full-tenant export, \`user-<short>\` for a per-user export.
- \`<date>\` — the export's \`created_at\`, UTC, ISO-8601 date.

Examples:

\`\`\`
eurobase-livestylist-project-2026-05-16.zip
eurobase-superapp-user-a1b2c3d4-2026-05-12.zip
\`\`\`

## What changed

- \`internal/storage/s3.go\` — new \`GeneratePresignedDownloadURLAs\` accepting a suggested filename; sets \`ResponseContentDisposition\`. Original \`GeneratePresignedDownloadURL\` stays as a no-rename wrapper so the storage SDK + functions internal handler are unaffected.
- \`internal/compliance/export.go\` — \`GenerateDownloadURL\` signature changes from \`(ctx, bucket, s3Key)\` to \`(ctx, bucket, *ExportRequest)\` so it can derive scope from \`UserID\` and look up the slug. New helpers \`buildExportFilename\`, \`lookupProjectSlug\`, \`shortID\`, \`sanitiseFilenamePart\`.
- \`internal/compliance/export_handler.go\` — three call sites pass the \`ExportRequest\` pointer instead of \`*req.S3Key\`.
- \`sanitiseFilenamePart\` drops quotes/slashes/control chars and collapses whitespace to \`-\` — defence-in-depth on the Content-Disposition header.

## Test plan

- [x] \`go build ./... && go test ./internal/storage/...\` clean
- [ ] Merge + deploy
- [ ] Click Download on a completed export → file saves as \`eurobase-<slug>-project-<date>.zip\`
- [ ] Trigger a per-user export → file saves as \`eurobase-<slug>-user-<short>-<date>.zip\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)