### PR TITLE
DSAR: fix "User not found" false negative on user-export request

### DIFF
--- a/internal/compliance/export.go
+++ b/internal/compliance/export.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/eurobase/euroback/internal/audit"
+	edb "github.com/eurobase/euroback/internal/db"
 	"github.com/eurobase/euroback/internal/jobs"
 	"github.com/eurobase/euroback/internal/storage"
 	"github.com/jackc/pgx/v5"
@@ -104,11 +105,15 @@ func (s *ExportService) CreateExportRequest(ctx context.Context, projectID strin
 // to accept any UUID and enqueue a worker even if the user wasn't in
 // the tenant — producing a useless near-empty zip and burning compute.
 //
-// schema_name is resolved from projects in one round-trip; we use a
-// single QueryRow with EXISTS so the call is cheap (~1ms on hot path).
-// quoteIdent guards the schema name even though it comes from a
-// platform-controlled column, on the principle that defence in depth
-// for identifier interpolation is free.
+// schema_name is resolved from projects in one round-trip; the EXISTS
+// query against the tenant's users table runs through edb.RunAsService
+// so app.end_user_role='service' is set for the transaction. Without
+// that GUC, RLS on `<schema>.users` filters every row out (no
+// authenticated end-user context exists here — the actor is the
+// platform admin), and EXISTS would falsely return false even for a
+// user that's clearly present. listEndUsers already uses the same
+// pattern. quoteIdent guards the schema identifier even though it
+// comes from a platform-controlled column, as defence-in-depth.
 func (s *ExportService) UserExistsInTenant(ctx context.Context, projectID, userID string) (bool, error) {
 	var schemaName string
 	err := s.Pool.QueryRow(ctx,
@@ -120,7 +125,9 @@ func (s *ExportService) UserExistsInTenant(ctx context.Context, projectID, userI
 
 	var exists bool
 	q := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s.users WHERE id = $1)`, quoteIdent(schemaName))
-	if err := s.Pool.QueryRow(ctx, q, userID).Scan(&exists); err != nil {
+	if err := edb.RunAsService(ctx, s.Pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, q, userID).Scan(&exists)
+	}); err != nil {
 		return false, fmt.Errorf("check user existence: %w", err)
 	}
 	return exists, nil


### PR DESCRIPTION
Live-repro: on superapp, user \`725764d0-9380-4e21-ba35-0e2df71fc1da\` (\`stefan.gimeson+12@gmail.com\`) is clearly present in the tenant's users table (visible in the search picker, MCP \`runSQL\` returns the row). Clicking **Export User Data** in the new Single-User Export UI from PR #142 returns **\"User not found\" (404)**.

## Root cause

PR #125 added \`UserExistsInTenant\` (issue #102) as a pre-check so bogus UUIDs don't burn worker compute. The check runs a plain \`pool.QueryRow\` against \`<tenant_schema>.users\`:

\`\`\`go
q := fmt.Sprintf(\`SELECT EXISTS (SELECT 1 FROM %s.users WHERE id = $1)\`, quoteIdent(schemaName))
s.Pool.QueryRow(ctx, q, userID).Scan(&exists)
\`\`\`

The tenant's \`users\` table has RLS enabled. The check has **no session-level GUCs** set, so:

- \`app.end_user_id\` is empty (no authenticated end-user — this is a platform-admin path).
- \`app.end_user_role\` is empty (which means \"not service\").

RLS policy filters every row out under those conditions. \`EXISTS\` returns false → handler returns 404.

\`listEndUsers\` — the same endpoint the search picker uses — wraps its query in \`edb.RunAsService\`, which sets \`app.end_user_role='service'\` for the transaction. Per migration 000038, that's the documented RLS bypass for legitimate platform-admin paths. \`RunAsService\`'s docstring explicitly lists \"GDPR export on behalf of a user\" as one of the intended use cases — the export pre-check just never used it.

## Fix

Route the \`EXISTS\` query through \`edb.RunAsService\`. 7-line change, same pattern \`listEndUsers\` already uses. No new SQL, no schema migration.

\`\`\`go
if err := edb.RunAsService(ctx, s.Pool, func(ctx context.Context, tx pgx.Tx) error {
    return tx.QueryRow(ctx, q, userID).Scan(&exists)
}); err != nil { … }
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [ ] Merge + deploy
- [ ] Reproduce the original failure path on superapp / \`stefan.gimeson+12@gmail.com\`:
   1. Search the user → row appears
   2. Click row → confirmation chip shows full UUID
   3. Click **Export User Data** → row added to Export History (no more 404)
- [ ] Re-check with an actually-bogus UUID → 404 (existence check still rejects)

## Why this didn't surface in tests

The Go test suite skips compliance integration tests when \`DATABASE_URL\` isn't set (which it isn't in CI). A real-DB test of \`UserExistsInTenant\` would have caught this — worth adding when the next compliance test pass happens, but this one-line fix is unblocking and shouldn't wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)