### PR TITLE
SDK 0.4.0: eb.auth.exportMyData() + getMyExport() for self-serve DSAR

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eurobase/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Eurobase TypeScript SDK — EU-sovereign Backend-as-a-Service. Auth, database, storage, realtime, functions, vault, and schema DDL.",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc && node test/fix-dist-imports.mjs",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node test/token-propagation.mjs && node test/realtime-url.mjs && node test/schedules.mjs"
+    "test": "npm run build && node test/token-propagation.mjs && node test/realtime-url.mjs && node test/schedules.mjs && node test/auth-export.mjs"
   },
   "keywords": [
     "eurobase",

--- a/sdk/js/src/auth.ts
+++ b/sdk/js/src/auth.ts
@@ -41,6 +41,29 @@ export interface SignInCredentials {
 export type AuthEvent = 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED'
 export type AuthStateChangeCallback = (event: AuthEvent, session: AuthSession | null) => void
 
+/** Status of an end-user-initiated DSAR export (Article 15/20). */
+export type ExportStatus = 'pending' | 'running' | 'completed' | 'failed'
+
+/** A row from POST /v1/auth/me/export or GET /v1/auth/me/export/{id}. */
+export interface ExportRequest {
+  id: string
+  project_id: string
+  /** Always the signed-in user's id for self-serve exports. */
+  user_id?: string
+  status: ExportStatus
+  format: 'json' | 'csv'
+  /** Only set when status === 'completed'. Presigned, 1h TTL. */
+  download_url?: string
+  /** Set when status === 'failed'. */
+  error?: string
+  file_size?: number
+  /** When the download link itself stops working. 7 days after completion. */
+  expires_at?: string
+  started_at?: string
+  completed_at?: string
+  created_at: string
+}
+
 // ---------------------------------------------------------------------------
 // AuthClient
 // ---------------------------------------------------------------------------
@@ -205,6 +228,52 @@ export class AuthClient {
       return { data: null, error: result.error }
     }
     return { data: result, error: null }
+  }
+
+  /**
+   * Request a DSAR export of the signed-in user's own data
+   * (GDPR Article 15 / 20). Returns the queued export request — poll
+   * with `getMyExport(id)` until `status === 'completed'`, then read
+   * `download_url`.
+   *
+   * Rate-limited per user (1 export / 24h on Free; configurable on
+   * higher tiers). The download link, once issued, expires after 7
+   * days.
+   *
+   * @example
+   * const { data } = await eb.auth.exportMyData('json')
+   * if (data) {
+   *   // poll
+   *   const { data: ready } = await eb.auth.getMyExport(data.id)
+   *   if (ready?.status === 'completed') window.location = ready.download_url!
+   * }
+   */
+  async exportMyData(
+    format: 'json' | 'csv' = 'json',
+  ): Promise<{ data: ExportRequest | null; error: string | null }> {
+    const result = await this.http.post('/v1/auth/me/export', { format })
+    if (result?.error) {
+      return { data: null, error: result.error }
+    }
+    return { data: result as ExportRequest, error: null }
+  }
+
+  /**
+   * Fetch the status of an export the signed-in user previously
+   * requested. Returns `status` + (when completed) a presigned
+   * `download_url`.
+   *
+   * Each call generates a fresh 1-hour-TTL download URL — safe to
+   * call repeatedly.
+   */
+  async getMyExport(
+    exportId: string,
+  ): Promise<{ data: ExportRequest | null; error: string | null }> {
+    const result = await this.http.get(`/v1/auth/me/export/${encodeURIComponent(exportId)}`)
+    if (result?.error) {
+      return { data: null, error: result.error }
+    }
+    return { data: result as ExportRequest, error: null }
   }
 
   /** Get the current session (from memory, not server). */

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -51,4 +51,6 @@ export type {
   SignInCredentials,
   AuthEvent,
   AuthStateChangeCallback,
+  ExportRequest,
+  ExportStatus,
 } from './auth'

--- a/sdk/js/test/auth-export.mjs
+++ b/sdk/js/test/auth-export.mjs
@@ -1,0 +1,152 @@
+// Asserts the new eb.auth.exportMyData() / getMyExport() helpers send
+// the right HTTP requests to /v1/auth/me/export and surface the
+// queued/completed ExportRequest cleanly. Uses a stubbed global fetch
+// so the test runs without a real gateway.
+//
+// Run via: npm run build && node test/auth-export.mjs
+
+import { createClient } from '../dist/index.js'
+import assert from 'node:assert/strict'
+
+const URL_BASE = 'https://newtek2.eurobase.app'
+
+let captured = null
+let nextResponse = null
+
+function reset(response) {
+  captured = null
+  nextResponse = response
+}
+
+globalThis.fetch = async (url, init) => {
+  let bodyJson
+  if (init && typeof init.body === 'string') {
+    try { bodyJson = JSON.parse(init.body) } catch { bodyJson = init.body }
+  }
+  captured = {
+    url,
+    method: init?.method ?? 'GET',
+    headers: init?.headers ?? {},
+    body: bodyJson,
+  }
+  const { status = 200, body = {}, headers = { 'content-type': 'application/json' } } = nextResponse ?? {}
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `HTTP ${status}`,
+    headers: { get: (k) => headers[k.toLowerCase()] ?? null },
+    async json() { return body },
+  }
+}
+
+const eb = createClient({ url: URL_BASE, apiKey: 'eb_pk_test' })
+
+// Simulate a signed-in end-user — exportMyData requires the access
+// token, set via the normal setSession path the SDK already exercises.
+eb.auth.setSession({
+  access_token: 'eyJ-end-user-jwt',
+  token_type: 'bearer',
+  expires_in: 3600,
+  refresh_token: 'rt-fake',
+  user: { id: 'u1', email: 'alex@example.com', created_at: '', updated_at: '' },
+})
+
+const queuedRow = {
+  id: 'exp-123',
+  project_id: 'proj-1',
+  user_id: 'u1',
+  status: 'pending',
+  format: 'json',
+  created_at: '2026-05-16T18:00:00Z',
+}
+
+const completedRow = {
+  ...queuedRow,
+  status: 'completed',
+  file_size: 14823,
+  download_url: 'https://s3.fr-par.scw.cloud/.../exp-123?signed=…',
+  started_at: '2026-05-16T18:00:02Z',
+  completed_at: '2026-05-16T18:00:09Z',
+  expires_at: '2026-05-23T18:00:09Z',
+}
+
+// ── 1. exportMyData('json') — POST /v1/auth/me/export with format ──
+{
+  reset({ status: 202, body: queuedRow })
+  const res = await eb.auth.exportMyData('json')
+  assert.equal(captured.method, 'POST')
+  assert.equal(captured.url, `${URL_BASE}/v1/auth/me/export`)
+  assert.deepEqual(captured.body, { format: 'json' })
+  assert.equal(captured.headers.Authorization, 'Bearer eyJ-end-user-jwt')
+  assert.equal(res.error, null)
+  assert.equal(res.data.id, 'exp-123')
+  assert.equal(res.data.status, 'pending')
+  console.log('✓ exportMyData("json"): POST /v1/auth/me/export with body + bearer')
+}
+
+// ── 2. exportMyData() defaults to JSON ─────────────────────────────
+{
+  reset({ status: 202, body: queuedRow })
+  await eb.auth.exportMyData()
+  assert.deepEqual(captured.body, { format: 'json' })
+  console.log('✓ exportMyData(): default format is JSON')
+}
+
+// ── 3. exportMyData('csv') ─────────────────────────────────────────
+{
+  reset({ status: 202, body: { ...queuedRow, format: 'csv' } })
+  const res = await eb.auth.exportMyData('csv')
+  assert.deepEqual(captured.body, { format: 'csv' })
+  assert.equal(res.data.format, 'csv')
+  console.log('✓ exportMyData("csv"): forwards format')
+}
+
+// ── 4. exportMyData() — 429 rate-limit surfaces the error ──────────
+{
+  reset({ status: 429, body: { error: 'rate limit exceeded: 1 export per 24 hours' } })
+  const res = await eb.auth.exportMyData()
+  assert.equal(res.data, null)
+  assert.match(res.error, /rate limit/)
+  console.log('✓ exportMyData: 429 returns error.message, data=null')
+}
+
+// ── 5. getMyExport(id) — GET /v1/auth/me/export/:id ────────────────
+{
+  reset({ status: 200, body: queuedRow })
+  const res = await eb.auth.getMyExport('exp-123')
+  assert.equal(captured.method, 'GET')
+  assert.equal(captured.url, `${URL_BASE}/v1/auth/me/export/exp-123`)
+  assert.equal(captured.headers.Authorization, 'Bearer eyJ-end-user-jwt')
+  assert.equal(res.error, null)
+  assert.equal(res.data.status, 'pending')
+  console.log('✓ getMyExport: GET /v1/auth/me/export/:id')
+}
+
+// ── 6. getMyExport(completedId) → completed row has download_url ───
+{
+  reset({ status: 200, body: completedRow })
+  const res = await eb.auth.getMyExport('exp-123')
+  assert.equal(res.data.status, 'completed')
+  assert.equal(res.data.download_url, completedRow.download_url)
+  assert.equal(res.data.file_size, 14823)
+  console.log('✓ getMyExport: completed row surfaces download_url + size')
+}
+
+// ── 7. URL encoding on the export id ───────────────────────────────
+{
+  reset({ status: 200, body: queuedRow })
+  await eb.auth.getMyExport('weird id/with/slashes')
+  assert.equal(captured.url, `${URL_BASE}/v1/auth/me/export/${encodeURIComponent('weird id/with/slashes')}`)
+  console.log('✓ getMyExport: id is URL-encoded')
+}
+
+// ── 8. getMyExport on a missing id → 404 ───────────────────────────
+{
+  reset({ status: 404, body: { error: 'export not found' } })
+  const res = await eb.auth.getMyExport('nope')
+  assert.equal(res.data, null)
+  assert.match(res.error, /not found/)
+  console.log('✓ getMyExport: 404 returns error, data=null')
+}
+
+console.log('\nAll auth-export SDK tests passed.')


### PR DESCRIPTION
The backend routes for end-user-initiated DSAR exports (\`POST /v1/auth/me/export\`, \`GET /v1/auth/me/export/{id}\`) have been live since DSAR shipped. The SDK never wrapped them — apps that wanted to give their end-users a \"Download my data\" button had to hand-roll \`fetch\` + access-token plumbing.

This adds two methods to \`AuthClient\`:

\`\`\`ts
eb.auth.exportMyData(format)        // POST /v1/auth/me/export
eb.auth.getMyExport(exportId)       // GET  /v1/auth/me/export/:id
\`\`\`

Plus matching types: \`ExportRequest\`, \`ExportStatus\`. Re-exported from \`index.ts\`.

## Usage

\`\`\`ts
const { data } = await eb.auth.exportMyData('json')
if (data) {
  // poll until ready — small projects complete in seconds, big tenants in minutes
  const { data: ready } = await eb.auth.getMyExport(data.id)
  if (ready?.status === 'completed') {
    window.location = ready.download_url!
  }
}
\`\`\`

The polling loop is left to the caller — apps know whether they want a tight poll, a push notification, or an email-on-ready.

## Test coverage

8 cases in \`test/auth-export.mjs\` against a stubbed global fetch:

- POST shape (URL, method, body, bearer header)
- Default format is JSON; csv forwarded
- 429 surfaces \`error.message\`, \`data=null\`
- GET shape with URL encoding of the export id
- Completed row exposes \`download_url\` + \`file_size\`
- 404 surfaces error, data=null

All passing locally.

## Version bump

\`0.3.0\` → \`0.4.0\`. New public surface on \`AuthClient\`, minor bump per semver. \`test\` script in \`package.json\` adds the new file.

## Why this matters

This unblocks the LinkedIn compliance post claim: \"End-users can self-serve via the SDK (\`eb.auth.exportMyData()\`). Rate-limited, audited, no admin in the loop.\" Without this PR that line would be aspirational; with it, it's accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)