### PR TITLE
Email: chunk SendBulk to fit Scaleway TEM 9-recipient quota (#35)

### DIFF
--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -1283,7 +1283,17 @@ export class EurobaseAPI {
 	 * one recipient is supplied the server uses BCC, so recipients do not
 	 * see each other. Superadmin only.
 	 */
-	async adminSendAllowlistEmail(emails: string[], subject: string, bodyHtml: string): Promise<{ status: string; sent: number; bcc: boolean }> {
+	async adminSendAllowlistEmail(
+		emails: string[],
+		subject: string,
+		bodyHtml: string
+	): Promise<{
+		status: 'sent' | 'partial';
+		sent: number;
+		failed: number;
+		errors?: { recipients: string[]; error: string }[];
+		bcc: boolean;
+	}> {
 		return this.fetch('/platform/admin/allowlist/email', {
 			method: 'POST',
 			body: JSON.stringify({ emails, subject, body_html: bodyHtml })

--- a/console/src/routes/(app)/admin/+page.svelte
+++ b/console/src/routes/(app)/admin/+page.svelte
@@ -17,6 +17,12 @@
 	let composeBusy = $state(false);
 	let composeError = $state<string | null>(null);
 	let composeSuccess = $state<string | null>(null);
+	// Closes #35. When some chunks fail (Scaleway TEM quota,
+	// network blip), the API returns status=partial plus an `errors`
+	// array. We capture it here so the operator can see WHICH chunks
+	// didn't go out and retry just those — much better than the
+	// pre-fix "send 9, deselect, send next 9, lather, rinse" loop.
+	let composeFailures = $state<{ recipients: string[]; error: string }[]>([]);
 
 	const INVITATION_TEMPLATE = {
 		subject: "You're invited to Eurobase (closed beta)",
@@ -135,11 +141,24 @@
 		)
 			return;
 		composeBusy = true;
+		composeFailures = [];
 		try {
 			const res = await api.adminSendAllowlistEmail(recipients, composeSubject, composeBody);
-			composeSuccess = `Sent to ${res.sent}${res.bcc ? ' (BCC)' : ''}.`;
+			// Partial success: the server sent SOME chunks, others
+			// failed. Show how many landed + surface the failing
+			// chunks so the operator can retry just those addresses
+			// instead of re-sending to everyone.
+			if (res.status === 'partial') {
+				composeSuccess = `Partial: ${res.sent} sent, ${res.failed} failed${res.bcc ? ' (BCC)' : ''}.`;
+				composeFailures = res.errors ?? [];
+				// Keep the failed addresses selected so the operator
+				// can click Email again to retry just them.
+				selected = new Set(composeFailures.flatMap((e) => e.recipients));
+			} else {
+				composeSuccess = `Sent to ${res.sent}${res.bcc ? ' (BCC)' : ''}.`;
+				selected = new Set();
+			}
 			// Leave modal open so the user can see confirmation; they close manually.
-			selected = new Set();
 		} catch (e: any) {
 			composeError = e?.message ?? 'Send failed';
 		} finally {
@@ -151,6 +170,7 @@
 		composeOpen = false;
 		composeError = null;
 		composeSuccess = null;
+		composeFailures = [];
 	}
 </script>
 
@@ -381,6 +401,21 @@
 				{/if}
 				{#if composeSuccess}
 					<div class="rounded-md bg-green-50 border border-green-200 p-2 text-xs text-green-800">{composeSuccess}</div>
+				{/if}
+				{#if composeFailures.length > 0}
+					<details class="rounded-md border border-amber-200 bg-amber-50 text-xs text-amber-900">
+						<summary class="cursor-pointer px-3 py-2 font-medium">
+							{composeFailures.length} chunk{composeFailures.length === 1 ? '' : 's'} failed — click Email to retry the still-selected addresses
+						</summary>
+						<ul class="border-t border-amber-200 px-3 py-2 space-y-1">
+							{#each composeFailures as f}
+								<li>
+									<div class="font-mono text-[11px] text-amber-800">{f.recipients.join(', ')}</div>
+									<div class="text-[11px] text-amber-700">{f.error}</div>
+								</li>
+							{/each}
+						</ul>
+					</details>
 				{/if}
 			</div>
 

--- a/internal/email/client.go
+++ b/internal/email/client.go
@@ -9,8 +9,37 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 )
+
+// defaultMaxBCC is the upper bound on recipients per TEM POST when we
+// don't have an explicit override. Closes #35. Scaleway TEM caps
+// recipients per message at TemEmailsMaxRecipients (10 on a default
+// domain) — and that quota counts the visible To slot too, so we send
+// 1 To + at most defaultMaxBCC BCCs per chunk. Operators with a raised
+// Scaleway quota set TEM_MAX_RECIPIENTS_PER_MESSAGE to the new limit
+// without a deploy.
+const defaultMaxBCC = 9
+
+// BulkChunkError records a single per-chunk failure during a bulk send.
+// Recipients is the BCC list that didn't go out; Err is the wrapped
+// underlying error (typically a TEM API non-2xx response).
+type BulkChunkError struct {
+	Recipients []string `json:"recipients"`
+	Error      string   `json:"error"`
+}
+
+// BulkResult is the per-call summary of a chunked bulk send. Sent /
+// Failed are recipient counts (not chunk counts) so the UI can surface
+// "12 / 15 delivered" directly. Errors lists the chunks that didn't go
+// out so an operator can retry just those.
+type BulkResult struct {
+	Sent   int              `json:"sent"`
+	Failed int              `json:"failed"`
+	Errors []BulkChunkError `json:"errors,omitempty"`
+}
 
 // EmailClient sends transactional emails via the Scaleway TEM REST API.
 type EmailClient struct {
@@ -115,19 +144,72 @@ func (c *EmailClient) Send(ctx context.Context, to, subject, htmlBody string) er
 	return nil
 }
 
-// SendBulk sends one HTML email to every recipient via BCC so recipients
-// don't see each other's addresses. The visible To is the sender itself
-// (configured fromEmail), which is standard for announcements.
-// Returns early with an error and does NOT send if the client is
-// unconfigured, to avoid silently dropping an admin broadcast.
-func (c *EmailClient) SendBulk(ctx context.Context, bccRecipients []string, subject, htmlBody string) error {
+// SendBulk sends one HTML email to every recipient via BCC so
+// recipients don't see each other's addresses. The visible To is the
+// sender itself (configured fromEmail), which is standard for
+// announcements.
+//
+// Closes #35. The recipient list is split into chunks of at most
+// maxBCCPerMessage(), one TEM POST per chunk. A chunk that fails
+// (network error, TEM 403/429/5xx) is recorded in BulkResult.Errors
+// and the loop continues; this matters because the original behaviour
+// — a single POST with N recipients — returned 403 from TEM the
+// moment N exceeded the per-message quota, dropping the whole send
+// even though up to 10 of the addresses would have gone out fine. The
+// caller decides how to surface partial success; the wrapping error
+// is non-nil only when every chunk failed.
+//
+// Recipients are sent in the order received; ordering matters for
+// audit-trail reproducibility (the first 9 of an alphabetical list
+// will land in chunk 1, etc.).
+func (c *EmailClient) SendBulk(ctx context.Context, bccRecipients []string, subject, htmlBody string) (BulkResult, error) {
+	res := BulkResult{}
 	if !c.Configured() {
-		return fmt.Errorf("email client not configured (TEM credentials missing)")
+		return res, fmt.Errorf("email client not configured (TEM credentials missing)")
 	}
 	if len(bccRecipients) == 0 {
-		return fmt.Errorf("no recipients")
+		return res, fmt.Errorf("no recipients")
 	}
 
+	chunkSize := maxBCCPerMessage()
+	chunks := chunkRecipients(bccRecipients, chunkSize)
+
+	for i, chunk := range chunks {
+		if err := c.sendBulkChunk(ctx, chunk, subject, htmlBody); err != nil {
+			res.Failed += len(chunk)
+			res.Errors = append(res.Errors, BulkChunkError{
+				Recipients: chunk,
+				Error:      err.Error(),
+			})
+			slog.Error("bulk email chunk failed",
+				"chunk_index", i,
+				"chunk_size", len(chunk),
+				"total_chunks", len(chunks),
+				"error", err,
+				"subject", subject,
+			)
+			continue
+		}
+		res.Sent += len(chunk)
+	}
+
+	slog.Info("bulk email completed",
+		"sent", res.Sent,
+		"failed", res.Failed,
+		"chunks", len(chunks),
+		"subject", subject,
+	)
+
+	if res.Sent == 0 {
+		return res, fmt.Errorf("every chunk failed: %d recipients, %d errors", len(bccRecipients), len(res.Errors))
+	}
+	return res, nil
+}
+
+// sendBulkChunk issues one TEM POST for a single chunk of recipients.
+// The chunk size is bounded by the caller (SendBulk) to fit the
+// TemEmailsMaxRecipients quota; this function only does the HTTP.
+func (c *EmailClient) sendBulkChunk(ctx context.Context, bccRecipients []string, subject, htmlBody string) error {
 	bcc := make([]temAddress, 0, len(bccRecipients))
 	for _, r := range bccRecipients {
 		bcc = append(bcc, temAddress{Email: r})
@@ -166,6 +248,42 @@ func (c *EmailClient) SendBulk(ctx context.Context, bccRecipients []string, subj
 		return fmt.Errorf("TEM API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	slog.Info("bulk email sent", "recipients", len(bccRecipients), "subject", subject)
 	return nil
+}
+
+// chunkRecipients splits the recipient list into contiguous chunks of
+// at most size. Stable order: chunk[0] is recipients[0:size], chunk[1]
+// is recipients[size:2*size], etc. Empty input returns an empty
+// slice; size<=0 falls back to defaultMaxBCC so a misconfigured env
+// override can't disable batching entirely.
+func chunkRecipients(recipients []string, size int) [][]string {
+	if size <= 0 {
+		size = defaultMaxBCC
+	}
+	if len(recipients) == 0 {
+		return nil
+	}
+	chunks := make([][]string, 0, (len(recipients)+size-1)/size)
+	for i := 0; i < len(recipients); i += size {
+		end := i + size
+		if end > len(recipients) {
+			end = len(recipients)
+		}
+		chunks = append(chunks, recipients[i:end])
+	}
+	return chunks
+}
+
+// maxBCCPerMessage returns the per-TEM-POST BCC cap. Reads the
+// TEM_MAX_RECIPIENTS_PER_MESSAGE env var and falls back to
+// defaultMaxBCC (9) on missing/invalid values. Operators with a
+// raised Scaleway quota flip this env var; no deploy needed.
+func maxBCCPerMessage() int {
+	if raw := os.Getenv("TEM_MAX_RECIPIENTS_PER_MESSAGE"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+		slog.Warn("ignoring invalid TEM_MAX_RECIPIENTS_PER_MESSAGE", "value", raw)
+	}
+	return defaultMaxBCC
 }

--- a/internal/email/client_test.go
+++ b/internal/email/client_test.go
@@ -1,0 +1,263 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+// Closes #35. Verifies the chunker splits at the right boundaries,
+// the env override picks up, and SendBulk delivers per-chunk
+// continue-on-error semantics.
+
+func TestChunkRecipients(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        []string
+		size      int
+		wantLens  []int // length of each chunk (we don't pin contents — order test below covers that)
+	}{
+		{"empty input", nil, 9, nil},
+		{"empty input, size 0 falls back to default", nil, 0, nil},
+		{"single under cap", []string{"a"}, 9, []int{1}},
+		{"exactly cap", makeAddrs(9), 9, []int{9}},
+		{"one over cap", makeAddrs(10), 9, []int{9, 1}},
+		{"two over cap", makeAddrs(11), 9, []int{9, 2}},
+		{"twenty, cap 9", makeAddrs(20), 9, []int{9, 9, 2}},
+		{"five, cap 2", makeAddrs(5), 2, []int{2, 2, 1}},
+		// cap 0 should NOT mean "everyone in one chunk" — that's exactly the
+		// pre-#35 bug. The chunker falls back to the default so an env
+		// misconfig can't silently disable batching.
+		{"size 0 falls back to default", makeAddrs(15), 0, []int{9, 6}},
+		{"negative size also falls back", makeAddrs(15), -1, []int{9, 6}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chunkRecipients(tc.in, tc.size)
+			if len(got) != len(tc.wantLens) {
+				t.Fatalf("chunk count: got %d, want %d (chunks=%v)", len(got), len(tc.wantLens), got)
+			}
+			for i, c := range got {
+				if len(c) != tc.wantLens[i] {
+					t.Errorf("chunk[%d] size: got %d, want %d", i, len(c), tc.wantLens[i])
+				}
+			}
+		})
+	}
+}
+
+// TestChunkRecipients_PreservesOrder is its own test because the
+// audit trail depends on chunk N containing the same addresses every
+// time. If someone rewrites this in terms of a hash map iteration in
+// future, the test catches it.
+func TestChunkRecipients_PreservesOrder(t *testing.T) {
+	in := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	got := chunkRecipients(in, 4)
+	want := [][]string{
+		{"a", "b", "c", "d"},
+		{"e", "f", "g", "h"},
+		{"i", "j"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMaxBCCPerMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", defaultMaxBCC},
+		{"explicit 20", "20", 20},
+		{"non-numeric falls back", "abc", defaultMaxBCC},
+		{"zero falls back", "0", defaultMaxBCC},
+		{"negative falls back", "-3", defaultMaxBCC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TEM_MAX_RECIPIENTS_PER_MESSAGE", tc.env)
+			if got := maxBCCPerMessage(); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSendBulk_ChunksAndContinuesOnError wires a fake TEM server that
+// fails one specific chunk and succeeds the rest, asserts the
+// per-chunk failure didn't abort the loop, and confirms the
+// BulkResult tallies recipient counts (not chunk counts).
+func TestSendBulk_ChunksAndContinuesOnError(t *testing.T) {
+	// 25 recipients with chunk size 9 → chunks of 9, 9, 7.
+	// We'll fail chunk #2 (the second 9) and let chunks #1 and #3 succeed.
+	addrs := makeAddrs(25)
+	var seen [][]string
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body temRequest
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var rcpts []string
+		for _, a := range body.Bcc {
+			rcpts = append(rcpts, a.Email)
+		}
+		seen = append(seen, rcpts)
+		n := atomic.AddInt32(&hits, 1)
+		if n == 2 {
+			// Simulate TEM 403 quota error on chunk #2.
+			http.Error(w, `{"details":[{"resource":"TemEmailsMaxRecipients"}]}`, http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"emails":[]}`))
+	}))
+	defer srv.Close()
+
+	c := newClientPointingAt(srv.URL)
+	res, err := c.SendBulk(context.Background(), addrs, "subj", "<p>hi</p>")
+	if err != nil {
+		t.Fatalf("unexpected error from SendBulk (some chunks should have succeeded): %v", err)
+	}
+
+	wantSent := 9 + 7   // chunk 1 + chunk 3
+	wantFailed := 9     // chunk 2
+	if res.Sent != wantSent {
+		t.Errorf("Sent: got %d, want %d", res.Sent, wantSent)
+	}
+	if res.Failed != wantFailed {
+		t.Errorf("Failed: got %d, want %d", res.Failed, wantFailed)
+	}
+	if len(res.Errors) != 1 {
+		t.Fatalf("Errors: got %d entries, want 1", len(res.Errors))
+	}
+	if len(res.Errors[0].Recipients) != 9 {
+		t.Errorf("Errors[0].Recipients: got %d, want 9", len(res.Errors[0].Recipients))
+	}
+	if hits != 3 {
+		t.Errorf("expected 3 TEM POSTs, got %d (regression: SendBulk aborted on chunk failure)", hits)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 captured payloads, got %d", len(seen))
+	}
+	// Order property: chunk N contains recipients[(N-1)*9 : N*9].
+	for i, chunk := range seen {
+		startIdx := i * 9
+		endIdx := startIdx + 9
+		if endIdx > len(addrs) {
+			endIdx = len(addrs)
+		}
+		wantChunk := addrs[startIdx:endIdx]
+		if !reflect.DeepEqual(chunk, wantChunk) {
+			t.Errorf("chunk %d: got %v, want %v", i, chunk, wantChunk)
+		}
+	}
+}
+
+// TestSendBulk_AllChunksFail returns an error so the handler can 502.
+// We're not OK with silently logging "0 sent" — that would let a
+// totally-broken TEM look like a partial success to the operator.
+func TestSendBulk_AllChunksFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `down`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newClientPointingAt(srv.URL)
+	res, err := c.SendBulk(context.Background(), makeAddrs(11), "subj", "<p>x</p>")
+	if err == nil {
+		t.Fatal("expected error when every chunk fails, got nil")
+	}
+	if res.Sent != 0 {
+		t.Errorf("Sent: got %d, want 0", res.Sent)
+	}
+	if res.Failed != 11 {
+		t.Errorf("Failed: got %d, want 11", res.Failed)
+	}
+}
+
+func TestSendBulk_SingleChunkUnderCap(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newClientPointingAt(srv.URL)
+	res, err := c.SendBulk(context.Background(), makeAddrs(5), "s", "b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Sent != 5 || res.Failed != 0 || len(res.Errors) != 0 {
+		t.Errorf("partial-result shape: %+v", res)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 TEM POST, got %d", hits)
+	}
+}
+
+func TestSendBulk_Unconfigured(t *testing.T) {
+	// No authToken → Configured() == false. We don't want to silently
+	// no-op an admin broadcast; bubble the error so the caller knows
+	// nothing went out.
+	c := NewEmailClient("", "fr-par", "p", "from@example.com", "Eurobase")
+	_, err := c.SendBulk(context.Background(), []string{"a@example.com"}, "s", "b")
+	if err == nil {
+		t.Fatal("expected error from unconfigured client, got nil")
+	}
+}
+
+func TestSendBulk_EmptyRecipients(t *testing.T) {
+	c := newClientPointingAt("http://unused")
+	_, err := c.SendBulk(context.Background(), nil, "s", "b")
+	if err == nil {
+		t.Fatal("expected error for empty recipients, got nil")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func makeAddrs(n int) []string {
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = string(rune('a'+i)) + "@test.local"
+	}
+	return out
+}
+
+// newClientPointingAt returns an EmailClient whose HTTP requests land
+// at the given test server. We override the URL by hijacking the
+// region field (the path the client builds includes the region in the
+// URL prefix — see SendBulk). For tests we patch httpClient.Transport
+// to a redirect.
+func newClientPointingAt(base string) *EmailClient {
+	c := NewEmailClient("token", "fr-par", "proj-x", "from@example.com", "Eurobase")
+	c.httpClient = &http.Client{
+		Transport: redirectingTransport{base: base},
+	}
+	return c
+}
+
+// redirectingTransport rewrites the request URL so client_test's
+// httptest server gets the request rather than api.scaleway.com.
+// Tests assert on body/headers, not on the URL host.
+type redirectingTransport struct{ base string }
+
+func (rt redirectingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r2 := r.Clone(r.Context())
+	u, _ := http.NewRequest("POST", rt.base+"/tem", nil)
+	r2.URL = u.URL
+	r2.Host = u.URL.Host
+	return http.DefaultTransport.RoundTrip(r2)
+}

--- a/internal/email/client_test.go
+++ b/internal/email/client_test.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -229,9 +230,13 @@ func TestSendBulk_EmptyRecipients(t *testing.T) {
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 func makeAddrs(n int) []string {
+	// Use a printf-formed local-part so the addresses stay valid no
+	// matter how large n grows. Earlier version used
+	// string(rune('a'+i)) which produced non-letter runes ({, |, etc.)
+	// at i>=26.
 	out := make([]string, n)
 	for i := 0; i < n; i++ {
-		out[i] = string(rune('a'+i)) + "@test.local"
+		out[i] = fmt.Sprintf("user%d@test.local", i)
 	}
 	return out
 }

--- a/internal/email/service.go
+++ b/internal/email/service.go
@@ -46,7 +46,11 @@ func (s *EmailService) Configured() bool {
 // Recipients do NOT see each other's addresses. Used by superadmin
 // broadcast features (e.g. beta-allowlist invitations) where a single
 // announcement goes to many people.
-func (s *EmailService) SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) error {
+//
+// Closes #35. Returns a BulkResult so the handler can surface partial
+// success ("8/10 sent · 2 failed") to the console. The error is
+// non-nil only when nothing went out at all.
+func (s *EmailService) SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) (BulkResult, error) {
 	return s.client.SendBulk(ctx, recipients, subject, htmlBody)
 }
 

--- a/internal/tenant/admin_handlers.go
+++ b/internal/tenant/admin_handlers.go
@@ -9,15 +9,17 @@ import (
 	"time"
 
 	"github.com/eurobase/euroback/internal/audit"
+	"github.com/eurobase/euroback/internal/email"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // BulkEmailer is the subset of internal/email.EmailService that admin
-// broadcast needs. Kept as an interface so this package doesn't import
-// internal/email (would be a circular graph through tenant→email→tenant).
+// broadcast needs. Returns a BulkResult so the handler can surface
+// per-chunk success/failure to the console after a chunked TEM send
+// (closes #35).
 type BulkEmailer interface {
-	SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) error
+	SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) (email.BulkResult, error)
 }
 
 // AdminProject is a platform-wide project row returned to superadmins.
@@ -219,10 +221,23 @@ func AdminSendAllowlistEmail(pool *pgxpool.Pool, mailer BulkEmailer) http.Handle
 			return
 		}
 
-		if err := mailer.SendBulkBCC(r.Context(), final, req.Subject, req.BodyHTML); err != nil {
-			slog.Error("admin bulk email failed", "error", err, "count", len(final))
+		result, err := mailer.SendBulkBCC(r.Context(), final, req.Subject, req.BodyHTML)
+		if err != nil && result.Sent == 0 {
+			// Every chunk failed. Return 502 so the console treats it
+			// as a hard failure to retry.
+			slog.Error("admin bulk email: every chunk failed", "error", err, "count", len(final))
 			http.Error(w, `{"error":"send failed: `+err.Error()+`"}`, http.StatusBadGateway)
 			return
+		}
+
+		// status reflects what reached TEM: "sent" when every chunk
+		// went out, "partial" when some chunks landed and some didn't.
+		// The shape (sent / failed / errors) lets the console show
+		// "12 / 15 delivered" and an expandable list of failures so
+		// the operator can retry just the failed addresses.
+		status := "sent"
+		if result.Failed > 0 {
+			status = "partial"
 		}
 
 		if svc := audit.FromContext(r.Context()); svc != nil {
@@ -230,6 +245,8 @@ func AdminSendAllowlistEmail(pool *pgxpool.Pool, mailer BulkEmailer) http.Handle
 			svc.Log(r.Context(), "", actorID, actorEmail, audit.ActionAllowlistEmailed,
 				audit.WithMetadata(map[string]any{
 					"recipient_count": len(final),
+					"sent":            result.Sent,
+					"failed":          result.Failed,
 					"subject":         req.Subject,
 				}),
 				audit.WithIP(r.RemoteAddr))
@@ -237,8 +254,10 @@ func AdminSendAllowlistEmail(pool *pgxpool.Pool, mailer BulkEmailer) http.Handle
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"status": "sent",
-			"sent":   len(final),
+			"status": status,
+			"sent":   result.Sent,
+			"failed": result.Failed,
+			"errors": result.Errors,
 			"bcc":    len(final) > 1,
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #35. The superadmin "Email" button on Platform Admin → Signup Allowlist sent a single TEM request with every selected address in BCC. Scaleway TEM caps per-message recipients at `TemEmailsMaxRecipients` (10 by default, including the visible To slot) — so picking 10+ recipients returned 403 from TEM and the operator had to fall back to selecting nine at a time, sending, deselecting, picking the next nine, etc. The closed-beta allowlist is past 15 entries now, so the workaround hurts every send.

## SendBulk now chunks

- `chunkRecipients(recipients, size)` helper splits the list into chunks of at most `size`. Empty input → no chunks; `size<=0` falls back to the default so an env-typo can't silently disable batching.
- `maxBCCPerMessage()` reads `TEM_MAX_RECIPIENTS_PER_MESSAGE`, defaults to **9**. Operators who get a raised Scaleway quota flip the env var without a redeploy.
- `SendBulk` iterates chunks, issues one TEM POST each via a new `sendBulkChunk()`, accumulates a per-chunk error in `BulkResult.Errors` on failure, and continues. Wrapping error is non-nil only when **every** chunk failed.
- Recipient order is preserved so a given address always lands in the same chunk for a given selection — matters for reproducing what an audit row recorded.

## Partial-success response shape

```json
{
  "status": "sent" | "partial",
  "sent":   <int>,
  "failed": <int>,
  "errors": [{"recipients":[...], "error":"..."}],
  "bcc":    <bool>
}
```

`POST /platform/admin/allowlist/email` returns **502 only when nothing went out at all**; partial success is **HTTP 200 with `status=partial`**. The audit row gets sent/failed counts so the Compliance → Audit Log shows what actually happened, not just "the operator clicked Send."

## Console

- `api.ts` ts type widened.
- `admin/+page.svelte`:
  - "Partial: X sent, Y failed (BCC)." on partial outcomes
  - **Failed recipients stay selected** so clicking Email again retries just them — no manual re-tick of the still-failed addresses
  - Expandable details section showing per-chunk error text from TEM

## Tests

8 new test functions in `internal/email/client_test.go`:

- `TestChunkRecipients` — boundaries (empty, exactly at cap, one over, 20-with-cap-9, 5-with-cap-2) + the `size<=0` fallback regression guard
- `TestChunkRecipients_PreservesOrder` — chunk N contains `recipients[(N-1)*size : N*size]` every time
- `TestMaxBCCPerMessage` — env override + invalid-value fallbacks
- `TestSendBulk_ChunksAndContinuesOnError` — fake TEM server fails chunk #2, succeeds 1 & 3; asserts `sent=16 failed=9`, errors has one entry of 9 addresses, all three chunks were POSTed
- `TestSendBulk_AllChunksFail` — every chunk 500s → returns error, `sent=0`
- `TestSendBulk_SingleChunkUnderCap` — five recipients, one POST, clean success
- `TestSendBulk_Unconfigured` / `_EmptyRecipients` — guard rails

## Test plan

- [x] `go test -short ./...` → all 26 packages green
- [x] `npx svelte-check` → no new errors in `admin/+page.svelte` or `lib/api.ts` (the pre-existing 139 errors elsewhere are issue #11)
- [ ] After merge: in the Platform Admin → Signup Allowlist UI, select 15+ recipients, click Email, expect "Sent to 15 (BCC)." with no 403
- [ ] Force a partial: set `TEM_MAX_RECIPIENTS_PER_MESSAGE=3` (or break TEM creds), confirm the partial banner appears + the failed addresses stay selected for retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)