### PR TITLE
SDK README + CHANGELOG: cover schedules (0.3.0) and auth.exportMyData (0.4.0)

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,0 +1,44 @@
+# @eurobase/sdk — CHANGELOG
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 — 2026-05-17
+
+### Added
+
+- **`eb.auth.exportMyData(format)`** and **`eb.auth.getMyExport(exportId)`** — self-serve DSAR exports for end-users (GDPR Article 15 / 20). The signed-in user queues an export of their own data and polls until ready. Rate-limited per user (default: 1 export / 24 hours).
+- New types `ExportRequest` and `ExportStatus` re-exported from the package root.
+
+### Notes
+
+- Backend routes (`POST /v1/auth/me/export`, `GET /v1/auth/me/export/{id}`) have been live since the DSAR feature shipped — this release just adds the typed SDK helpers so apps don't need to hand-roll `fetch` + access-token plumbing for a "Download my data" button.
+
+## 0.3.0 — 2026-05-12
+
+### Added
+
+- **`eb.functions.schedules`** — control-plane API for cron schedules attached to deployed edge functions. Closes the gap that forced developers to declare schedules through the dashboard separately from the function code (which lived in their repo).
+  - `create(name, spec)` / `update(name, partialSpec)` / `get(name)` / `list()` / `delete(name)`
+  - `createOrUpdate(name, spec)` for idempotent provisioning scripts
+  - Discriminated `ScheduleError` with `code: 'already_exists' | 'not_found' | 'forbidden' | 'invalid'` so callers can branch on collisions cleanly.
+- Schedules require a secret API key (`eb_sk_*`) — control-plane writes are gated server-side.
+- Locked-in semantics: POSIX 5-field cron only, evaluated in the schedule's `timezone` (defaults to UTC); missed ticks during downtime dropped (no backfill); no overlap protection between ticks.
+
+### Notes
+
+- Function action_type extended to `function` on the backend so schedules can fire deployed edge functions directly (in addition to SQL and RPC actions).
+
+## 0.2.3 — 2026-05-11
+
+### Fixed
+
+- **Realtime WebSocket URL** now passes `project_id` as a query parameter, fixing #62 where the gateway couldn't route events to the right project for end-user JWT realtime subscriptions.
+- New `buildWebSocketURL()` helper on `RealtimeClient` so unit tests can assert the URL shape without spinning up a real socket.
+
+## 0.2.2 — earlier
+
+- Token propagation, realtime, edge function invocation, vault, DDL surface — see git history.
+
+---
+
+If you upgraded across multiple versions: the SDK is additive across 0.2 → 0.4. No breaking signature changes; the new methods are net-new namespaces on existing clients (`functions.schedules`, `auth.exportMyData`).

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -74,6 +74,27 @@ await eb.auth.signOut()
 
 Sessions are automatically persisted to `localStorage` (in browsers) and refreshed before expiry.
 
+### Self-Serve Data Export (GDPR Article 15 / 20)
+
+Let signed-in end-users export their own data as a zip — rows from every table that references them, plus their auth record. Useful for "Download my data" buttons in privacy / settings pages.
+
+```ts
+// Request the export (async — small projects complete in seconds,
+// larger tenants take minutes). Rate-limited per user (default:
+// 1 export per 24 hours).
+const { data, error } = await eb.auth.exportMyData('json')   // or 'csv'
+if (data) {
+  // Poll until ready. Each call returns a fresh 1h presigned download_url
+  // when status === 'completed'.
+  const { data: ready } = await eb.auth.getMyExport(data.id)
+  if (ready?.status === 'completed') {
+    window.location.href = ready.download_url!
+  }
+}
+```
+
+The polling loop is left to the caller — apps know whether they want a tight poll, a push notification, or email-on-ready.
+
 ## Database
 
 ```ts
@@ -263,6 +284,30 @@ const { data } = await eb.functions.invoke('webhook-proxy', {
 })
 ```
 
+### Scheduled Functions (cron)
+
+Declare a function's schedule from the same repo that ships the function. Requires a secret API key (`eb_sk_*`) — schedules are control-plane state.
+
+```ts
+await eb.functions.schedules.create('purge-expired-images', {
+  functionName: 'purge-expired-images',  // must already be deployed
+  cron: '0 4 * * *',                     // POSIX 5-field
+  timezone: 'UTC',                        // optional IANA tz
+  description: 'Daily purge of session_images past 24h TTL',
+})
+
+// Idempotent provisioning — create-or-update
+await eb.functions.schedules.createOrUpdate('purge-expired-images', { ... })
+
+// List / get / update / delete
+const { data } = await eb.functions.schedules.list()
+const { data } = await eb.functions.schedules.get('purge-expired-images')
+await eb.functions.schedules.update('purge-expired-images', { enabled: false })
+await eb.functions.schedules.delete('purge-expired-images')
+```
+
+`create()` returns `{ error: { code: 'already_exists' } }` (HTTP 409) if a schedule with the same name exists; use `update()` or `createOrUpdate()` to change one. Missed ticks during downtime are dropped (no backfill). Each tick is independent — no overlap protection in v1.
+
 ## Vault
 
 ```ts
@@ -298,16 +343,25 @@ import type {
   QueryResult,
   AuthUser,
   AuthSession,
+  ExportRequest,
+  ExportStatus,
   RealtimeEvent,
   ObjectInfo,
   VaultSecret,
   FunctionInvokeOptions,
+  ScheduleSpec,
+  ScheduleRow,
+  ScheduleError,
 } from '@eurobase/sdk'
 ```
 
 ## EU Sovereignty
 
-All data processed through the Eurobase SDK stays on EU infrastructure (Scaleway, France). No US CLOUD Act exposure. GDPR-compliant by design.
+All data processed through the Eurobase SDK stays in EU jurisdiction (Scaleway, France). GDPR-compliant by design.
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md).
 
 ## License
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ]
 }


### PR DESCRIPTION
README was stuck at 0.2.x coverage. Two major releases shipped without docs:

- \`eb.functions.schedules.*\` (PR #113, 0.3.0)
- \`eb.auth.exportMyData()\` / \`getMyExport()\` (PR #141, 0.4.0, just merged)

This PR closes the doc gap before the next \`npm publish\`.

## README

- **Self-Serve Data Export (GDPR Article 15 / 20)** — new subsection under Authentication. Walks through request → poll → download with the example from the auth doc-comments.
- **Scheduled Functions (cron)** — new subsection under Edge Functions. Covers \`create\` / \`update\` / \`get\` / \`list\` / \`delete\` / \`createOrUpdate\`, the \`already_exists\` discriminated error code, and the locked-in semantics from #113 (POSIX 5-field cron, missed ticks dropped, no overlap protection).
- **TypeScript imports** — adds \`ExportRequest\`, \`ExportStatus\`, \`ScheduleSpec\`, \`ScheduleRow\`, \`ScheduleError\`.
- **EU Sovereignty footer** — drops the \"No US CLOUD Act exposure\" anti-positioning per the standing marketing preference; keeps the factual \"data stays in EU jurisdiction (Scaleway, France) + GDPR by design\" claim.

## CHANGELOG.md (new)

Standard Keep-a-Changelog format covering 0.2.3 → 0.4.0:

- **0.4.0** — \`eb.auth.exportMyData\` / \`getMyExport\` + \`ExportRequest\` / \`ExportStatus\` types
- **0.3.0** — \`eb.functions.schedules.*\`, \`function\` action_type backend changes, discriminated \`ScheduleError\`
- **0.2.3** — realtime URL \`project_id\` fix (#62) + \`buildWebSocketURL()\` helper
- **0.2.2** — earlier (see git history)

Closing note: all three minor versions are additive. No breaking signature changes — new methods live on net-new namespaces (\`functions.schedules\`, \`auth.exportMyData\`).

## package.json

Adds \`CHANGELOG.md\` to the \`files\` array so it ships in the npm tarball. Verified with \`npm pack --dry-run\`:

\`\`\`
npm notice 2.6kB CHANGELOG.md
npm notice 9.8kB README.md
npm notice version: 0.4.0
\`\`\`

## Publish order

Merge this PR **first**, then \`cd sdk/js && npm publish\` from the updated main. Publishing before merging would ship 0.4.0 with the stale 0.2.x README — the npm page renders whatever \`README.md\` was in the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)