### PR TITLE
Security: mitigate CVE-2026-46333 (ssh-keysign-pwn) on Kapsule nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,12 @@ jobs:
 
       - name: Apply K8s manifests (security, ingress, functions, MCP server)
         run: |
-          # CVE-2026-31431 mitigation must land before any pod restart so newly
-          # scheduled pods can't briefly run on a node with algif_aead loaded.
+          # CVE-2026-31431 (Copy Fail) and CVE-2026-46333 (ssh-keysign-pwn)
+          # mitigations must land before any pod restart so newly scheduled
+          # pods can't briefly run on a node with algif_aead loaded or
+          # unprivileged ptrace enabled.
           kubectl apply -f deploy/k8s/security/disable-algif-aead.yaml
+          kubectl apply -f deploy/k8s/security/disable-ptrace.yaml
           # In-cluster Redis replaces managed RED1-micro to cut the
           # beta-stage bill (~€59/mo). Apply before the gateway/worker
           # rollout so REDIS_URL=redis://redis.eurobase.svc.cluster.local
@@ -278,6 +281,7 @@ jobs:
           # for the gateway (it logs a warning and disables those features),
           # but a clean roll keeps the failure paths out of the deploy log.
           kubectl rollout status statefulset/redis -n eurobase --timeout=120s
+          kubectl rollout status daemonset/disable-ptrace -n kube-system --timeout=120s
           kubectl rollout status deployment/gateway -n eurobase --timeout=120s
           kubectl rollout status deployment/worker -n eurobase --timeout=120s
           kubectl rollout status deployment/console -n eurobase --timeout=120s

--- a/deploy/k8s/security/disable-ptrace.yaml
+++ b/deploy/k8s/security/disable-ptrace.yaml
@@ -1,0 +1,82 @@
+##############################################################################
+# CVE-2026-46333 ("ssh-keysign-pwn") mitigation.
+#
+# Linux kernel logical flaw in process management allows Local Privilege
+# Escalation and Information Disclosure. An attacker within a pod can use
+# unprivileged process tracing (ptrace) to extract host-level secrets
+# (SSH private keys, /etc/shadow), leading to full host compromise and
+# container escape. Public exploits are available as of 2026-05-14.
+#
+# Eurobase runs untrusted tenant JS in the functions-runner pods on
+# shared Kapsule nodes, so the LPE → container escape path is in scope
+# until every node is on a patched kernel.
+#
+# Mitigation: set kernel.yama.ptrace_scope=3 (no process may trace any
+# other process). This is the most restrictive setting and the
+# Scaleway-recommended workaround. No Eurobase component uses ptrace:
+# the Go gateway/worker, Deno functions runner, pgx, gorilla/websocket,
+# and V8 crypto all operate without it. `kubectl exec` still works
+# (it uses the CRI API, not ptrace).
+#
+# Rollback: kubectl delete -f this file, then
+#   sysctl -w kernel.yama.ptrace_scope=1
+# on each node if immediate effect is needed.
+##############################################################################
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disable-ptrace
+  namespace: kube-system
+  labels:
+    app: disable-ptrace
+spec:
+  selector:
+    matchLabels:
+      app: disable-ptrace
+  template:
+    metadata:
+      labels:
+        app: disable-ptrace
+    spec:
+      hostPID: true
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      initContainers:
+        - name: disable-ptrace
+          image: alpine:3.23
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Set ptrace_scope=3 via sysctl (immediate effect).
+              sysctl -w kernel.yama.ptrace_scope=3
+              # Persist into sysctl.d so a `sysctl --system` reload
+              # re-applies the setting. Does NOT survive a reboot on
+              # its own — the DaemonSet re-runs on node boot.
+              echo "kernel.yama.ptrace_scope = 3" > /host-sysctl/99-disable-ptrace.conf
+              # Verify.
+              actual=$(cat /proc/sys/kernel/yama/ptrace_scope)
+              if [ "$actual" != "3" ]; then
+                echo "ERROR: ptrace_scope is $actual, expected 3"
+                exit 1
+              fi
+              echo "ptrace_scope set to 3 — CVE-2026-46333 mitigated"
+          volumeMounts:
+            - name: host-sysctl
+              mountPath: /host-sysctl
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            limits:
+              cpu: 1m
+              memory: 8Mi
+      volumes:
+        - name: host-sysctl
+          hostPath:
+            path: /etc/sysctl.d


### PR DESCRIPTION
Supersedes #148 (which was opened off an outdated base and inadvertently included 5 unrelated commits — see the close comment there for the breakdown).

Same intent: defend against the Scaleway advisory 2026-05-14 kernel LPE (`CVE-2026-46333`, "ssh-keysign-pwn") that lets a pod-local attacker use unprivileged ptrace to extract host secrets (SSH keys, `/etc/shadow`). Same threat shape as the merged Copy Fail (`disable-algif-aead`) and the still-open #116 Dirty Frag (`disable-dirty-frag`). Belt-and-suspenders bridge until a patched Kapsule kernel ships.

## What lands

- `deploy/k8s/security/disable-ptrace.yaml` — DaemonSet sets `kernel.yama.ptrace_scope=3` on every node, persists to `/etc/sysctl.d/99-disable-ptrace.conf`, tolerates all taints so autoscaler-spawned nodes are also hardened on first boot. initContainer verifies the setting took effect.
- `.github/workflows/ci.yml` — applies the DaemonSet alongside `disable-algif-aead.yaml` (before any pod restart), and the rollout-status check covers it.

Diff: **2 files, +88 / -2**. Cherry-picked the single relevant commit (`b36bb3a`) onto current main and resolved a ci.yml conflict.

## Risk check (verbatim from #148)

No Eurobase component uses ptrace:
- Go gateway/worker: no debugger, no strace
- Deno functions runner: V8 doesn't ptrace
- pgx, gorilla/websocket: no ptrace
- `kubectl exec` into pods still works (it uses the CRI API, not ptrace)

The only thing broken by `ptrace_scope=3` is attaching `strace`/`gdb` to a running process on the node. If needed during an incident, temporarily `sysctl -w kernel.yama.ptrace_scope=1` on the specific node.

Rollback: `kubectl delete -f deploy/k8s/security/disable-ptrace.yaml`, then `sysctl -w kernel.yama.ptrace_scope=1` on each node.

## Test plan

- [ ] Merge + deploy
- [ ] `kubectl get ds -n kube-system disable-ptrace` shows DESIRED == CURRENT == READY across all nodes
- [ ] On any node: `cat /proc/sys/kernel/yama/ptrace_scope` returns `3`

## Operator follow-up (not in this PR)

Roll the Kapsule node pool to the patched kernel once Scaleway publishes the image:

```
scw k8s pool upgrade <pool-id>
```

DaemonSet stays in place as defence-in-depth, same as the other two security DaemonSets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)