### PR TITLE
DSAR cluster: stream zip + audit on failure + rate-limit fix (#99, #100, #101)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,17 +1,16 @@
 # TODO
 
-## Scaleway Infrastructure — Wildcard Subdomain Setup
+## Scaleway Infrastructure — Wildcard Subdomain Setup ✅ DONE (verified 2026-05-18)
 
-These steps are required to make SDK URLs (`{slug}.eurobase.app`) work in production.
+SDK URLs (`{slug}.eurobase.app`) resolve in production.
 
-- [ ] Install [Scaleway cert-manager webhook](https://github.com/scaleway/cert-manager-webhook-scaleway) in the Kapsule cluster
-- [ ] Create `scaleway-credentials` secret in cert-manager namespace with `SCW_ACCESS_KEY` and `SCW_SECRET_KEY`
-- [ ] Add wildcard DNS record: `*.eurobase.app` → ingress load balancer IP (A or CNAME)
-- [ ] Deploy updated `deploy/k8s/ingress.yaml` (wildcard rule + DNS-01 issuer + Certificate resource)
-- [ ] Verify wildcard TLS cert is issued: `kubectl get certificate eurobase-wildcard -n eurobase`
-- [ ] Deploy updated gateway (includes `SubdomainMiddleware`)
-- [ ] Set `DOMAIN_SUFFIX=eurobase.app` in gateway deployment env (or omit — it's the default)
-- [ ] Smoke test: `curl -H "apikey: eb_pk_..." https://{slug}.eurobase.app/v1/db/{table}`
+- [x] Scaleway cert-manager webhook installed (cert-manager ns active)
+- [x] `scaleway-credentials` secret present in cert-manager namespace
+- [x] Wildcard DNS `*.eurobase.app` → `163.172.128.215` (ingress-nginx LB)
+- [x] `deploy/k8s/ingress.yaml` applied — wildcard rule + DNS-01 ClusterIssuer + Certificate
+- [x] `kubectl get certificate eurobase-wildcard -n eurobase` → Ready=True (valid until 2026-06-24)
+- [x] Gateway running with `SubdomainMiddleware`; `DOMAIN_SUFFIX` defaults to `eurobase.app`
+- [x] Smoke: real slug resolves (401 missing apikey), unknown slug returns `{"error":"project not found"}`
 
 ## Scaleway TEM — Transactional Email (Pre-Production)
 

--- a/internal/compliance/export.go
+++ b/internal/compliance/export.go
@@ -2,7 +2,6 @@ package compliance
 
 import (
 	"archive/zip"
-	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -203,12 +202,22 @@ func (s *ExportService) ListExports(ctx context.Context, projectID string, limit
 
 // CheckRateLimit returns true if the rate limit for this export type is exceeded.
 // Tenant: 1 per project per hour. User: 1 per user per 24 hours.
+//
+// Closes #101. The previous query counted every row, including ones
+// that ended in `status = 'failed'`. That punished users for our
+// failures: if a worker crashed (bad schema, S3 outage, OOM), the
+// retry was blocked for 24h. The fix is one predicate — only
+// in-flight (pending/running) and completed exports count toward
+// the budget. A failed export is effectively a no-op and the user
+// can re-request immediately.
 func (s *ExportService) CheckRateLimit(ctx context.Context, projectID string, userID *string) (bool, error) {
 	var count int
 	if userID != nil {
 		err := s.Pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM export_requests
-			 WHERE project_id = $1 AND user_id = $2 AND created_at > now() - interval '24 hours'`,
+			 WHERE project_id = $1 AND user_id = $2
+			   AND status <> 'failed'
+			   AND created_at > now() - interval '24 hours'`,
 			projectID, *userID,
 		).Scan(&count)
 		if err != nil {
@@ -217,7 +226,9 @@ func (s *ExportService) CheckRateLimit(ctx context.Context, projectID string, us
 	} else {
 		err := s.Pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM export_requests
-			 WHERE project_id = $1 AND user_id IS NULL AND created_at > now() - interval '1 hour'`,
+			 WHERE project_id = $1 AND user_id IS NULL
+			   AND status <> 'failed'
+			   AND created_at > now() - interval '1 hour'`,
 			projectID,
 		).Scan(&count)
 		if err != nil {
@@ -471,39 +482,48 @@ type ExportMetadata struct {
 	TotalRows   int       `json:"total_rows"`
 }
 
-// BuildTenantExportZip generates a zip archive of all tenant data.
-func BuildTenantExportZip(ctx context.Context, pool *pgxpool.Pool, schemaName, projectID, exportID, format string) (*bytes.Buffer, int, error) {
-	buf := &bytes.Buffer{}
-	zw := zip.NewWriter(buf)
+// WriteTenantExport streams a tenant-scope export zip into w. Closes
+// #99: the previous BuildTenantExportZip materialised the entire archive
+// in a *bytes.Buffer and accumulated every row of every table into a
+// []map[string]interface{} before zipping — a single tenant with one
+// large table could OOM the worker pod. The streaming variant iterates
+// rows.Next() row-by-row through the zip writer, so memory is bounded
+// by one row + zip compression buffer regardless of table size.
+//
+// Callers pass a temp file or io.Pipe so the zip never lands in RAM.
+// Returns total rows written.
+func WriteTenantExport(ctx context.Context, pool *pgxpool.Pool, w io.Writer, schemaName, projectID, exportID, format string) (int, error) {
+	zw := zip.NewWriter(w)
 	totalRows := 0
 
 	tables, err := ListTenantTables(ctx, pool, schemaName)
 	if err != nil {
-		return nil, 0, err
+		_ = zw.Close()
+		return 0, err
 	}
 
 	for _, table := range tables {
-		rows, err := queryTable(ctx, pool, schemaName, table, "", "")
+		q := fmt.Sprintf(`SELECT * FROM %s.%s LIMIT 100000`, quoteIdent(schemaName), quoteIdent(table))
+		n, err := streamQueryToZip(ctx, pool, zw, q, nil, fmt.Sprintf("tables/%s", table), format)
 		if err != nil {
-			slog.Warn("export: failed to query table", "table", table, "error", err)
-			continue
-		}
-		n, err := writeTableToZip(zw, fmt.Sprintf("tables/%s", table), rows, format)
-		if err != nil {
-			slog.Warn("export: failed to write table", "table", table, "error", err)
+			slog.Warn("export: failed to stream table", "table", table, "error", err)
 			continue
 		}
 		totalRows += n
 	}
 
-	// Audit log for this project
-	auditData, err := queryRaw(ctx, pool,
+	// Audit log for this project. The 10k cap is a soft bound — a
+	// streaming archive could in principle take more, but at 10k
+	// rows the zip is already representative of "what we audited"
+	// and beyond that the recipient is better served by a targeted
+	// query.
+	n, err := streamQueryToZip(ctx, pool, zw,
 		`SELECT id, actor_id, actor_email, action, target_type, target_id, metadata, ip_address, created_at
 		 FROM public.audit_log WHERE project_id = $1 ORDER BY created_at DESC LIMIT 10000`,
-		projectID,
+		[]interface{}{projectID},
+		"_audit_log", format,
 	)
-	if err == nil && len(auditData) > 0 {
-		n, _ := writeTableToZip(zw, "_audit_log", auditData, format)
+	if err == nil {
 		totalRows += n
 	}
 
@@ -518,53 +538,54 @@ func BuildTenantExportZip(ctx context.Context, pool *pgxpool.Pool, schemaName, p
 	writeJSONToZip(zw, "_metadata.json", meta)
 
 	if err := zw.Close(); err != nil {
-		return nil, 0, fmt.Errorf("close zip: %w", err)
+		return totalRows, fmt.Errorf("close zip: %w", err)
 	}
-	return buf, totalRows, nil
+	return totalRows, nil
 }
 
-// BuildUserExportZip generates a zip archive of a specific user's data.
-func BuildUserExportZip(ctx context.Context, pool *pgxpool.Pool, schemaName, projectID, userID, exportID, format string) (*bytes.Buffer, int, error) {
-	buf := &bytes.Buffer{}
-	zw := zip.NewWriter(buf)
+// WriteUserExport streams a per-user export zip into w. Same streaming
+// contract as WriteTenantExport — see #99.
+func WriteUserExport(ctx context.Context, pool *pgxpool.Pool, w io.Writer, schemaName, projectID, userID, exportID, format string) (int, error) {
+	zw := zip.NewWriter(w)
 	totalRows := 0
 
 	// User profile
-	profileData, err := queryTable(ctx, pool, schemaName, "users", "id", userID)
-	if err == nil && len(profileData) > 0 {
-		n, _ := writeTableToZip(zw, "_user_profile", profileData, format)
+	n, err := streamQueryToZip(ctx, pool, zw,
+		fmt.Sprintf(`SELECT * FROM %s.users WHERE id = $1`, quoteIdent(schemaName)),
+		[]interface{}{userID},
+		"_user_profile", format,
+	)
+	if err == nil {
 		totalRows += n
 	}
 
-	// Discover tables with user_id references
 	refs, err := DiscoverUserTables(ctx, pool, schemaName)
 	if err != nil {
-		return nil, 0, err
+		_ = zw.Close()
+		return totalRows, err
 	}
 
 	for _, ref := range refs {
-		rows, err := queryTable(ctx, pool, schemaName, ref.TableName, ref.UserColumn, userID)
+		q := fmt.Sprintf(`SELECT * FROM %s.%s WHERE %s = $1 LIMIT 100000`,
+			quoteIdent(schemaName), quoteIdent(ref.TableName), quoteIdent(ref.UserColumn))
+		n, err := streamQueryToZip(ctx, pool, zw, q, []interface{}{userID}, fmt.Sprintf("tables/%s", ref.TableName), format)
 		if err != nil {
-			slog.Warn("export: failed to query user table", "table", ref.TableName, "error", err)
-			continue
-		}
-		n, err := writeTableToZip(zw, fmt.Sprintf("tables/%s", ref.TableName), rows, format)
-		if err != nil {
+			slog.Warn("export: failed to stream user table", "table", ref.TableName, "error", err)
 			continue
 		}
 		totalRows += n
 	}
 
 	// User's audit entries
-	auditData, err := queryRaw(ctx, pool,
+	n, err = streamQueryToZip(ctx, pool, zw,
 		`SELECT id, actor_id, actor_email, action, target_type, target_id, metadata, ip_address, created_at
 		 FROM public.audit_log
 		 WHERE project_id = $1 AND (actor_id = $2 OR target_id = $2)
 		 ORDER BY created_at DESC LIMIT 5000`,
-		projectID, userID,
+		[]interface{}{projectID, userID},
+		"_audit_log", format,
 	)
-	if err == nil && len(auditData) > 0 {
-		n, _ := writeTableToZip(zw, "_audit_log", auditData, format)
+	if err == nil {
 		totalRows += n
 	}
 
@@ -580,9 +601,9 @@ func BuildUserExportZip(ctx context.Context, pool *pgxpool.Pool, schemaName, pro
 	writeJSONToZip(zw, "_metadata.json", meta)
 
 	if err := zw.Close(); err != nil {
-		return nil, 0, fmt.Errorf("close zip: %w", err)
+		return totalRows, fmt.Errorf("close zip: %w", err)
 	}
-	return buf, totalRows, nil
+	return totalRows, nil
 }
 
 // ── Internal helpers ───────────────────────────────────────────────────────
@@ -591,69 +612,118 @@ func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
-func queryTable(ctx context.Context, pool *pgxpool.Pool, schemaName, tableName, filterCol, filterVal string) ([]map[string]interface{}, error) {
-	q := fmt.Sprintf(`SELECT * FROM %s.%s`, quoteIdent(schemaName), quoteIdent(tableName))
-	var args []interface{}
-	if filterCol != "" && filterVal != "" {
-		q += fmt.Sprintf(` WHERE %s = $1`, quoteIdent(filterCol))
-		args = append(args, filterVal)
-	}
-	q += " LIMIT 100000"
-
-	rows, err := pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	descs := rows.FieldDescriptions()
-	var results []map[string]interface{}
-	for rows.Next() {
-		vals, err := rows.Values()
-		if err != nil {
-			return nil, err
-		}
-		row := make(map[string]interface{}, len(descs))
-		for i, desc := range descs {
-			row[string(desc.Name)] = vals[i]
-		}
-		results = append(results, row)
-	}
-	return results, nil
-}
-
-func writeTableToZip(zw *zip.Writer, name string, rows []map[string]interface{}, format string) (int, error) {
-	if len(rows) == 0 {
-		return 0, nil
-	}
-	if format == "csv" {
-		return writeCSVToZip(zw, name+".csv", rows)
-	}
-	return writeJSONRowsToZip(zw, name+".json", rows)
-}
-
-// queryRaw executes a SQL query and returns the results as generic maps.
-func queryRaw(ctx context.Context, pool *pgxpool.Pool, sql string, args ...interface{}) ([]map[string]interface{}, error) {
+// streamQueryToZip opens a zip entry, runs the query, and pipes rows
+// through it without ever holding more than one row in Go memory at a
+// time. Skips creating the entry if the query returns zero rows so
+// empty tables stay out of the archive (matches previous behaviour).
+//
+// JSON output is an indented array — same shape as the old
+// json.Encoder.Encode([]map) so existing consumers (the SDK test
+// fixtures, the console download viewer, any scripts customers wrote
+// against v0.4) don't see a format change. The cost of preserving the
+// array shape over streaming JSON Lines is one extra byte per row plus
+// some bookkeeping.
+func streamQueryToZip(ctx context.Context, pool *pgxpool.Pool, zw *zip.Writer, sql string, args []interface{}, zipPath, format string) (int, error) {
 	rows, err := pool.Query(ctx, sql, args...)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer rows.Close()
 
 	descs := rows.FieldDescriptions()
-	var results []map[string]interface{}
+	cols := make([]string, len(descs))
+	for i, d := range descs {
+		cols[i] = string(d.Name)
+	}
+
+	// Defer the zw.Create() call until we've seen at least one row.
+	// Empty tables don't get a file in the zip.
+	var entry io.Writer
+	var cw *csv.Writer
+	var jsonFirst bool
+	var jsonInited bool
+
+	rowCount := 0
 	for rows.Next() {
 		vals, err := rows.Values()
 		if err != nil {
-			return nil, err
+			return rowCount, err
 		}
-		row := make(map[string]interface{}, len(descs))
-		for i, desc := range descs {
-			row[string(desc.Name)] = vals[i]
+
+		if entry == nil {
+			name := zipPath
+			if format == "csv" {
+				name += ".csv"
+			} else {
+				name += ".json"
+			}
+			entry, err = zw.Create(name)
+			if err != nil {
+				return rowCount, err
+			}
+			if format == "csv" {
+				cw = csv.NewWriter(entry)
+				if err := cw.Write(cols); err != nil {
+					return rowCount, err
+				}
+			} else {
+				if _, err := io.WriteString(entry, "[\n"); err != nil {
+					return rowCount, err
+				}
+				jsonFirst = true
+				jsonInited = true
+			}
 		}
-		results = append(results, row)
+
+		if format == "csv" {
+			record := make([]string, len(cols))
+			for i, c := range cols {
+				_ = c
+				record[i] = formatCSVCell(vals[i])
+			}
+			if err := cw.Write(record); err != nil {
+				return rowCount, err
+			}
+		} else {
+			row := make(map[string]interface{}, len(cols))
+			for i, c := range cols {
+				row[c] = vals[i]
+			}
+			if !jsonFirst {
+				if _, err := io.WriteString(entry, ",\n"); err != nil {
+					return rowCount, err
+				}
+			}
+			jsonFirst = false
+			b, err := json.MarshalIndent(row, "  ", "  ")
+			if err != nil {
+				return rowCount, err
+			}
+			if _, err := io.WriteString(entry, "  "); err != nil {
+				return rowCount, err
+			}
+			if _, err := entry.Write(b); err != nil {
+				return rowCount, err
+			}
+		}
+		rowCount++
 	}
-	return results, nil
+	if err := rows.Err(); err != nil {
+		return rowCount, err
+	}
+
+	if cw != nil {
+		cw.Flush()
+		if err := cw.Error(); err != nil {
+			return rowCount, err
+		}
+	}
+	if jsonInited {
+		if _, err := io.WriteString(entry, "\n]\n"); err != nil {
+			return rowCount, err
+		}
+	}
+	return rowCount, nil
 }
 
 func writeJSONToZip(zw *zip.Writer, name string, data interface{}) {
@@ -664,55 +734,6 @@ func writeJSONToZip(zw *zip.Writer, name string, data interface{}) {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(data)
-}
-
-func writeJSONRowsToZip(zw *zip.Writer, name string, rows []map[string]interface{}) (int, error) {
-	w, err := zw.Create(name)
-	if err != nil {
-		return 0, err
-	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(rows); err != nil {
-		return 0, err
-	}
-	return len(rows), nil
-}
-
-func writeCSVToZip(zw *zip.Writer, name string, rows []map[string]interface{}) (int, error) {
-	if len(rows) == 0 {
-		return 0, nil
-	}
-	w, err := zw.Create(name)
-	if err != nil {
-		return 0, err
-	}
-	return writeCSV(w, rows)
-}
-
-func writeCSV(w io.Writer, rows []map[string]interface{}) (int, error) {
-	if len(rows) == 0 {
-		return 0, nil
-	}
-
-	// Collect column names from first row (stable order).
-	var cols []string
-	for k := range rows[0] {
-		cols = append(cols, k)
-	}
-
-	cw := csv.NewWriter(w)
-	_ = cw.Write(cols)
-
-	for _, row := range rows {
-		record := make([]string, len(cols))
-		for i, col := range cols {
-			record[i] = formatCSVCell(row[col])
-		}
-		_ = cw.Write(record)
-	}
-	cw.Flush()
-	return len(rows), cw.Error()
 }
 
 // formatCSVCell renders one column value for the DSAR CSV export.

--- a/internal/compliance/export.go
+++ b/internal/compliance/export.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/eurobase/euroback/internal/audit"
+	edb "github.com/eurobase/euroback/internal/db"
 	"github.com/eurobase/euroback/internal/jobs"
 	"github.com/eurobase/euroback/internal/storage"
 	"github.com/jackc/pgx/v5"
@@ -104,11 +105,15 @@ func (s *ExportService) CreateExportRequest(ctx context.Context, projectID strin
 // to accept any UUID and enqueue a worker even if the user wasn't in
 // the tenant — producing a useless near-empty zip and burning compute.
 //
-// schema_name is resolved from projects in one round-trip; we use a
-// single QueryRow with EXISTS so the call is cheap (~1ms on hot path).
-// quoteIdent guards the schema name even though it comes from a
-// platform-controlled column, on the principle that defence in depth
-// for identifier interpolation is free.
+// schema_name is resolved from projects in one round-trip; the EXISTS
+// query against the tenant's users table runs through edb.RunAsService
+// so app.end_user_role='service' is set for the transaction. Without
+// that GUC, RLS on `<schema>.users` filters every row out (no
+// authenticated end-user context exists here — the actor is the
+// platform admin), and EXISTS would falsely return false even for a
+// user that's clearly present. listEndUsers already uses the same
+// pattern. quoteIdent guards the schema identifier even though it
+// comes from a platform-controlled column, as defence-in-depth.
 func (s *ExportService) UserExistsInTenant(ctx context.Context, projectID, userID string) (bool, error) {
 	var schemaName string
 	err := s.Pool.QueryRow(ctx,
@@ -120,7 +125,9 @@ func (s *ExportService) UserExistsInTenant(ctx context.Context, projectID, userI
 
 	var exists bool
 	q := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s.users WHERE id = $1)`, quoteIdent(schemaName))
-	if err := s.Pool.QueryRow(ctx, q, userID).Scan(&exists); err != nil {
+	if err := edb.RunAsService(ctx, s.Pool, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, q, userID).Scan(&exists)
+	}); err != nil {
 		return false, fmt.Errorf("check user existence: %w", err)
 	}
 	return exists, nil

--- a/internal/compliance/export_handler.go
+++ b/internal/compliance/export_handler.go
@@ -69,6 +69,23 @@ func HandleRequestTenantExport(exportSvc *ExportService) http.HandlerFunc {
 		if err := exportSvc.EnqueueTenantExport(r.Context(), req.ID, projectID, body.Format); err != nil {
 			slog.Error("enqueue tenant export job failed", "error", err)
 			_ = exportSvc.MarkFailed(r.Context(), req.ID, "failed to enqueue job")
+			// Closes #100 (failed-paths follow-up). The request-time
+			// audit row is only written below on success; emit the
+			// failure variant explicitly here so the audit feed
+			// shows what happened from the requester's perspective
+			// (queueing failed → no completion event will follow).
+			if svc := audit.FromContext(r.Context()); svc != nil {
+				svc.Log(r.Context(), projectID, claims.Subject, claims.Email,
+					audit.ActionExportFailed,
+					audit.WithTarget("export", req.ID),
+					audit.WithMetadata(map[string]any{
+						"format": body.Format,
+						"scope":  "tenant",
+						"stage":  "enqueue",
+						"error":  "failed to enqueue job",
+					}),
+					audit.WithIP(r.RemoteAddr))
+			}
 			writeExportError(w, "failed to enqueue export", http.StatusInternalServerError)
 			return
 		}
@@ -153,6 +170,19 @@ func HandleRequestUserExport(exportSvc *ExportService) http.HandlerFunc {
 
 		if err := exportSvc.EnqueueUserExport(r.Context(), req.ID, projectID, body.UserID, body.Format); err != nil {
 			_ = exportSvc.MarkFailed(r.Context(), req.ID, "failed to enqueue job")
+			if svc := audit.FromContext(r.Context()); svc != nil {
+				svc.Log(r.Context(), projectID, claims.Subject, claims.Email,
+					audit.ActionExportFailed,
+					audit.WithTarget("export", req.ID),
+					audit.WithMetadata(map[string]any{
+						"format":         body.Format,
+						"scope":          "user",
+						"target_user_id": body.UserID,
+						"stage":          "enqueue",
+						"error":          "failed to enqueue job",
+					}),
+					audit.WithIP(r.RemoteAddr))
+			}
 			writeExportError(w, "failed to enqueue export", http.StatusInternalServerError)
 			return
 		}
@@ -304,6 +334,22 @@ func HandleSelfServeExport(pool *pgxpool.Pool, s3 *storage.S3Client, auditSvc *a
 
 		if err := exportSvc.EnqueueUserExport(r.Context(), req.ID, pc.ProjectID, userID, body.Format); err != nil {
 			_ = exportSvc.MarkFailed(r.Context(), req.ID, "failed to enqueue job")
+			if auditSvc != nil {
+				email := ""
+				if endUserClaims != nil {
+					email = endUserClaims.Email
+				}
+				auditSvc.Log(r.Context(), pc.ProjectID, userID, email,
+					audit.ActionExportFailed,
+					audit.WithTarget("export", req.ID),
+					audit.WithMetadata(map[string]any{
+						"format": body.Format,
+						"scope":  "user",
+						"stage":  "enqueue",
+						"error":  "failed to enqueue job",
+					}),
+					audit.WithIP(r.RemoteAddr))
+			}
 			writeExportError(w, "failed to enqueue export", http.StatusInternalServerError)
 			return
 		}

--- a/internal/compliance/export_test.go
+++ b/internal/compliance/export_test.go
@@ -1,0 +1,521 @@
+package compliance
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ── #103: formatCSVCell — pure unit tests (no DB) ────────────────────────────
+
+// TestFormatCSVCell_JSONBRoundTrips locks in #103: a JSONB column
+// pulled out as map[string]interface{} must serialise as parseable JSON
+// in the CSV cell, NOT Go's fmt "%v" form (`map[key:val]`).
+func TestFormatCSVCell_JSONBRoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		// We don't compare raw strings because map iteration order is
+		// non-deterministic; instead we re-parse the output as JSON
+		// and verify it's structurally equal.
+		want any
+	}{
+		{
+			name: "jsonb object",
+			in:   map[string]interface{}{"k": "v", "n": float64(7)},
+			want: map[string]interface{}{"k": "v", "n": float64(7)},
+		},
+		{
+			name: "text array",
+			in:   []interface{}{"a", "b", "c"},
+			want: []interface{}{"a", "b", "c"},
+		},
+		{
+			name: "nested",
+			in: map[string]interface{}{
+				"settings": map[string]interface{}{"theme": "dark", "count": float64(2)},
+				"tags":     []interface{}{"x", "y"},
+			},
+			want: map[string]interface{}{
+				"settings": map[string]interface{}{"theme": "dark", "count": float64(2)},
+				"tags":     []interface{}{"x", "y"},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := formatCSVCell(c.in)
+			if s == "" {
+				t.Fatalf("got empty string for input %v", c.in)
+			}
+			if strings.HasPrefix(s, "map[") {
+				t.Fatalf("regression of #103: cell formatted via Go fmt %%v: %q", s)
+			}
+			var got any
+			if err := json.Unmarshal([]byte(s), &got); err != nil {
+				t.Fatalf("cell not parseable as JSON: %v\nraw: %q", err, s)
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(c.want)
+			// Re-marshal both sides to canonicalise.
+			if !bytes.Equal(gotJSON, wantJSON) {
+				t.Errorf("round-trip mismatch:\n got %s\nwant %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestFormatCSVCell_Scalars(t *testing.T) {
+	if got := formatCSVCell(nil); got != "" {
+		t.Errorf("nil: got %q, want empty string", got)
+	}
+	if got := formatCSVCell("hello"); got != "hello" {
+		t.Errorf("string: got %q, want %q", got, "hello")
+	}
+	if got := formatCSVCell([]byte("raw")); got != "raw" {
+		t.Errorf("bytes: got %q, want %q", got, "raw")
+	}
+	if got := formatCSVCell(int64(42)); got != "42" {
+		t.Errorf("int64: got %q, want %q", got, "42")
+	}
+	if got := formatCSVCell(true); got != "true" {
+		t.Errorf("bool: got %q, want %q", got, "true")
+	}
+	ts, _ := time.Parse(time.RFC3339Nano, "2026-05-18T09:00:00Z")
+	if got := formatCSVCell(ts); got != "2026-05-18T09:00:00Z" {
+		t.Errorf("time: got %q, want RFC3339Nano", got)
+	}
+}
+
+// ── #99: streaming WriteTenantExport — DB-backed ─────────────────────────────
+
+// TestWriteTenantExport_StreamsZipStructure exercises the full
+// streaming pipeline against a real Postgres so the bug-fix is wired
+// to the same SQL path production uses. Skipped in -short mode.
+//
+// What we assert:
+//   - The returned io.Writer (a bytes.Buffer here, a temp file in prod)
+//     contains a valid zip archive
+//   - That archive has the expected entries (tables/<name>.json,
+//     _audit_log.json, _metadata.json)
+//   - Per-table JSON entries are parseable arrays of objects with
+//     the rows we inserted (regression guard for the JSON-array
+//     streaming format)
+//   - CSV entries are valid CSV with the right header + row count
+//   - Total row count returned matches reality
+func TestWriteTenantExport_StreamsZipStructure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openTestPool(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	schema, projectID, cleanup := setupExportFixture(t, pool)
+	defer cleanup()
+
+	for _, format := range []string{"json", "csv"} {
+		t.Run("format="+format, func(t *testing.T) {
+			var buf bytes.Buffer
+			total, err := WriteTenantExport(ctx, pool, &buf, schema, projectID, "exp-"+format, format)
+			if err != nil {
+				t.Fatalf("WriteTenantExport: %v", err)
+			}
+			if total < 3 {
+				t.Fatalf("expected ≥3 rows total (2 todos + 1 user), got %d", total)
+			}
+
+			zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			if err != nil {
+				t.Fatalf("zip not parseable: %v", err)
+			}
+
+			ext := "." + format
+			wantEntries := []string{"tables/todos" + ext, "tables/users" + ext, "_metadata.json"}
+			gotEntries := map[string]*zip.File{}
+			for _, f := range zr.File {
+				gotEntries[f.Name] = f
+			}
+			for _, name := range wantEntries {
+				if _, ok := gotEntries[name]; !ok {
+					t.Errorf("missing zip entry %q", name)
+				}
+			}
+
+			// Spot-check the todos file is well-formed.
+			f, ok := gotEntries["tables/todos"+ext]
+			if !ok {
+				t.Fatalf("no todos entry in zip; have: %v", keysOf(gotEntries))
+			}
+			rc, _ := f.Open()
+			body, _ := io.ReadAll(rc)
+			rc.Close()
+			switch format {
+			case "json":
+				var rows []map[string]interface{}
+				if err := json.Unmarshal(body, &rows); err != nil {
+					t.Fatalf("todos.json not array of objects: %v\nbody:\n%s", err, body)
+				}
+				if len(rows) != 2 {
+					t.Errorf("todos.json: got %d rows, want 2", len(rows))
+				}
+			case "csv":
+				rdr := csv.NewReader(bytes.NewReader(body))
+				records, err := rdr.ReadAll()
+				if err != nil {
+					t.Fatalf("todos.csv not parseable: %v", err)
+				}
+				if len(records) != 3 { // header + 2 rows
+					t.Errorf("todos.csv: got %d records (incl header), want 3", len(records))
+				}
+			}
+
+			// Spot-check metadata.
+			fm, ok := gotEntries["_metadata.json"]
+			if !ok {
+				t.Fatalf("no _metadata.json in zip")
+			}
+			rc, _ = fm.Open()
+			body, _ = io.ReadAll(rc)
+			rc.Close()
+			var meta ExportMetadata
+			if err := json.Unmarshal(body, &meta); err != nil {
+				t.Fatalf("_metadata.json: %v\nbody:\n%s", err, body)
+			}
+			if meta.ProjectID != projectID {
+				t.Errorf("metadata project_id: got %q want %q", meta.ProjectID, projectID)
+			}
+			if meta.Format != format {
+				t.Errorf("metadata format: got %q want %q", meta.Format, format)
+			}
+		})
+	}
+}
+
+// TestWriteUserExport_FiltersToOneUser locks in the per-user export
+// scope: a per-user zip must contain only that user's profile row and
+// only rows they own from tables with a user_id column.
+func TestWriteUserExport_FiltersToOneUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openTestPool(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	schema, projectID, cleanup := setupExportFixture(t, pool)
+	defer cleanup()
+
+	// The fixture inserts two todos owned by user A and one by user B.
+	// A user-scoped export for A should only contain A's two.
+	var userAID string
+	if err := pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT id FROM %s.users WHERE email = $1`, quoteIdent(schema)),
+		"a@test.local",
+	).Scan(&userAID); err != nil {
+		t.Fatalf("lookup user A: %v", err)
+	}
+
+	var buf bytes.Buffer
+	total, err := WriteUserExport(ctx, pool, &buf, schema, projectID, userAID, "exp-user", "json")
+	if err != nil {
+		t.Fatalf("WriteUserExport: %v", err)
+	}
+	if total < 1 {
+		t.Fatalf("expected ≥1 row, got %d", total)
+	}
+
+	zr, _ := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	gotEntries := map[string]*zip.File{}
+	for _, f := range zr.File {
+		gotEntries[f.Name] = f
+	}
+	todos, ok := gotEntries["tables/todos.json"]
+	if !ok {
+		t.Fatalf("expected tables/todos.json in user export; have %v", keysOf(gotEntries))
+	}
+	rc, _ := todos.Open()
+	body, _ := io.ReadAll(rc)
+	rc.Close()
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		t.Fatalf("todos.json: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("user export todos: got %d rows, want 2 (user A only)", len(rows))
+	}
+	for _, r := range rows {
+		if r["user_id"] != userAID {
+			t.Errorf("user export leaked another user's row: %v", r)
+		}
+	}
+}
+
+// TestWriteTenantExport_BoundedMemory is a coarse regression guard for
+// the #99 fix. Before the streaming refactor a 5k-row tenant export
+// held every row in RAM plus the entire zip; afterwards memory should
+// be roughly constant. We measure by writing the zip into an io.Writer
+// that simply discards bytes — a counting writer — and verifying we
+// never need to hold the whole thing.
+//
+// We don't try to measure RSS (too flaky); instead the test asserts
+// the function works when streaming to a writer that doesn't expose a
+// .Bytes() / .Len() handle to the caller. Old code path returned a
+// *bytes.Buffer; if anyone reintroduces that pattern, this test won't
+// catch it, but the file-level diff will. The real protection is the
+// type signature: WriteTenantExport now requires io.Writer.
+func TestWriteTenantExport_AcceptsArbitraryWriter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openTestPool(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	schema, projectID, cleanup := setupExportFixture(t, pool)
+	defer cleanup()
+
+	cw := &countingWriter{}
+	total, err := WriteTenantExport(ctx, pool, cw, schema, projectID, "exp-cw", "json")
+	if err != nil {
+		t.Fatalf("WriteTenantExport into counting writer: %v", err)
+	}
+	if total < 3 {
+		t.Errorf("rows: got %d want ≥3", total)
+	}
+	if cw.bytes < 100 {
+		t.Errorf("counting writer received only %d bytes — zip wasn't streamed", cw.bytes)
+	}
+}
+
+// ── #101: CheckRateLimit ignores failed exports ──────────────────────────────
+
+// TestCheckRateLimit_IgnoresFailedExports verifies that a failed export
+// does NOT count against the 24h/1h budget — the bug #101 was that any
+// row in export_requests created in the window counted, so a worker
+// crash locked the user out.
+func TestCheckRateLimit_IgnoresFailedExports(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openTestPool(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	_, projectID, cleanup := setupExportFixture(t, pool)
+	defer cleanup()
+
+	svc := NewExportService(pool, nil, nil)
+
+	// 1. Fresh project, no rows → not limited.
+	if limited, err := svc.CheckRateLimit(ctx, projectID, nil); err != nil || limited {
+		t.Fatalf("fresh project tenant: limited=%v err=%v want false/nil", limited, err)
+	}
+
+	// 2. Insert a failed tenant export → still not limited.
+	failedID := insertExportRequest(t, pool, projectID, nil, "failed")
+	defer deleteExportRequest(t, pool, failedID)
+	if limited, err := svc.CheckRateLimit(ctx, projectID, nil); err != nil || limited {
+		t.Errorf("with 1 failed export: limited=%v err=%v want false/nil (regression of #101)", limited, err)
+	}
+
+	// 3. Insert a completed tenant export → now limited.
+	completedID := insertExportRequest(t, pool, projectID, nil, "completed")
+	defer deleteExportRequest(t, pool, completedID)
+	if limited, err := svc.CheckRateLimit(ctx, projectID, nil); err != nil || !limited {
+		t.Errorf("with 1 completed export: limited=%v err=%v want true/nil", limited, err)
+	}
+
+	// Same shape for user-scope limit.
+	userID := "11111111-1111-1111-1111-111111111111"
+	if limited, _ := svc.CheckRateLimit(ctx, projectID, &userID); limited {
+		t.Errorf("user-scope fresh: limited=true want false")
+	}
+	failedUserID := insertExportRequest(t, pool, projectID, &userID, "failed")
+	defer deleteExportRequest(t, pool, failedUserID)
+	if limited, _ := svc.CheckRateLimit(ctx, projectID, &userID); limited {
+		t.Errorf("user-scope with failed: limited=true want false (regression of #101)")
+	}
+}
+
+// ── #102: UserExistsInTenant ─────────────────────────────────────────────────
+
+// TestUserExistsInTenant_FalseForUnknownUUID locks in #102: random
+// UUIDs must come back as not-existing, so the handler can return 404
+// before enqueueing a useless worker job.
+func TestUserExistsInTenant_TrueFalse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openTestPool(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	schema, projectID, cleanup := setupExportFixture(t, pool)
+	defer cleanup()
+	_ = schema
+
+	svc := NewExportService(pool, nil, nil)
+
+	var userAID string
+	if err := pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT id FROM %s.users WHERE email = $1`, quoteIdent(schema)),
+		"a@test.local",
+	).Scan(&userAID); err != nil {
+		t.Fatalf("lookup user A: %v", err)
+	}
+
+	exists, err := svc.UserExistsInTenant(ctx, projectID, userAID)
+	if err != nil {
+		t.Fatalf("UserExistsInTenant existing: %v", err)
+	}
+	if !exists {
+		t.Error("existing user A: got false, want true (RLS bypass regression — see PR #144)")
+	}
+
+	exists, err = svc.UserExistsInTenant(ctx, projectID, "00000000-0000-0000-0000-000000000000")
+	if err != nil {
+		t.Fatalf("UserExistsInTenant unknown: %v", err)
+	}
+	if exists {
+		t.Error("unknown UUID: got true, want false (regression of #102)")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func openTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		url = "postgres://eurobase_api:localdev@localhost:5433/eurobase?sslmode=disable"
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("cannot connect to %s: %v", url, err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("cannot ping %s: %v", url, err)
+	}
+	return pool
+}
+
+// setupExportFixture stands up a throwaway tenant schema with a users
+// table and a todos table seeded with deterministic data, plus a
+// public.projects row pointing at it. Returns schema, project_id, and
+// a cleanup func that tears it all down.
+//
+// The fixture intentionally uses very small data so tests stay fast.
+// Schema names are randomised per-test so parallel runs don't collide.
+func setupExportFixture(t *testing.T, pool *pgxpool.Pool) (schema, projectID string, cleanup func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Random schema + ids
+	suffix := fmt.Sprintf("dsar_test_%d", time.Now().UnixNano())
+	schema = suffix
+	projectID = randomUUID(t, pool)
+
+	cleanupFn := func() {
+		// Best-effort: drop the schema and the project row.
+		_, _ = pool.Exec(ctx, fmt.Sprintf(`DROP SCHEMA IF EXISTS %s CASCADE`, quoteIdent(schema)))
+		_, _ = pool.Exec(ctx, `DELETE FROM export_requests WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM public.audit_log WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+	}
+
+	// Build the fixture.
+	stmts := []string{
+		fmt.Sprintf(`CREATE SCHEMA %s`, quoteIdent(schema)),
+		fmt.Sprintf(`CREATE TABLE %s.users (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), email text)`, quoteIdent(schema)),
+		fmt.Sprintf(`CREATE TABLE %s.todos (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid, title text, meta jsonb)`, quoteIdent(schema)),
+		fmt.Sprintf(`INSERT INTO %s.users (email) VALUES ('a@test.local'), ('b@test.local')`, quoteIdent(schema)),
+		fmt.Sprintf(`INSERT INTO %s.todos (user_id, title, meta)
+			SELECT id, 'A1', '{"tags": ["x"]}'::jsonb FROM %s.users WHERE email = 'a@test.local'`,
+			quoteIdent(schema), quoteIdent(schema)),
+		fmt.Sprintf(`INSERT INTO %s.todos (user_id, title, meta)
+			SELECT id, 'A2', '{"tags": ["y"]}'::jsonb FROM %s.users WHERE email = 'a@test.local'`,
+			quoteIdent(schema), quoteIdent(schema)),
+		fmt.Sprintf(`INSERT INTO %s.todos (user_id, title, meta)
+			SELECT id, 'B1', '{"tags": ["z"]}'::jsonb FROM %s.users WHERE email = 'b@test.local'`,
+			quoteIdent(schema), quoteIdent(schema)),
+	}
+	for _, s := range stmts {
+		if _, err := pool.Exec(ctx, s); err != nil {
+			cleanupFn()
+			t.Skipf("fixture setup: %v\nstmt: %s", err, s)
+		}
+	}
+
+	// Make the per-tenant users.id visible to UserExistsInTenant.
+	// In production this query goes through edb.RunAsService which sets
+	// `app.end_user_role='service'` — but RLS is only ON for tables
+	// created via the platform migrator. Our test users table has no
+	// policies so plain SELECT works.
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO projects (id, slug, name, schema_name, s3_bucket)
+		 VALUES ($1, 'dsar-test-' || substr($1::text, 1, 8), 'DSAR Test', $2, 'dsar-test-bucket')`,
+		projectID, schema,
+	); err != nil {
+		cleanupFn()
+		t.Skipf("insert project row: %v", err)
+	}
+
+	return schema, projectID, cleanupFn
+}
+
+func randomUUID(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	var id string
+	if err := pool.QueryRow(context.Background(), `SELECT gen_random_uuid()::text`).Scan(&id); err != nil {
+		t.Fatalf("gen_random_uuid: %v", err)
+	}
+	return id
+}
+
+func insertExportRequest(t *testing.T, pool *pgxpool.Pool, projectID string, userID *string, status string) string {
+	t.Helper()
+	var id string
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO export_requests (project_id, user_id, format, requested_by, requested_by_type, status)
+		 VALUES ($1, $2, 'json', $3, 'platform', $4)
+		 RETURNING id`,
+		projectID, userID, "00000000-0000-0000-0000-000000000000", status,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert export_requests (%s): %v", status, err)
+	}
+	return id
+}
+
+func deleteExportRequest(t *testing.T, pool *pgxpool.Pool, id string) {
+	t.Helper()
+	_, _ = pool.Exec(context.Background(), `DELETE FROM export_requests WHERE id = $1`, id)
+}
+
+type countingWriter struct{ bytes int64 }
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.bytes += int64(len(p))
+	return len(p), nil
+}
+
+func keysOf(m map[string]*zip.File) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/workers/export.go
+++ b/internal/workers/export.go
@@ -1,10 +1,11 @@
 package workers
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 
 	"github.com/eurobase/euroback/internal/audit"
 	"github.com/eurobase/euroback/internal/compliance"
@@ -27,32 +28,58 @@ func (w *TenantExportWorker) Work(ctx context.Context, job *river.Job[jobs.Tenan
 	logger := slog.With("export_id", args.ExportID, "project_id", args.ProjectID, "type", "tenant")
 
 	exportSvc := compliance.NewExportService(w.DBPool, w.S3, w.AuditSvc)
+	failExport := func(stage string, err error) {
+		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		// Closes #100 (failed-paths follow-up). Workers run async so
+		// the requester's HTTP response is already returned by the
+		// time we get here; the audit row is the only place a failure
+		// surfaces in the Compliance feed. Actor fields are empty —
+		// the request-time audit row records the human; this entry
+		// records the system event.
+		if w.AuditSvc != nil {
+			w.AuditSvc.Log(ctx, args.ProjectID, "", "",
+				audit.ActionExportFailed,
+				audit.WithTarget("export", args.ExportID),
+				audit.WithMetadata(map[string]any{
+					"scope": "tenant",
+					"stage": stage,
+					"error": err.Error(),
+				}))
+		}
+	}
+
 	if err := exportSvc.MarkRunning(ctx, args.ExportID); err != nil {
 		return fmt.Errorf("mark running: %w", err)
 	}
 
 	schemaName, s3Bucket, err := resolveProject(ctx, w.DBPool, args.ProjectID)
 	if err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		failExport("resolve_project", err)
 		return err
 	}
 
-	logger.Info("building tenant export zip")
-	buf, totalRows, err := compliance.BuildTenantExportZip(ctx, w.DBPool, schemaName, args.ProjectID, args.ExportID, args.Format)
+	logger.Info("streaming tenant export zip to temp file")
+	tmpFile, size, totalRows, err := streamExportToTempFile(
+		ctx, args.ExportID,
+		func(out io.Writer) (int, error) {
+			return compliance.WriteTenantExport(ctx, w.DBPool, out, schemaName, args.ProjectID, args.ExportID, args.Format)
+		},
+	)
 	if err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		failExport("build_zip", err)
 		return fmt.Errorf("build zip: %w", err)
 	}
+	defer cleanupTempFile(tmpFile)
 
 	s3Key := fmt.Sprintf("exports/%s/%s.zip", args.ProjectID, args.ExportID)
-	logger.Info("uploading export to s3", "key", s3Key, "size", buf.Len(), "rows", totalRows)
+	logger.Info("uploading export to s3", "key", s3Key, "size", size, "rows", totalRows)
 
-	if err := w.S3.UploadObject(ctx, s3Bucket, s3Key, bytes.NewReader(buf.Bytes()), "application/zip", int64(buf.Len())); err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+	if err := w.S3.UploadObject(ctx, s3Bucket, s3Key, tmpFile, "application/zip", size); err != nil {
+		failExport("upload", err)
 		return fmt.Errorf("upload: %w", err)
 	}
 
-	if err := exportSvc.MarkCompleted(ctx, args.ExportID, s3Key, int64(buf.Len())); err != nil {
+	if err := exportSvc.MarkCompleted(ctx, args.ExportID, s3Key, size); err != nil {
 		return fmt.Errorf("mark completed: %w", err)
 	}
 
@@ -68,13 +95,13 @@ func (w *TenantExportWorker) Work(ctx context.Context, job *river.Job[jobs.Tenan
 			audit.WithTarget("export", args.ExportID),
 			audit.WithMetadata(map[string]any{
 				"s3_key":    s3Key,
-				"file_size": buf.Len(),
+				"file_size": size,
 				"rows":      totalRows,
 				"scope":     "tenant",
 			}))
 	}
 
-	logger.Info("tenant export completed", "size", buf.Len(), "rows", totalRows)
+	logger.Info("tenant export completed", "size", size, "rows", totalRows)
 	return nil
 }
 
@@ -91,32 +118,53 @@ func (w *UserExportWorker) Work(ctx context.Context, job *river.Job[jobs.UserExp
 	logger := slog.With("export_id", args.ExportID, "project_id", args.ProjectID, "user_id", args.UserID, "type", "user")
 
 	exportSvc := compliance.NewExportService(w.DBPool, w.S3, w.AuditSvc)
+	failExport := func(stage string, err error) {
+		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		if w.AuditSvc != nil {
+			w.AuditSvc.Log(ctx, args.ProjectID, "", "",
+				audit.ActionExportFailed,
+				audit.WithTarget("export", args.ExportID),
+				audit.WithMetadata(map[string]any{
+					"scope":          "user",
+					"target_user_id": args.UserID,
+					"stage":          stage,
+					"error":          err.Error(),
+				}))
+		}
+	}
+
 	if err := exportSvc.MarkRunning(ctx, args.ExportID); err != nil {
 		return fmt.Errorf("mark running: %w", err)
 	}
 
 	schemaName, s3Bucket, err := resolveProject(ctx, w.DBPool, args.ProjectID)
 	if err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		failExport("resolve_project", err)
 		return err
 	}
 
-	logger.Info("building user export zip")
-	buf, totalRows, err := compliance.BuildUserExportZip(ctx, w.DBPool, schemaName, args.ProjectID, args.UserID, args.ExportID, args.Format)
+	logger.Info("streaming user export zip to temp file")
+	tmpFile, size, totalRows, err := streamExportToTempFile(
+		ctx, args.ExportID,
+		func(out io.Writer) (int, error) {
+			return compliance.WriteUserExport(ctx, w.DBPool, out, schemaName, args.ProjectID, args.UserID, args.ExportID, args.Format)
+		},
+	)
 	if err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+		failExport("build_zip", err)
 		return fmt.Errorf("build zip: %w", err)
 	}
+	defer cleanupTempFile(tmpFile)
 
 	s3Key := fmt.Sprintf("exports/%s/users/%s/%s.zip", args.ProjectID, args.UserID, args.ExportID)
-	logger.Info("uploading user export to s3", "key", s3Key, "size", buf.Len(), "rows", totalRows)
+	logger.Info("uploading user export to s3", "key", s3Key, "size", size, "rows", totalRows)
 
-	if err := w.S3.UploadObject(ctx, s3Bucket, s3Key, bytes.NewReader(buf.Bytes()), "application/zip", int64(buf.Len())); err != nil {
-		_ = exportSvc.MarkFailed(ctx, args.ExportID, err.Error())
+	if err := w.S3.UploadObject(ctx, s3Bucket, s3Key, tmpFile, "application/zip", size); err != nil {
+		failExport("upload", err)
 		return fmt.Errorf("upload: %w", err)
 	}
 
-	if err := exportSvc.MarkCompleted(ctx, args.ExportID, s3Key, int64(buf.Len())); err != nil {
+	if err := exportSvc.MarkCompleted(ctx, args.ExportID, s3Key, size); err != nil {
 		return fmt.Errorf("mark completed: %w", err)
 	}
 
@@ -127,15 +175,61 @@ func (w *UserExportWorker) Work(ctx context.Context, job *river.Job[jobs.UserExp
 			audit.WithTarget("export", args.ExportID),
 			audit.WithMetadata(map[string]any{
 				"s3_key":         s3Key,
-				"file_size":      buf.Len(),
+				"file_size":      size,
 				"rows":           totalRows,
 				"scope":          "user",
 				"target_user_id": args.UserID,
 			}))
 	}
 
-	logger.Info("user export completed", "size", buf.Len(), "rows", totalRows)
+	logger.Info("user export completed", "size", size, "rows", totalRows)
 	return nil
+}
+
+// streamExportToTempFile drives one of the compliance.Write*Export
+// streaming functions into a temp file on local disk, then rewinds it
+// for the upload step. Closes #99: the previous Build*ExportZip
+// returned a *bytes.Buffer holding the entire archive in RAM. For a
+// tenant with millions of rows that buffer alone could OOM the worker
+// pod (each row was also kept as a []map[string]interface{} before
+// being zipped). The temp file gives us a bounded-memory pipeline:
+// row → CSV/JSON encoder → zip compressor → disk → S3.
+//
+// The file lives in the OS temp dir (Linux /tmp, K8s emptyDir by
+// default), is removed on exit even on the error path, and the
+// uploaded size comes from Seek(end) rather than buf.Len() — so the
+// size given to S3 always matches the bytes actually streamed.
+func streamExportToTempFile(_ context.Context, exportID string, write func(io.Writer) (int, error)) (*os.File, int64, int, error) {
+	f, err := os.CreateTemp("", "dsar-export-"+exportID+"-*.zip")
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("create temp file: %w", err)
+	}
+	totalRows, err := write(f)
+	if err != nil {
+		cleanupTempFile(f)
+		return nil, 0, 0, err
+	}
+	size, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		cleanupTempFile(f)
+		return nil, 0, 0, fmt.Errorf("seek temp file: %w", err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		cleanupTempFile(f)
+		return nil, 0, 0, fmt.Errorf("rewind temp file: %w", err)
+	}
+	return f, size, totalRows, nil
+}
+
+func cleanupTempFile(f *os.File) {
+	if f == nil {
+		return
+	}
+	name := f.Name()
+	_ = f.Close()
+	if err := os.Remove(name); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove export temp file", "path", name, "error", err)
+	}
 }
 
 func resolveProject(ctx context.Context, pool *pgxpool.Pool, projectID string) (schemaName, s3Bucket string, err error) {

--- a/sdk/js/test/auth-export.mjs
+++ b/sdk/js/test/auth-export.mjs
@@ -150,3 +150,10 @@ const completedRow = {
 }
 
 console.log('\nAll auth-export SDK tests passed.')
+
+// setSession() schedules a setTimeout for the auto-refresh ~1h out;
+// that timer keeps the Node event loop alive and `npm test` would
+// otherwise hang for an hour after this file's last assertion. The
+// other SDK test files never call setSession so they exit cleanly on
+// their own. Explicit signOut() clears the timer.
+await eb.auth.signOut()


### PR DESCRIPTION
## Summary

- **#99** — `BuildTenantExportZip`/`BuildUserExportZip` (returned `*bytes.Buffer`) replaced with `WriteTenantExport`/`WriteUserExport` (`io.Writer` destination). Workers stream into a temp file, then upload the rewound `*os.File` to S3. Memory is bounded by one row + zip buffer regardless of table size.
- **#100 (failed-paths follow-up)** — Three handler enqueue-failure paths and three worker failure stages (`resolve_project`, `build_zip`, `upload`) now emit `compliance.export.failed` with `stage` + `error` metadata. Makes the SDK README's "rate-limited and audited" claim true for the failure path.
- **#101** — `CheckRateLimit` SQL now filters `status <> 'failed'`. A worker crash no longer locks the requester out for 24h.
- **#102, #103 lock-in tests** — Both were fixed in PR #125 but had no regression test. Added pure unit tests for `formatCSVCell` (jsonb maps, arrays, scalars) and an integration test for `UserExistsInTenant` (true for present users, false for random UUIDs).
- **#3** — Verified live (cert Ready=True until 2026-06-24); `docs/TODO.md` ticked, issue closed separately.

### Streaming detail

`streamQueryToZip` is the new single helper for both functions:

```
rows.Next() → row map → CSV writer / manual-JSON encoder → zip entry → io.Writer
```

JSON-array shape (`[{...},{...}]`) preserved on the wire — no consumer change for the SDK, console download, or any scripts customers wrote against v0.4. Empty queries skip the zip entry entirely (matches previous behaviour).

### Drive-bys

- `sdk/js/test/auth-export.mjs`: `setSession()` schedules a refresh-token `setTimeout` ~59 min out that kept Node alive after assertions passed, so `npm test` hung indefinitely. Pre-existing — not regression of this PR — but it was blocking the test suite from completing. Added explicit `await eb.auth.signOut()` at end.

## Files

| File | Change |
|---|---|
| `internal/compliance/export.go` | Streaming refactor; `CheckRateLimit` SQL fix; old `Build*ExportZip` removed |
| `internal/compliance/export_handler.go` | Audit emission on enqueue failure (3 handlers) |
| `internal/workers/export.go` | Temp-file streaming; `failExport` closure for audit on each stage |
| `internal/compliance/export_test.go` | **NEW** — 521 lines, 6 test functions |
| `docs/TODO.md` | #3 wildcard TLS section ticked |
| `sdk/js/test/auth-export.mjs` | Clean Node exit |

## Test plan

- [x] `go test -short ./...` → all 26 packages green
- [x] All 4 SDK test files pass individually (token-propagation, realtime-url, schedules, auth-export)
- [x] `npm test` now completes (was hanging on auth-export.mjs)
- [ ] CI runs full integration suite with `DATABASE_URL` set → `TestCheckRateLimit_IgnoresFailedExports`, `TestUserExistsInTenant_TrueFalse`, `TestWriteTenantExport_StreamsZipStructure`, `TestWriteUserExport_FiltersToOneUser` execute against real Postgres
- [ ] After merge: verify a project DSAR export still works end-to-end on superapp; confirm the audit log shows new entries for any failed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)