### PR TITLE
Mollie payment system: subscriptions, dunning, deferred Pro signup (#2, #70)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -13,7 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/eurobase/euroback/internal/audit"
 	"github.com/eurobase/euroback/internal/auth"
+	"github.com/eurobase/euroback/internal/billing"
 	"github.com/eurobase/euroback/internal/compliance"
 	"github.com/eurobase/euroback/internal/db"
 	"github.com/eurobase/euroback/internal/email"
@@ -231,6 +233,26 @@ func main() {
 	// ── Start usage alerts job (daily scan, 80/90/100% thresholds) ──
 	limitsSvc.StartUsageAlerts(ctx, emailService)
 	slog.Info("usage alerts job started")
+
+	// ── Start billing dunning sweep (hourly) ──
+	// Idempotent + lightweight; safe to run alongside the workers
+	// pod's River queue. Only fires real DB writes when subscriptions
+	// have actually exited grace or hit cancel_at_period_end.
+	{
+		auditSvc := audit.NewService(pool)
+		mollieClient := billing.NewMollieClient(
+			os.Getenv("MOLLIE_API_KEY"),
+			os.Getenv("MOLLIE_WEBHOOK_SECRET"),
+		)
+		billingConsoleURL := consoleURL
+		billingWebhookBase := os.Getenv("PUBLIC_GATEWAY_URL")
+		if billingWebhookBase == "" {
+			billingWebhookBase = "https://api.eurobase.app"
+		}
+		billingSvc := billing.NewService(pool, mollieClient, auditSvc, billingConsoleURL, billingWebhookBase)
+		go billingSvc.StartDunningWorker(ctx)
+		slog.Info("billing dunning worker started")
+	}
 
 	// ── Dev mode: bypass platform auth for local testing ──
 	// Refuses to start if DEV_MODE is true on a production-looking host, so a

--- a/console/src/lib/api.ts
+++ b/console/src/lib/api.ts
@@ -386,8 +386,13 @@ export class EurobaseAPI {
 		slug?: string;
 		region?: string;
 		plan?: string;
-	}): Promise<Project> {
-		return this.fetch<Project>('/v1/tenants', {
+	}): Promise<Project | PendingProjectResponse> {
+		// #70: when plan='pro' is requested AND Mollie is configured
+		// server-side, the backend returns 202 with a pending_payment
+		// shape instead of creating the project synchronously. Callers
+		// must narrow on the `status` field before treating the
+		// response as a Project.
+		return this.fetch<Project | PendingProjectResponse>('/v1/tenants', {
 			method: 'POST',
 			body: JSON.stringify(data)
 		});
@@ -1326,6 +1331,31 @@ export class EurobaseAPI {
 		const qs = searchParams.toString();
 		return this.fetch<LogsResponse>(`/platform/projects/${projectId}/logs${qs ? `?${qs}` : ''}`);
 	}
+
+	// ── Billing (Mollie) ─────────────────────────────────────────────────
+	// Per-project subscription state + checkout. The Mollie webhook is
+	// server-only (POST /webhooks/mollie) — the console never calls it.
+
+	async getSubscription(projectId: string): Promise<SubscriptionView> {
+		return this.fetch<SubscriptionView>(`/platform/projects/${projectId}/billing/subscription`);
+	}
+
+	async listInvoices(projectId: string): Promise<{ invoices: Invoice[] }> {
+		return this.fetch<{ invoices: Invoice[] }>(`/platform/projects/${projectId}/billing/invoices`);
+	}
+
+	async startCheckout(projectId: string, plan: 'pro' = 'pro'): Promise<{ checkout_url: string }> {
+		return this.fetch<{ checkout_url: string }>(`/platform/projects/${projectId}/billing/checkout`, {
+			method: 'POST',
+			body: JSON.stringify({ plan })
+		});
+	}
+
+	async cancelSubscription(projectId: string): Promise<{ status: string }> {
+		return this.fetch<{ status: string }>(`/platform/projects/${projectId}/billing/cancel`, {
+			method: 'POST'
+		});
+	}
 }
 
 export interface VaultSecret {
@@ -1700,6 +1730,35 @@ export interface FunctionMetrics {
 	avg_duration_ms: number;
 	p95_duration_ms: number;
 	period: string;
+}
+
+// ── Billing types ───────────────────────────────────────────────────────────
+
+/** Returned by createProject when the user picked Pro and the server
+ *  deferred creation pending payment (#70). */
+export interface PendingProjectResponse {
+	status: 'pending_payment';
+	pending_project_id: string;
+	checkout_url: string;
+}
+
+export interface SubscriptionView {
+	plan: 'free' | 'pro';
+	status: 'free' | 'pending_payment' | 'active' | 'grace' | 'pro_until_period_end' | 'cancelled';
+	amount_eur?: string;
+	current_period_end?: string;
+	cancel_at_period_end: boolean;
+	grace_until?: string;
+}
+
+export interface Invoice {
+	id: string;
+	mollie_payment_id: string;
+	amount_cents: number;
+	currency: string;
+	status: string;
+	paid_at?: string;
+	created_at: string;
 }
 
 export const api = new EurobaseAPI();

--- a/console/src/routes/(app)/p/[id]/billing/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/billing/+page.svelte
@@ -102,7 +102,7 @@
 	<header>
 		<h1 class="text-2xl font-semibold text-gray-900">Billing</h1>
 		<p class="text-sm text-gray-500 mt-1">
-			Eurobase Pro — €9/month. Payments processed by Mollie (EU, Netherlands).
+			Eurobase Pro — €19/month. Payments processed by Mollie (EU, Netherlands).
 		</p>
 	</header>
 

--- a/console/src/routes/(app)/p/[id]/billing/+page.svelte
+++ b/console/src/routes/(app)/p/[id]/billing/+page.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { api, type SubscriptionView, type Invoice } from '$lib/api.js';
+	import { onMount } from 'svelte';
+
+	let projectId = $derived($page.params.id);
+
+	let view: SubscriptionView | null = $state(null);
+	let invoices: Invoice[] = $state([]);
+	let loading = $state(true);
+	let error: string | null = $state(null);
+	let busy = $state(false);
+
+	let showCancelModal = $state(false);
+
+	onMount(async () => {
+		await load();
+		// Honour ?autostart=1 — coming from the pricing page or the
+		// project-creation flow (#70) where the user already declared
+		// intent. One-click into the Mollie checkout, no extra
+		// confirmation needed.
+		const params = new URLSearchParams(window.location.search);
+		if (params.get('autostart') === '1' && view?.plan === 'free') {
+			await startCheckout();
+		}
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			view = await api.getSubscription(projectId);
+			const inv = await api.listInvoices(projectId);
+			invoices = inv.invoices;
+		} catch (e: any) {
+			error = e?.message ?? 'Failed to load billing state';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function startCheckout() {
+		busy = true;
+		error = null;
+		try {
+			const { checkout_url } = await api.startCheckout(projectId, 'pro');
+			window.location.href = checkout_url;
+		} catch (e: any) {
+			error = e?.message ?? 'Failed to start checkout';
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function confirmCancel() {
+		busy = true;
+		error = null;
+		try {
+			await api.cancelSubscription(projectId);
+			showCancelModal = false;
+			await load();
+		} catch (e: any) {
+			error = e?.message ?? 'Cancel failed';
+		} finally {
+			busy = false;
+		}
+	}
+
+	function formatCents(cents: number): string {
+		return `€${(cents / 100).toFixed(2)}`;
+	}
+
+	function formatDate(s: string | undefined): string {
+		if (!s) return '—';
+		return new Date(s).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' });
+	}
+
+	function statusLabel(status: SubscriptionView['status']): string {
+		switch (status) {
+			case 'active': return 'Active';
+			case 'pending_payment': return 'Pending payment';
+			case 'grace': return 'Payment failed — grace period';
+			case 'pro_until_period_end': return 'Cancelled — Pro until period end';
+			case 'cancelled': return 'Cancelled';
+			default: return 'Free';
+		}
+	}
+
+	function statusBadgeClass(status: SubscriptionView['status']): string {
+		switch (status) {
+			case 'active': return 'bg-green-100 text-green-800';
+			case 'pending_payment': return 'bg-yellow-100 text-yellow-800';
+			case 'grace': return 'bg-red-100 text-red-800';
+			case 'pro_until_period_end': return 'bg-blue-100 text-blue-800';
+			case 'cancelled': return 'bg-gray-100 text-gray-800';
+			default: return 'bg-gray-100 text-gray-700';
+		}
+	}
+</script>
+
+<div class="max-w-4xl mx-auto p-6 space-y-8">
+	<header>
+		<h1 class="text-2xl font-semibold text-gray-900">Billing</h1>
+		<p class="text-sm text-gray-500 mt-1">
+			Eurobase Pro — €9/month. Payments processed by Mollie (EU, Netherlands).
+		</p>
+	</header>
+
+	{#if loading}
+		<div class="text-gray-500">Loading…</div>
+	{:else if error}
+		<div class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-800">{error}</div>
+	{:else if view}
+		<!-- Subscription state card -->
+		<section class="rounded-lg border border-gray-200 bg-white">
+			<div class="p-5 border-b border-gray-100 flex items-center justify-between">
+				<div>
+					<div class="text-xs uppercase tracking-wide text-gray-500">Current plan</div>
+					<div class="text-xl font-semibold text-gray-900 mt-1">
+						{view.plan === 'pro' ? 'Pro' : 'Free'}
+					</div>
+				</div>
+				<span class="text-xs px-2 py-1 rounded {statusBadgeClass(view.status)}">
+					{statusLabel(view.status)}
+				</span>
+			</div>
+
+			<div class="p-5 grid grid-cols-2 gap-4 text-sm">
+				{#if view.amount_eur}
+					<div>
+						<div class="text-gray-500">Monthly amount</div>
+						<div class="text-gray-900 font-medium">€{view.amount_eur}</div>
+					</div>
+				{/if}
+				{#if view.current_period_end}
+					<div>
+						<div class="text-gray-500">
+							{view.cancel_at_period_end ? 'Access until' : 'Next charge'}
+						</div>
+						<div class="text-gray-900 font-medium">{formatDate(view.current_period_end)}</div>
+					</div>
+				{/if}
+				{#if view.grace_until}
+					<div>
+						<div class="text-gray-500">Grace period ends</div>
+						<div class="text-red-700 font-medium">{formatDate(view.grace_until)}</div>
+					</div>
+				{/if}
+			</div>
+
+			<div class="p-5 border-t border-gray-100 flex flex-wrap gap-2">
+				{#if view.plan === 'free' || view.status === 'cancelled'}
+					<button
+						type="button"
+						class="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+						disabled={busy}
+						onclick={startCheckout}
+					>
+						{busy ? 'Starting checkout…' : 'Upgrade to Pro'}
+					</button>
+				{:else if view.status === 'grace' || view.status === 'pending_payment'}
+					<button
+						type="button"
+						class="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+						disabled={busy}
+						onclick={startCheckout}
+					>
+						{busy ? 'Starting checkout…' : 'Update payment method'}
+					</button>
+				{/if}
+
+				{#if (view.status === 'active' || view.status === 'grace') && !view.cancel_at_period_end}
+					<button
+						type="button"
+						class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+						onclick={() => (showCancelModal = true)}
+					>
+						Cancel subscription
+					</button>
+				{/if}
+			</div>
+		</section>
+
+		<!-- Invoices -->
+		<section class="rounded-lg border border-gray-200 bg-white">
+			<div class="p-5 border-b border-gray-100">
+				<h2 class="text-lg font-semibold text-gray-900">Invoices</h2>
+				<p class="text-xs text-gray-500 mt-1">Latest 20 charges. PDFs are hosted by Mollie.</p>
+			</div>
+			{#if invoices.length === 0}
+				<div class="p-5 text-sm text-gray-500">No invoices yet.</div>
+			{:else}
+				<table class="w-full text-sm">
+					<thead class="bg-gray-50 text-xs uppercase text-gray-500">
+						<tr>
+							<th class="text-left px-4 py-2 font-medium">Date</th>
+							<th class="text-left px-4 py-2 font-medium">Amount</th>
+							<th class="text-left px-4 py-2 font-medium">Status</th>
+							<th class="text-left px-4 py-2 font-medium">Mollie ID</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each invoices as inv}
+							<tr class="border-t border-gray-100">
+								<td class="px-4 py-2">{formatDate(inv.paid_at || inv.created_at)}</td>
+								<td class="px-4 py-2">{formatCents(inv.amount_cents)} {inv.currency}</td>
+								<td class="px-4 py-2">
+									<span class="text-xs px-2 py-0.5 rounded {inv.status === 'paid' ? 'bg-green-100 text-green-800' : inv.status === 'failed' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-700'}">
+										{inv.status}
+									</span>
+								</td>
+								<td class="px-4 py-2 font-mono text-xs text-gray-500">{inv.mollie_payment_id}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+		</section>
+	{/if}
+
+	{#if showCancelModal}
+		<div class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+			<div class="bg-white rounded-lg max-w-md w-full p-6 space-y-4">
+				<h3 class="text-lg font-semibold text-gray-900">Cancel Pro subscription?</h3>
+				<p class="text-sm text-gray-600">
+					Pro features stay active until {formatDate(view?.current_period_end)}.
+					Mollie will not charge you again. You can resubscribe at any time.
+				</p>
+				<div class="flex gap-2 justify-end">
+					<button
+						type="button"
+						class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+						onclick={() => (showCancelModal = false)}
+					>Keep subscription</button>
+					<button
+						type="button"
+						class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+						disabled={busy}
+						onclick={confirmCancel}
+					>{busy ? 'Cancelling…' : 'Confirm cancel'}</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/docs/runbooks/billing-mollie.md
+++ b/docs/runbooks/billing-mollie.md
@@ -1,0 +1,217 @@
+# Runbook — Mollie billing
+
+Integration shipped under issues #157–#162 (umbrella #2). Mollie is
+the only billing provider — Netherlands-based, listed in the DPA
+sub-processor registry since migration 000025, CLAUDE.md-compliant
+("no US cloud services").
+
+This runbook covers first-time setup, day-to-day operator tasks, and
+the failure modes you'll see in production.
+
+## First-time setup
+
+### 1. Create Mollie account + organisation
+
+- Sign up at https://www.mollie.com/dashboard (one Mollie organisation
+  per Eurobase environment — separate orgs for staging and prod, OR
+  one org with separate profiles for each)
+- Enable the Eurobase profile in the dashboard
+- Verify your business details so Mollie unblocks live mode
+
+### 2. Generate API keys
+
+In the Mollie dashboard → Developers → API keys:
+
+- Copy the **test key** (`test_*`) for dev/staging environments
+- Copy the **live key** (`live_*`) for production
+- Generate a webhook signing secret (32+ random bytes,
+  `openssl rand -hex 32`) and save it somewhere you control —
+  Mollie does NOT generate this for you; we use it client-side
+  to verify webhook payloads
+
+### 3. Populate vault keys
+
+The gateway reads two env vars at boot:
+
+| Env var | Where |
+|---|---|
+| `MOLLIE_API_KEY` | `eurobase-secrets` k8s Secret, key `MOLLIE_API_KEY` |
+| `MOLLIE_WEBHOOK_SECRET` | same Secret, key `MOLLIE_WEBHOOK_SECRET` |
+
+Optional:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `PUBLIC_GATEWAY_URL` | `https://api.eurobase.app` | Used to build the webhook URL Mollie POSTs back to |
+| `CONSOLE_URL` | `http://localhost:5173` | User's browser returns here after Mollie checkout |
+
+The gateway logs `billing: Mollie not configured` if either of the
+two required vars is missing — every `/billing` endpoint then returns
+503 (fail-closed, no silent no-ops).
+
+### 4. Configure Mollie webhook URL
+
+In the Mollie dashboard → Developers → Webhooks, set the URL to:
+
+```
+https://api.eurobase.app/webhooks/mollie
+```
+
+(or your environment's equivalent of `$PUBLIC_GATEWAY_URL/webhooks/mollie`)
+
+Mollie validates the URL by POSTing a test ping. The gateway returns
+200 regardless of internal outcome (so retries don't pile up), then
+verifies the signature + cross-checks with Mollie's API before
+applying any state change.
+
+### 5. Smoke test (test mode)
+
+```bash
+# 1. Bring up the gateway with MOLLIE_API_KEY=test_... in env
+# 2. Sign in to the console as a platform admin
+# 3. Navigate to /p/<test-project-id>/billing
+# 4. Click "Upgrade to Pro"
+# 5. Use Mollie's test cards: https://docs.mollie.com/overview/testing
+#    - Approved card:   4242 4242 4242 4242 / any CVC / future expiry
+#    - Declined card:   4111 1110 0030 0036
+# 6. Confirm the webhook fires:
+kubectl logs -n eurobase deploy/gateway --tail=200 | grep -i mollie
+# 7. Confirm projects.plan flipped:
+psql -c "SELECT plan FROM public.projects WHERE id = '<project>'"
+```
+
+### 6. Compliance / DPA registry
+
+Mollie was added as a sub-processor in migration 000025. To confirm
+it surfaces in the DPA report when the Billing feature is active:
+
+```bash
+curl -H "Authorization: Bearer <platform-token>" \
+  https://api.eurobase.app/platform/projects/<id>/compliance/dpa-report \
+  | jq '.sub_processors[] | select(.name=="Mollie")'
+```
+
+If you don't see Mollie listed, check `internal/compliance/registry.go`
+→ `resolveActiveFeatures()` returns "billing" once at least one
+subscription row exists for the project.
+
+## Day-to-day operator tasks
+
+### Manual reconciliation
+
+When a customer reports a charge but no Pro features, almost always
+it's a webhook delivery delay or signature mismatch. Verify manually:
+
+```bash
+# 1. Find the customer's Mollie payment ID (from Mollie dashboard
+#    or from public.invoices)
+psql -c "SELECT mollie_payment_id, status, created_at
+         FROM public.invoices
+         WHERE project_id = '<id>' ORDER BY created_at DESC LIMIT 5"
+
+# 2. Pull authoritative state from Mollie:
+curl -H "Authorization: Bearer $MOLLIE_API_KEY" \
+  https://api.mollie.com/v2/payments/<tr_xxx> | jq
+
+# 3. If status="paid" but our DB says otherwise, trigger the webhook
+#    handler manually:
+curl -X POST https://api.eurobase.app/webhooks/mollie \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-Mollie-Signature: <hex sig over body>" \
+  -d "id=<tr_xxx>"
+```
+
+Computing the signature for a one-off:
+```bash
+echo -n "id=tr_xxx" | openssl dgst -sha256 -hmac "$MOLLIE_WEBHOOK_SECRET"
+```
+
+A proper CLI command (`eurobase admin billing reconcile <project>`)
+is a planned follow-up — until then, the curl above is the way.
+
+### Refunds
+
+Issue refunds in the Mollie dashboard. Mollie sends a webhook with
+`payment.status=refunded`; our handler updates the `invoices` row but
+does NOT auto-downgrade the project. Decide per case:
+
+- Partial refund → no plan change
+- Full refund of the only successful payment + active subscription
+  → cancel the subscription manually + downgrade (or wait for the
+  next failed-renewal → grace → downgrade)
+
+Every refund leaves an `audit_log` entry; the actor field is empty
+because the refund originates from Mollie's dashboard, not from our
+console.
+
+### Plan changes: test → live
+
+When you're ready to take real money:
+
+1. In Mollie: switch organisation to live mode, generate `live_*` key
+2. Update the `MOLLIE_API_KEY` value in the k8s Secret
+3. Roll the gateway deployment (`kubectl rollout restart deploy/gateway -n eurobase`)
+4. Check logs — should now see `billing: Mollie test mode` warning is
+   GONE
+5. Run a €0.01 smoke payment with a real card; refund immediately
+6. Update Mollie's webhook URL in the dashboard if it points at staging
+
+## Common failure modes
+
+### "Pending payment" never clears
+
+User clicked Upgrade but is still on Free. Likely causes:
+
+| Symptom | Diagnose | Fix |
+|---|---|---|
+| No Mollie webhook in gateway logs | Mollie webhook URL wrong in dashboard | Update webhook URL, retry payment |
+| Webhook arrives, signature mismatch in logs | `MOLLIE_WEBHOOK_SECRET` env doesn't match what's in Mollie dashboard | Rotate secret on both sides + roll gateway |
+| Webhook applied, but `projects.plan` still free | Customer paid but the metadata.project_id was wrong (very rare — would be a code bug) | Manual SQL update + audit_log entry |
+
+### "Pro" signup creates project as Free
+
+This is **issue #70** which the new flow closes. If you see it,
+verify the gateway has `MOLLIE_API_KEY` set — when unset, the
+project-creation handler falls back to immediate creation (the
+pre-#70 behaviour) regardless of `plan: 'pro'`. That's intentional
+(local dev), but should never happen in production.
+
+### Stuck `pending_projects` rows
+
+The dunning sweeper deletes rows older than 24h. If you see a slug
+"reserved" that shouldn't be, check `public.pending_projects`:
+
+```sql
+SELECT id, name, slug, mollie_payment_id, expires_at
+FROM public.pending_projects
+WHERE expires_at < now();
+```
+
+Manual cleanup:
+```sql
+DELETE FROM public.pending_projects WHERE id = '<id>';
+```
+
+## What's NOT in this rollout (issue references)
+
+- **Custom plan tiers / usage-based metering** — #128 (function metering), #131 (per-org pricing)
+- **Annual billing** — Mollie supports it; not enabled
+- **Card-update flow inside our UI** — currently we redirect to
+  Mollie's hosted payment page each time; their own customer portal
+  is a planned add
+- **Cross-page "Pro is pending" banner** — present on the billing page
+  itself; not yet on every project page header
+- **Reconciliation CLI command** — `eurobase admin billing reconcile`
+  is documented but not yet implemented (use the curl path above)
+
+## Audit log actions emitted by billing
+
+| Action | When |
+|---|---|
+| `billing.subscription.created` | User starts checkout (writes the pending_payment row) |
+| `billing.subscription.cancelled` | User clicks Cancel |
+| `billing.payment.succeeded` | Webhook: payment.status=paid |
+| `billing.payment.failed` | Webhook: payment.status=failed/expired/canceled |
+| `billing.plan.changed` | projects.plan transitions (free→pro on first paid, pro→free on grace expiry or period end) |
+
+Visible in the Compliance → Audit Log tab of the affected project.

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -40,6 +40,19 @@ const (
 	ActionExportSelfRequested = "compliance.export.self_requested"
 	ActionExportCompleted     = "compliance.export.completed"
 	ActionExportFailed        = "compliance.export.failed"
+
+	// Billing / subscription lifecycle. Part of #2 (Mollie). Every
+	// transition the dunning state machine can make emits one of
+	// these so the Compliance → Audit Log feed answers "what
+	// happened, when, who" without a Mollie dashboard lookup. Each
+	// row carries a metadata blob with the Mollie IDs so the
+	// support flow can cross-reference without exposing them in
+	// the UI.
+	ActionSubscriptionCreated   = "billing.subscription.created"
+	ActionSubscriptionCancelled = "billing.subscription.cancelled"
+	ActionPaymentSucceeded      = "billing.payment.succeeded"
+	ActionPaymentFailed         = "billing.payment.failed"
+	ActionPlanChanged           = "billing.plan.changed"
 )
 
 // Entry represents a single audit log row.

--- a/internal/billing/dunning.go
+++ b/internal/billing/dunning.go
@@ -1,0 +1,150 @@
+package billing
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/eurobase/euroback/internal/audit"
+)
+
+// RunDunningSweep advances subscriptions that have exited grace
+// without recovering payment, and finalises cancel-at-period-end
+// transitions. Intended to be invoked from a 1-hour cron tick in
+// the worker pool (the existing River worker). Designed to be safe
+// to call concurrently — every UPDATE is idempotent and bounded by
+// a WHERE clause that only matches rows still in the transitional
+// state.
+//
+// Returns the number of rows transitioned for observability /
+// metrics. No error is returned for empty sweeps; a non-nil error
+// only fires on DB transport failure.
+func (s *Service) RunDunningSweep(ctx context.Context) (downgraded int, finalised int, err error) {
+	// 1. Grace-period expired → downgrade.
+	//    Move subscription to cancelled, flip project plan to free.
+	gRows, err := s.pool.Query(ctx,
+		`UPDATE public.subscriptions
+		 SET status = $1
+		 WHERE status = $2 AND grace_until IS NOT NULL AND grace_until < now()
+		 RETURNING project_id`,
+		StatusCancelled, StatusGrace,
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+	graceExpired := []string{}
+	for gRows.Next() {
+		var pid string
+		if scanErr := gRows.Scan(&pid); scanErr == nil {
+			graceExpired = append(graceExpired, pid)
+		}
+	}
+	gRows.Close()
+
+	for _, pid := range graceExpired {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE public.projects SET plan = $2 WHERE id = $1 AND plan = $3`,
+			pid, PlanFree, PlanPro,
+		); err != nil {
+			slog.Error("dunning: failed to downgrade project after grace expiry",
+				"project", pid, "error", err)
+			continue
+		}
+		downgraded++
+		if s.audit != nil {
+			s.audit.Log(ctx, pid, "", "", audit.ActionPlanChanged,
+				audit.WithMetadata(map[string]any{
+					"from":   PlanPro,
+					"to":     PlanFree,
+					"reason": "grace_period_expired",
+				}))
+		}
+	}
+
+	// 2. Cancel-at-period-end satisfied → downgrade.
+	//    Subscription was already flagged by the user-initiated Cancel.
+	cRows, err := s.pool.Query(ctx,
+		`UPDATE public.subscriptions
+		 SET status = $1
+		 WHERE cancel_at_period_end = true
+		   AND status = $2
+		   AND current_period_end IS NOT NULL
+		   AND current_period_end < now()
+		 RETURNING project_id`,
+		StatusCancelled, StatusProUntilPeriodEnd,
+	)
+	if err != nil {
+		return downgraded, 0, err
+	}
+	periodEnded := []string{}
+	for cRows.Next() {
+		var pid string
+		if scanErr := cRows.Scan(&pid); scanErr == nil {
+			periodEnded = append(periodEnded, pid)
+		}
+	}
+	cRows.Close()
+
+	for _, pid := range periodEnded {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE public.projects SET plan = $2 WHERE id = $1 AND plan = $3`,
+			pid, PlanFree, PlanPro,
+		); err != nil {
+			slog.Error("dunning: failed to downgrade project after period end",
+				"project", pid, "error", err)
+			continue
+		}
+		finalised++
+		if s.audit != nil {
+			s.audit.Log(ctx, pid, "", "", audit.ActionPlanChanged,
+				audit.WithMetadata(map[string]any{
+					"from":   PlanPro,
+					"to":     PlanFree,
+					"reason": "cancelled_at_period_end",
+				}))
+		}
+	}
+
+	// 3. Sweep stale pending_projects rows that never completed
+	//    checkout (24-hour TTL from migration 000056).
+	tag, perr := s.pool.Exec(ctx,
+		`DELETE FROM public.pending_projects WHERE expires_at < now()`)
+	if perr != nil {
+		slog.Warn("dunning: pending_projects cleanup failed", "error", perr)
+	} else if tag.RowsAffected() > 0 {
+		slog.Info("dunning: cleaned up pending_projects",
+			"count", tag.RowsAffected())
+	}
+
+	return downgraded, finalised, nil
+}
+
+// StartDunningWorker fires RunDunningSweep on a fixed interval. The
+// existing River worker pool runs the gateway-side workers (DSAR
+// export, etc.); this is a plain ticker because the sweep is
+// idempotent + lightweight and doesn't need queue semantics.
+//
+// Stops when ctx is cancelled.
+func (s *Service) StartDunningWorker(ctx context.Context) {
+	const interval = 1 * time.Hour
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	slog.Info("dunning worker started", "interval", interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			d, f, err := s.RunDunningSweep(ctx)
+			if err != nil {
+				slog.Error("dunning sweep failed", "error", err)
+				continue
+			}
+			if d > 0 || f > 0 {
+				slog.Info("dunning sweep completed",
+					"downgraded_after_grace", d,
+					"finalised_after_period_end", f)
+			}
+		}
+	}
+}

--- a/internal/billing/handler.go
+++ b/internal/billing/handler.go
@@ -1,0 +1,234 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/eurobase/euroback/internal/auth"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+)
+
+// HandleCheckout starts a Mollie checkout for the project's owner.
+// POST /platform/projects/{id}/billing/checkout
+// Body: { "plan": "pro" }
+// Returns: { "checkout_url": "..." }
+func HandleCheckout(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil || !svc.mollie.Configured() {
+			writeBillingJSON(w, map[string]string{"error": "billing not configured"}, http.StatusServiceUnavailable)
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeBillingJSON(w, map[string]string{"error": "unauthorized"}, http.StatusUnauthorized)
+			return
+		}
+
+		var body struct {
+			Plan string `json:"plan"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Plan == "" {
+			body.Plan = PlanPro
+		}
+
+		// We need the project's owner identity to attach to Mollie.
+		// The platform handler upstream is gated to admin role; the
+		// owner is the natural billing actor.
+		var ownerID, ownerEmail, ownerName string
+		err := svc.pool.QueryRow(r.Context(),
+			`SELECT pu.id, pu.email, COALESCE(pu.name, pu.email)
+			 FROM public.projects p
+			 JOIN public.platform_users pu ON pu.id = p.owner_id
+			 WHERE p.id = $1`,
+			projectID,
+		).Scan(&ownerID, &ownerEmail, &ownerName)
+		if err == pgx.ErrNoRows {
+			writeBillingJSON(w, map[string]string{"error": "project not found"}, http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			slog.Error("billing checkout: lookup owner failed", "project", projectID, "error", err)
+			writeBillingJSON(w, map[string]string{"error": "internal error"}, http.StatusInternalServerError)
+			return
+		}
+
+		checkoutURL, err := svc.StartUpgrade(r.Context(), projectID, ownerID, ownerEmail, ownerName, body.Plan)
+		if err != nil {
+			slog.Error("billing checkout failed", "project", projectID, "error", err)
+			writeBillingJSON(w, map[string]string{"error": "checkout failed"}, http.StatusBadGateway)
+			return
+		}
+		writeBillingJSON(w, map[string]string{"checkout_url": checkoutURL}, http.StatusOK)
+	}
+}
+
+// HandleGetSubscription returns the project's current subscription
+// state. Free projects with no row still get a valid response.
+// GET /platform/projects/{id}/billing/subscription
+func HandleGetSubscription(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		view, err := svc.GetSubscription(r.Context(), projectID)
+		if err != nil {
+			slog.Error("billing get subscription failed", "project", projectID, "error", err)
+			writeBillingJSON(w, map[string]string{"error": "internal error"}, http.StatusInternalServerError)
+			return
+		}
+		writeBillingJSON(w, view, http.StatusOK)
+	}
+}
+
+// HandleCancel flags the subscription cancel-at-period-end + asks
+// Mollie to stop further charges.
+// POST /platform/projects/{id}/billing/cancel
+func HandleCancel(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil || !svc.mollie.Configured() {
+			writeBillingJSON(w, map[string]string{"error": "billing not configured"}, http.StatusServiceUnavailable)
+			return
+		}
+		projectID := chi.URLParam(r, "id")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		actorID, actorEmail := "", ""
+		if claims != nil {
+			actorID = claims.Subject
+			actorEmail = claims.Email
+		}
+		if err := svc.Cancel(r.Context(), projectID, actorID, actorEmail); err != nil {
+			slog.Error("billing cancel failed", "project", projectID, "error", err)
+			writeBillingJSON(w, map[string]string{"error": err.Error()}, http.StatusBadRequest)
+			return
+		}
+		writeBillingJSON(w, map[string]string{"status": "cancelled_at_period_end"}, http.StatusOK)
+	}
+}
+
+// InvoiceView mirrors the columns the console renders.
+type InvoiceView struct {
+	ID              string `json:"id"`
+	MolliePaymentID string `json:"mollie_payment_id"`
+	AmountCents     int64  `json:"amount_cents"`
+	Currency        string `json:"currency"`
+	Status          string `json:"status"`
+	PaidAt          string `json:"paid_at,omitempty"`
+	CreatedAt       string `json:"created_at"`
+}
+
+// HandleListInvoices returns the project's invoices, newest first.
+// GET /platform/projects/{id}/billing/invoices
+func HandleListInvoices(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		rows, err := svc.pool.Query(r.Context(),
+			`SELECT id::text, mollie_payment_id, amount_cents, currency,
+			        status, COALESCE(paid_at::text, ''), created_at::text
+			 FROM public.invoices
+			 WHERE project_id = $1
+			 ORDER BY created_at DESC
+			 LIMIT 20`,
+			projectID,
+		)
+		if err != nil {
+			slog.Error("billing list invoices failed", "project", projectID, "error", err)
+			writeBillingJSON(w, map[string]string{"error": "internal error"}, http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		out := []InvoiceView{}
+		for rows.Next() {
+			var inv InvoiceView
+			if err := rows.Scan(&inv.ID, &inv.MolliePaymentID, &inv.AmountCents,
+				&inv.Currency, &inv.Status, &inv.PaidAt, &inv.CreatedAt); err != nil {
+				continue
+			}
+			out = append(out, inv)
+		}
+		writeBillingJSON(w, map[string]any{"invoices": out}, http.StatusOK)
+	}
+}
+
+// HandleWebhook is the Mollie webhook receiver. Unauthenticated by
+// design — Mollie can't carry our JWT — and protected by:
+// (a) HMAC signature verification using MOLLIE_WEBHOOK_SECRET
+// (b) a fetch of the payment from Mollie's authoritative API
+// (c) idempotent state transitions (ON CONFLICT DO NOTHING +
+//     status-machine guards in the service layer)
+//
+// We always return 200 to Mollie regardless of internal error.
+// Returning non-2xx triggers retries indefinitely; we never want a
+// poison-pill webhook stuck in retry loop. Internal failures are
+// logged + audit-trailed instead.
+//
+// POST /webhooks/mollie
+// Content-Type: application/x-www-form-urlencoded
+// Body: id=tr_xxxxxxxx
+// Header: X-Mollie-Signature: <hex sha256>
+func HandleWebhook(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if svc == nil || !svc.mollie.Configured() {
+			// Always 200 so Mollie doesn't retry; log loudly.
+			slog.Error("mollie webhook received but billing not configured")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+		if err != nil {
+			slog.Error("mollie webhook: read body failed", "error", err)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		sig := r.Header.Get("X-Mollie-Signature")
+		if err := svc.mollie.VerifyWebhookSignature(raw, sig); err != nil {
+			slog.Warn("mollie webhook signature invalid", "error", err, "sig_present", sig != "")
+			// Still 200 — signature failures should NOT cause Mollie
+			// to retry. The wrong-secret case is operator error,
+			// not transient.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Mollie sends payment IDs as form data: id=tr_xxxxxxxx.
+		paymentID := ""
+		if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
+			if err := r.ParseForm(); err == nil {
+				paymentID = r.PostFormValue("id")
+			}
+		}
+		if paymentID == "" {
+			// Some Mollie integration tooling posts JSON; tolerate.
+			var jsonBody struct{ ID string `json:"id"` }
+			_ = json.Unmarshal(raw, &jsonBody)
+			paymentID = jsonBody.ID
+		}
+		if paymentID == "" {
+			slog.Warn("mollie webhook: no payment ID found in body")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if err := svc.ApplyPaymentEvent(r.Context(), paymentID); err != nil {
+			slog.Error("mollie webhook: apply payment event failed",
+				"payment_id", paymentID, "error", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func writeBillingJSON(w http.ResponseWriter, data any, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+// pingDBRoundtrip is a no-op left in for future health-check use.
+// Kept here (rather than inlined) so dunning + handler share the
+// same package surface and the imports stay minimal.
+var _ = context.Background

--- a/internal/billing/handler.go
+++ b/internal/billing/handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/eurobase/euroback/internal/auth"
 	"github.com/go-chi/chi/v5"
@@ -196,10 +197,14 @@ func HandleWebhook(svc *Service) http.HandlerFunc {
 		}
 
 		// Mollie sends payment IDs as form data: id=tr_xxxxxxxx.
+		// We already drained r.Body into `raw` for signature
+		// verification, so `r.ParseForm()` reads an empty body and
+		// returns nothing — that was a real bug caught in PR #163
+		// review. Parse the already-read bytes instead.
 		paymentID := ""
 		if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
-			if err := r.ParseForm(); err == nil {
-				paymentID = r.PostFormValue("id")
+			if values, err := url.ParseQuery(string(raw)); err == nil {
+				paymentID = values.Get("id")
 			}
 		}
 		if paymentID == "" {

--- a/internal/billing/handler_test.go
+++ b/internal/billing/handler_test.go
@@ -1,0 +1,164 @@
+package billing
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestHandleWebhook_ExtractsPaymentIDFromFormBody is a regression
+// guard for the bug PR #163 review caught: HandleWebhook drains
+// r.Body into a local []byte for signature verification, so
+// r.ParseForm() reads an empty stream and the form-extraction path
+// silently returns "". Mollie's default Content-Type is
+// application/x-www-form-urlencoded; if the form-parsing path
+// breaks, every real Mollie webhook becomes a no-op until they
+// switch to JSON (which they don't).
+//
+// This test uses a partly-stubbed Service: the Mollie API client is
+// pointed at an httptest server that records whether GetPayment was
+// hit. If the payment ID was successfully extracted from the form
+// body, the handler invokes ApplyPaymentEvent which calls
+// GetPayment. If extraction silently failed (the bug), GetPayment
+// is never hit.
+func TestHandleWebhook_ExtractsPaymentIDFromFormBody(t *testing.T) {
+	var getPaymentHits int32
+	mollieSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/payments/") {
+			atomic.AddInt32(&getPaymentHits, 1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Return a "paid" payment so the downstream service path
+		// keeps running, but with empty metadata so it short-circuits
+		// before trying to touch the DB (we don't have one here).
+		_, _ = w.Write([]byte(`{
+			"id":"tr_webhook_test",
+			"status":"open",
+			"amount":{"currency":"EUR","value":"19.00"},
+			"customerId":"cst_x",
+			"metadata":{}
+		}`))
+	}))
+	defer mollieSrv.Close()
+
+	mc := NewMollieClient("test_x", "topsecret")
+	mc.baseURL = mollieSrv.URL
+
+	// nil pool — ApplyPaymentEvent will fail when it tries to
+	// upsert the invoice row, but only AFTER GetPayment is called
+	// from the same code path. That's enough to prove the form
+	// extraction worked. The handler always returns 200, so the
+	// downstream error doesn't surface to the test.
+	svc := &Service{mollie: mc}
+
+	body := "id=tr_webhook_test"
+	// Compute the signature the handler will verify against.
+	mac := computeHMACSHA256Hex(t, "topsecret", body)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/mollie", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Mollie-Signature", mac)
+
+	rec := httptest.NewRecorder()
+	HandleWebhook(svc)(rec, req)
+
+	// Handler must always return 200 so Mollie doesn't retry.
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (handler must not 4xx/5xx Mollie)", rec.Code)
+	}
+	// Critical assertion: did the handler extract the payment ID
+	// and dispatch through to Mollie's GetPayment?
+	if atomic.LoadInt32(&getPaymentHits) != 1 {
+		t.Fatal("GetPayment was never called — payment ID extraction silently failed " +
+			"(regression of the io.ReadAll + r.ParseForm bug from PR #163 review)")
+	}
+}
+
+// TestHandleWebhook_RejectsMissingSignature confirms unsigned
+// requests don't reach ApplyPaymentEvent.
+func TestHandleWebhook_RejectsMissingSignature(t *testing.T) {
+	var getPaymentHits int32
+	mollieSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&getPaymentHits, 1)
+		w.WriteHeader(200)
+	}))
+	defer mollieSrv.Close()
+	mc := NewMollieClient("test_x", "topsecret")
+	mc.baseURL = mollieSrv.URL
+	svc := &Service{mollie: mc}
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/mollie",
+		strings.NewReader("id=tr_unsigned"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// No X-Mollie-Signature header.
+	rec := httptest.NewRecorder()
+	HandleWebhook(svc)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d want 200 (still always 200 to Mollie)", rec.Code)
+	}
+	if atomic.LoadInt32(&getPaymentHits) != 0 {
+		t.Error("unsigned webhook should NOT reach Mollie API roundtrip")
+	}
+}
+
+// TestHandleWebhook_RejectsMisSignedBody confirms a wrong signature
+// also short-circuits before ApplyPaymentEvent.
+func TestHandleWebhook_RejectsMisSignedBody(t *testing.T) {
+	var getPaymentHits int32
+	mollieSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&getPaymentHits, 1)
+		w.WriteHeader(200)
+	}))
+	defer mollieSrv.Close()
+	mc := NewMollieClient("test_x", "topsecret")
+	mc.baseURL = mollieSrv.URL
+	svc := &Service{mollie: mc}
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/mollie",
+		strings.NewReader("id=tr_evil"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Mollie-Signature", "00deadbeef00deadbeef00deadbeef00deadbeef00deadbeef00deadbeef0000")
+	rec := httptest.NewRecorder()
+	HandleWebhook(svc)(rec, req)
+
+	if atomic.LoadInt32(&getPaymentHits) != 0 {
+		t.Error("mis-signed webhook should NOT reach Mollie API roundtrip")
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func computeHMACSHA256Hex(t *testing.T, secret, body string) string {
+	t.Helper()
+	mc := NewMollieClient("x", secret)
+	// Reuse VerifyWebhookSignature's inverse by computing the
+	// expected MAC the same way the implementation does, then
+	// asking it to verify against our computation. Since the
+	// implementation is the source of truth, this stays in sync.
+	for _, candidate := range knownGoodMACs(body) {
+		if err := mc.VerifyWebhookSignature([]byte(body), candidate); err == nil {
+			return candidate
+		}
+	}
+	// Fallback: compute it inline. This branch fires only if the
+	// pinned fixtures get out of sync (tests will then fail loudly).
+	t.Fatalf("could not compute MAC for body %q under secret %q — update knownGoodMACs", body, secret)
+	return ""
+}
+
+// knownGoodMACs lists the precomputed HMACs we use across the
+// handler tests. Pinned as fixtures so a test failure here surfaces
+// the algorithm change explicitly (rather than a silent
+// recomputation hiding a regression).
+func knownGoodMACs(body string) []string {
+	switch body {
+	case "id=tr_webhook_test":
+		// HMAC-SHA256("id=tr_webhook_test", "topsecret"). Compute with:
+		//   echo -n "id=tr_webhook_test" | openssl dgst -sha256 -hmac "topsecret"
+		return []string{"004510b3fd7d3ae69ae484908a63f3aedeb3bea3d58811b6a21c3c94a0533df0"}
+	}
+	return nil
+}

--- a/internal/billing/mollie.go
+++ b/internal/billing/mollie.go
@@ -1,0 +1,286 @@
+// Package billing integrates Mollie (Netherlands, EU) for subscription
+// payments. Closes #2.
+//
+// Mollie is the payment processor because the project's CLAUDE.md
+// explicitly forbids US-jurisdiction services and Mollie is already
+// listed in the DPA sub-processor registry (migration 000025). The
+// integration uses Mollie REST v2 — a "first payment" captures a
+// mandate, and subsequent monthly subscriptions charge against that
+// mandate automatically.
+//
+// Everything here speaks plain HTTPS against Mollie. There is no
+// official Go SDK we trust; the API surface we need is small enough
+// (5 calls) that a typed wrapper keeps the dependency footprint zero.
+package billing
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// MollieClient is a typed wrapper around the Mollie REST API.
+type MollieClient struct {
+	httpClient    *http.Client
+	apiKey        string
+	webhookSecret string
+	baseURL       string // injectable for tests; defaults to https://api.mollie.com/v2
+}
+
+// NewMollieClient creates a Mollie client. Pass an empty apiKey only
+// in tests; runtime callers MUST provide one — Configured() reports
+// the state for the startup gate.
+func NewMollieClient(apiKey, webhookSecret string) *MollieClient {
+	return &MollieClient{
+		httpClient:    &http.Client{Timeout: 15 * time.Second},
+		apiKey:        apiKey,
+		webhookSecret: webhookSecret,
+		baseURL:       "https://api.mollie.com/v2",
+	}
+}
+
+// Configured reports whether the client has the credentials it needs
+// to talk to Mollie. The gateway startup gate calls this before
+// mounting the /billing routes so a missing key fails closed rather
+// than silently degrading checkout to a no-op.
+func (c *MollieClient) Configured() bool {
+	return c.apiKey != "" && c.webhookSecret != ""
+}
+
+// TestMode reports whether the configured API key is a Mollie test
+// key (test_*). Used by the runbook + startup banner so it's
+// obvious when a non-prod deploy is talking to the sandbox.
+func (c *MollieClient) TestMode() bool {
+	return strings.HasPrefix(c.apiKey, "test_")
+}
+
+// ── Customer ────────────────────────────────────────────────────────────────
+
+// MollieCustomer is the subset of the Mollie Customer object we read
+// back. The full object has more fields (locale, metadata, etc.); we
+// only need id + email to round-trip identity.
+type MollieCustomer struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+// CreateCustomer creates a Mollie customer for the given email + name.
+// Returns the Mollie customer ID (string starting with "cst_...").
+// The caller is responsible for storing that ID against
+// platform_users.mollie_customer_id; the service layer wraps this
+// with idempotency by checking the DB first.
+func (c *MollieClient) CreateCustomer(ctx context.Context, email, name string) (string, error) {
+	body := map[string]string{"email": email, "name": name}
+	var out MollieCustomer
+	if err := c.do(ctx, http.MethodPost, "/customers", body, &out); err != nil {
+		return "", err
+	}
+	return out.ID, nil
+}
+
+// ── First payment (captures mandate for recurring) ──────────────────────────
+
+// MolliePayment mirrors the fields of a Mollie Payment object that we
+// read when reconciling webhook events. We deliberately do NOT model
+// the entire object — Mollie has dozens of fields, most of which are
+// irrelevant to our state machine.
+type MolliePayment struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"` // open | paid | failed | canceled | expired
+	Amount     struct {
+		Currency string `json:"currency"`
+		Value    string `json:"value"` // decimal string e.g. "9.00"
+	} `json:"amount"`
+	CustomerID    string             `json:"customerId"`
+	SubscriptionID string            `json:"subscriptionId,omitempty"`
+	MandateID     string             `json:"mandateId,omitempty"`
+	PaidAt        *time.Time         `json:"paidAt,omitempty"`
+	Description   string             `json:"description"`
+	Metadata      map[string]string  `json:"metadata,omitempty"`
+	Links         MolliePaymentLinks `json:"_links"`
+}
+
+// MolliePaymentLinks is the HATEOAS block Mollie returns. The
+// checkout URL is the one we redirect the browser to.
+type MolliePaymentLinks struct {
+	Checkout struct {
+		Href string `json:"href"`
+	} `json:"checkout"`
+}
+
+// FirstPaymentRequest is the request body for the "first payment"
+// pattern that creates a mandate. The mandate is the artifact that
+// lets us charge the customer later (via subscription) without
+// re-prompting for card details.
+type FirstPaymentRequest struct {
+	AmountEUR  string            // e.g. "9.00"
+	CustomerID string            // cst_...
+	RedirectURL string           // user's browser lands here after Mollie checkout
+	WebhookURL string            // Mollie POSTs here on payment status changes
+	Description string           // human-readable, shows on the Mollie receipt
+	Metadata   map[string]string // we put projectID + pendingProjectID here
+}
+
+// CreateFirstPayment captures a mandate for recurring charges and
+// returns the checkout URL the browser must redirect to. The mandate
+// becomes valid once Mollie webhooks back payment.status=paid; the
+// real subscription is then created in CreateSubscription against
+// that mandate.
+func (c *MollieClient) CreateFirstPayment(ctx context.Context, req FirstPaymentRequest) (*MolliePayment, error) {
+	body := map[string]any{
+		"amount":       map[string]string{"currency": "EUR", "value": req.AmountEUR},
+		"customerId":   req.CustomerID,
+		"sequenceType": "first", // captures mandate
+		"description":  req.Description,
+		"redirectUrl":  req.RedirectURL,
+		"webhookUrl":   req.WebhookURL,
+		"metadata":     req.Metadata,
+	}
+	var out MolliePayment
+	if err := c.do(ctx, http.MethodPost, "/payments", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetPayment fetches the current state of a payment by ID. The
+// webhook handler uses this to verify a payment ID handed to us by
+// the (untrusted) webhook against Mollie's authoritative state.
+func (c *MollieClient) GetPayment(ctx context.Context, paymentID string) (*MolliePayment, error) {
+	var out MolliePayment
+	if err := c.do(ctx, http.MethodGet, "/payments/"+paymentID, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ── Subscriptions ───────────────────────────────────────────────────────────
+
+// MollieSubscription is what Mollie returns after creating a recurring
+// subscription against a captured mandate.
+type MollieSubscription struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"` // active | pending | canceled | suspended | completed
+	Amount   struct {
+		Currency string `json:"currency"`
+		Value    string `json:"value"`
+	} `json:"amount"`
+	Interval    string             `json:"interval"`    // "1 month"
+	Description string             `json:"description"`
+	NextPaymentDate *string        `json:"nextPaymentDate,omitempty"`
+	WebhookURL  string             `json:"webhookUrl"`
+}
+
+// CreateSubscription starts a recurring monthly subscription against
+// an already-captured mandate. Call this from the webhook handler
+// when the first payment lands as paid, NOT at checkout time.
+func (c *MollieClient) CreateSubscription(ctx context.Context, customerID, amountEUR, description, webhookURL string) (*MollieSubscription, error) {
+	body := map[string]any{
+		"amount":      map[string]string{"currency": "EUR", "value": amountEUR},
+		"interval":    "1 month",
+		"description": description,
+		"webhookUrl":  webhookURL,
+	}
+	var out MollieSubscription
+	path := fmt.Sprintf("/customers/%s/subscriptions", customerID)
+	if err := c.do(ctx, http.MethodPost, path, body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CancelSubscription marks a Mollie subscription as cancelled. The
+// effective behaviour is "no further charges"; the customer keeps
+// access until current_period_end at the platform level. Mollie has
+// no concept of "cancel at period end" itself — that's our state
+// machine's responsibility.
+func (c *MollieClient) CancelSubscription(ctx context.Context, customerID, subscriptionID string) error {
+	path := fmt.Sprintf("/customers/%s/subscriptions/%s", customerID, subscriptionID)
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// ── Webhook signature verification ──────────────────────────────────────────
+
+// VerifyWebhookSignature returns nil if the signature header matches
+// the body computed under the shared secret. Mollie signs webhooks
+// with HMAC-SHA256 in the `X-Mollie-Signature` header. We never
+// trust the webhook body alone — even after this passes we re-fetch
+// the payment from Mollie's API to authoritatively confirm state.
+func (c *MollieClient) VerifyWebhookSignature(body []byte, signatureHeader string) error {
+	if c.webhookSecret == "" {
+		return fmt.Errorf("webhook secret not configured")
+	}
+	mac := hmac.New(sha256.New, []byte(c.webhookSecret))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	// constant-time compare to defeat timing oracles
+	if !hmac.Equal([]byte(expected), []byte(signatureHeader)) {
+		return fmt.Errorf("signature mismatch")
+	}
+	return nil
+}
+
+// ── Internal HTTP plumbing ──────────────────────────────────────────────────
+
+// do issues a JSON HTTP request to Mollie. body may be nil for GET/DELETE;
+// out may be nil to discard the response. All Mollie errors come back
+// as JSON with a `status` (HTTP code echoed) + `title` + `detail`;
+// we surface those verbatim in the wrapping error so the audit log
+// captures what Mollie actually said.
+func (c *MollieClient) do(ctx context.Context, method, path string, body any, out any) error {
+	var reqBody io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		reqBody = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mollie %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	rawResp, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		// Mollie shape: {"status":422,"title":"Unprocessable Entity","detail":"..."}
+		var apiErr struct {
+			Status int    `json:"status"`
+			Title  string `json:"title"`
+			Detail string `json:"detail"`
+		}
+		_ = json.Unmarshal(rawResp, &apiErr)
+		slog.Warn("mollie api error",
+			"method", method, "path", path,
+			"status", resp.StatusCode, "title", apiErr.Title, "detail", apiErr.Detail,
+		)
+		return fmt.Errorf("mollie %s %s -> %d %s: %s", method, path, resp.StatusCode, apiErr.Title, apiErr.Detail)
+	}
+	if out != nil {
+		if err := json.Unmarshal(rawResp, out); err != nil {
+			return fmt.Errorf("decode mollie response: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/billing/mollie_test.go
+++ b/internal/billing/mollie_test.go
@@ -1,0 +1,246 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Tests for the Mollie HTTP client and webhook signature verification.
+// All Mollie endpoints are mocked via httptest; no real network calls
+// land here. Closes the unit-test portion of issue #157.
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*MollieClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c := NewMollieClient("test_dummy", "test_webhook_secret")
+	c.baseURL = srv.URL
+	return c, srv
+}
+
+func TestMollieClient_Configured(t *testing.T) {
+	cases := []struct {
+		apiKey, secret string
+		want           bool
+	}{
+		{"", "", false},
+		{"test_x", "", false},
+		{"", "wh", false},
+		{"test_x", "wh", true},
+	}
+	for _, c := range cases {
+		got := NewMollieClient(c.apiKey, c.secret).Configured()
+		if got != c.want {
+			t.Errorf("Configured(apiKey=%q, secret=%q) = %v, want %v",
+				c.apiKey, c.secret, got, c.want)
+		}
+	}
+}
+
+func TestMollieClient_TestMode(t *testing.T) {
+	if !NewMollieClient("test_abc", "wh").TestMode() {
+		t.Error("test_ prefix should be TestMode")
+	}
+	if NewMollieClient("live_abc", "wh").TestMode() {
+		t.Error("live_ prefix should NOT be TestMode")
+	}
+}
+
+// TestMollieClient_CreateCustomer asserts POST /customers shape and
+// the returned ID parsing.
+func TestMollieClient_CreateCustomer(t *testing.T) {
+	var captured struct {
+		method, path, auth string
+		body               map[string]string
+	}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.auth = r.Header.Get("Authorization")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &captured.body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cst_abc","email":"a@b.c","name":"A B"}`))
+	})
+	defer srv.Close()
+
+	id, err := c.CreateCustomer(context.Background(), "a@b.c", "A B")
+	if err != nil {
+		t.Fatalf("CreateCustomer: %v", err)
+	}
+	if id != "cst_abc" {
+		t.Errorf("id: got %q want cst_abc", id)
+	}
+	if captured.method != "POST" || captured.path != "/customers" {
+		t.Errorf("request: %s %s, want POST /customers", captured.method, captured.path)
+	}
+	if captured.auth != "Bearer test_dummy" {
+		t.Errorf("auth header: %q", captured.auth)
+	}
+	if captured.body["email"] != "a@b.c" || captured.body["name"] != "A B" {
+		t.Errorf("body: %v", captured.body)
+	}
+}
+
+// TestMollieClient_CreateFirstPayment verifies the sequenceType=first
+// shape that captures a mandate, and that the returned checkout URL
+// surfaces.
+func TestMollieClient_CreateFirstPayment(t *testing.T) {
+	var captured map[string]any
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"tr_xyz",
+			"status":"open",
+			"amount":{"currency":"EUR","value":"9.00"},
+			"_links":{"checkout":{"href":"https://www.mollie.com/checkout/select-method/xyz"}}
+		}`))
+	})
+	defer srv.Close()
+
+	p, err := c.CreateFirstPayment(context.Background(), FirstPaymentRequest{
+		AmountEUR:   "9.00",
+		CustomerID:  "cst_abc",
+		RedirectURL: "https://app/return",
+		WebhookURL:  "https://api/webhooks/mollie",
+		Description: "Pro",
+		Metadata:    map[string]string{"project_id": "p1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateFirstPayment: %v", err)
+	}
+	if p.ID != "tr_xyz" {
+		t.Errorf("payment id: got %q want tr_xyz", p.ID)
+	}
+	if p.Links.Checkout.Href == "" {
+		t.Error("checkout href missing")
+	}
+	if captured["sequenceType"] != "first" {
+		t.Errorf("sequenceType: want 'first' to capture the mandate, got %v", captured["sequenceType"])
+	}
+	if captured["customerId"] != "cst_abc" {
+		t.Errorf("customerId: %v", captured["customerId"])
+	}
+	amt, _ := captured["amount"].(map[string]any)
+	if amt["currency"] != "EUR" || amt["value"] != "9.00" {
+		t.Errorf("amount: %v", amt)
+	}
+}
+
+// TestMollieClient_GetPayment fetches the authoritative state.
+func TestMollieClient_GetPayment(t *testing.T) {
+	var hits int32
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if r.Method != "GET" || r.URL.Path != "/payments/tr_x" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"tr_x",
+			"status":"paid",
+			"amount":{"currency":"EUR","value":"9.00"},
+			"customerId":"cst_x",
+			"metadata":{"project_id":"p1","plan":"pro"}
+		}`))
+	})
+	defer srv.Close()
+
+	p, err := c.GetPayment(context.Background(), "tr_x")
+	if err != nil {
+		t.Fatalf("GetPayment: %v", err)
+	}
+	if p.Status != "paid" {
+		t.Errorf("status: %q", p.Status)
+	}
+	if p.Metadata["project_id"] != "p1" {
+		t.Errorf("metadata: %v", p.Metadata)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 hit, got %d", hits)
+	}
+}
+
+func TestMollieClient_ErrorSurfacesDetail(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		_, _ = w.Write([]byte(`{"status":422,"title":"Unprocessable Entity","detail":"amount.value is invalid"}`))
+	})
+	defer srv.Close()
+	_, err := c.CreateCustomer(context.Background(), "x", "y")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "422") || !strings.Contains(err.Error(), "amount.value is invalid") {
+		t.Errorf("error should surface Mollie detail: %v", err)
+	}
+}
+
+// TestMollieClient_VerifyWebhookSignature exercises both the happy and
+// adversarial paths. The signature is HMAC-SHA256(body, secret) hex.
+func TestMollieClient_VerifyWebhookSignature(t *testing.T) {
+	c := NewMollieClient("test_x", "topsecret")
+	body := []byte("id=tr_abc")
+	// Hex of HMAC-SHA256("id=tr_abc", "topsecret"). Computed once
+	// and pinned as a fixture; recompute with:
+	//   echo -n "id=tr_abc" | openssl dgst -sha256 -hmac "topsecret"
+	good := "5d45ed6bc4c6d9e6b62f30bb3bc6fada7f104ae7261dec794792faf26812ba2d"
+
+	if err := c.VerifyWebhookSignature(body, good); err != nil {
+		t.Errorf("expected good signature to verify, got %v", err)
+	}
+	if err := c.VerifyWebhookSignature(body, "00"+good[2:]); err == nil {
+		t.Error("expected mis-signed body to fail")
+	}
+	if err := c.VerifyWebhookSignature(body, ""); err == nil {
+		t.Error("expected empty signature to fail")
+	}
+	// Bad-secret path: configure no secret → method refuses to even try.
+	noSecret := NewMollieClient("test_x", "")
+	if err := noSecret.VerifyWebhookSignature(body, good); err == nil {
+		t.Error("expected unconfigured-secret to fail")
+	}
+}
+
+// TestMollieClient_CancelSubscription verifies the DELETE path shape.
+func TestMollieClient_CancelSubscription(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method: %s want DELETE", r.Method)
+		}
+		if r.URL.Path != "/customers/cst_x/subscriptions/sub_y" {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		w.WriteHeader(200)
+	})
+	defer srv.Close()
+	if err := c.CancelSubscription(context.Background(), "cst_x", "sub_y"); err != nil {
+		t.Errorf("CancelSubscription: %v", err)
+	}
+}
+
+func TestEuroStringToCents(t *testing.T) {
+	cases := map[string]int{
+		"9.00":  900,
+		"9":     900,
+		"9.5":   950,
+		"9.99":  999,
+		"0.01":  1,
+		"0":     0,
+		"":      0,
+		"abc":   0,
+		"9.999": 999, // truncates at 2 decimals (Mollie never returns more)
+	}
+	for in, want := range cases {
+		if got := euroStringToCents(in); got != want {
+			t.Errorf("euroStringToCents(%q) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -21,8 +21,16 @@ import (
 const (
 	PlanPro          = "pro"
 	PlanFree         = "free"
-	ProPriceEUR      = "9.00"
-	ProAmountCents   = 900
+	// Pricing is single-source-of-truth here for the moment.
+	// The marketing site (`/pricing`, the onboarding card, the
+	// projects list "€19/mo" tag in console/src/routes/(app)/projects)
+	// and this constant MUST match — review feedback on PR #163 caught
+	// a €9/€19 mismatch that would have given the first paying
+	// customer a different price at checkout than what they were
+	// shown. When a Team or annual tier ships, move pricing into
+	// the plan_limits table so there's only one place to look.
+	ProPriceEUR      = "19.00"
+	ProAmountCents   = 1900
 	ProDescription   = "Eurobase Pro — monthly subscription"
 	GracePeriodHours = 72 // 3 days
 

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -1,0 +1,494 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/eurobase/euroback/internal/audit"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Pro plan price in EUR. Hard-coded for v1 because plan_limits doesn't
+// carry a price column (migration 000017). A follow-up migration can
+// move this into the DB once the Pro tier ships and a Team tier
+// shows up — until then, one constant is fewer moving parts than a
+// half-populated config table.
+const (
+	PlanPro          = "pro"
+	PlanFree         = "free"
+	ProPriceEUR      = "9.00"
+	ProAmountCents   = 900
+	ProDescription   = "Eurobase Pro — monthly subscription"
+	GracePeriodHours = 72 // 3 days
+
+	// Subscription rows go through these status values. The naming
+	// matches Mollie's where they overlap (active, cancelled) and
+	// invents the rest to carry our state machine that Mollie has
+	// no opinion on (pending_payment, grace, pro_until_period_end).
+	StatusPending             = "pending_payment"
+	StatusActive              = "active"
+	StatusGrace               = "grace"
+	StatusProUntilPeriodEnd   = "pro_until_period_end"
+	StatusCancelled           = "cancelled"
+)
+
+// Service is the billing facade. Construct with NewService; methods
+// are safe for concurrent use because each call opens its own
+// short-lived DB transaction.
+type Service struct {
+	pool   *pgxpool.Pool
+	mollie *MollieClient
+	audit  *audit.Service
+
+	// Public-facing base URL the customer's browser bounces back to
+	// after Mollie checkout. Populated from CONSOLE_URL env at boot.
+	consoleURL string
+	// Public URL Mollie POSTs webhooks to. Populated from
+	// PUBLIC_GATEWAY_URL env at boot.
+	webhookURL string
+
+	// Optional: materialiser for pending_projects rows. Wired by the
+	// gateway after both packages are constructed (avoids a
+	// tenant→billing dependency cycle). nil disables the
+	// pending-projects branch in ApplyPaymentEvent.
+	provisionPending ProjectProvisioner
+}
+
+func NewService(pool *pgxpool.Pool, mollie *MollieClient, auditSvc *audit.Service, consoleURL, webhookURL string) *Service {
+	return &Service{
+		pool:       pool,
+		mollie:     mollie,
+		audit:      auditSvc,
+		consoleURL: strings.TrimRight(consoleURL, "/"),
+		webhookURL: strings.TrimRight(webhookURL, "/"),
+	}
+}
+
+// EnsureCustomer returns the Mollie customer ID for the given
+// platform user, creating one in Mollie + writing it back to
+// platform_users.mollie_customer_id if it doesn't exist yet. The
+// operation is idempotent — two concurrent calls for the same user
+// both end up with the same final mollie_customer_id; the second
+// caller sees it cached.
+func (s *Service) EnsureCustomer(ctx context.Context, platformUserID, email, name string) (string, error) {
+	var existing *string
+	if err := s.pool.QueryRow(ctx,
+		`SELECT mollie_customer_id FROM public.platform_users WHERE id = $1`,
+		platformUserID,
+	).Scan(&existing); err != nil {
+		return "", fmt.Errorf("lookup platform user: %w", err)
+	}
+	if existing != nil && *existing != "" {
+		return *existing, nil
+	}
+
+	id, err := s.mollie.CreateCustomer(ctx, email, name)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE public.platform_users
+		 SET mollie_customer_id = $2
+		 WHERE id = $1
+		   AND (mollie_customer_id IS NULL OR mollie_customer_id = '')`,
+		platformUserID, id,
+	); err != nil {
+		// Don't fail — the customer exists in Mollie, we just couldn't
+		// cache the ID. Next call will look it up again.
+		slog.Warn("failed to cache mollie_customer_id", "user", platformUserID, "error", err)
+	}
+	return id, nil
+}
+
+// SubscriptionView is what the GET subscription endpoint surfaces.
+// Status here is the platform-side status, not Mollie's raw value.
+type SubscriptionView struct {
+	Plan               string     `json:"plan"`
+	Status             string     `json:"status"`
+	AmountEUR          string     `json:"amount_eur,omitempty"`
+	CurrentPeriodEnd   *time.Time `json:"current_period_end,omitempty"`
+	CancelAtPeriodEnd  bool       `json:"cancel_at_period_end"`
+	GraceUntil         *time.Time `json:"grace_until,omitempty"`
+	MollieSubscription *string    `json:"-"`
+}
+
+// GetSubscription returns the platform-side view of the project's
+// current subscription state. Free projects with no subscription row
+// still get a valid response (just plan=free, no period info).
+func (s *Service) GetSubscription(ctx context.Context, projectID string) (*SubscriptionView, error) {
+	var v SubscriptionView
+	var mollieID *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT s.plan, s.status, s.current_period_end, s.cancel_at_period_end,
+		        s.grace_until, s.mollie_subscription_id
+		 FROM public.subscriptions s
+		 WHERE s.project_id = $1
+		 ORDER BY s.created_at DESC
+		 LIMIT 1`,
+		projectID,
+	).Scan(&v.Plan, &v.Status, &v.CurrentPeriodEnd, &v.CancelAtPeriodEnd, &v.GraceUntil, &mollieID)
+	if err == pgx.ErrNoRows {
+		// No subscription row → genuinely on free. The projects.plan
+		// column is the authoritative tier flag; subscription is the
+		// audit trail of how that tier was set.
+		return &SubscriptionView{Plan: PlanFree, Status: PlanFree}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load subscription: %w", err)
+	}
+	if v.Plan == PlanPro {
+		v.AmountEUR = ProPriceEUR
+	}
+	v.MollieSubscription = mollieID
+	return &v, nil
+}
+
+// StartUpgradeForPending creates a Mollie first payment that, once
+// paid, materialises a brand-new project from a pending_projects row.
+// Closes #70 — Pro-at-signup used to silently downgrade to free
+// because the project was created before the user had paid for it.
+//
+// Returns the Mollie payment ID + checkout URL. The caller is
+// responsible for storing the payment ID on the pending_projects row
+// (we don't take a DB tx here — the handler does it).
+func (s *Service) StartUpgradeForPending(ctx context.Context, pendingProjectID, ownerID, ownerEmail, ownerName, plan string) (paymentID, checkoutURL string, err error) {
+	if plan != PlanPro {
+		return "", "", fmt.Errorf("unsupported plan: %q", plan)
+	}
+	customerID, err := s.EnsureCustomer(ctx, ownerID, ownerEmail, ownerName)
+	if err != nil {
+		return "", "", fmt.Errorf("ensure customer: %w", err)
+	}
+	payment, err := s.mollie.CreateFirstPayment(ctx, FirstPaymentRequest{
+		AmountEUR:   ProPriceEUR,
+		CustomerID:  customerID,
+		RedirectURL: fmt.Sprintf("%s/projects?status=pending_provision", s.consoleURL),
+		WebhookURL:  fmt.Sprintf("%s/webhooks/mollie", s.webhookURL),
+		Description: ProDescription,
+		Metadata: map[string]string{
+			"pending_project_id": pendingProjectID,
+			"plan":               plan,
+		},
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return payment.ID, payment.Links.Checkout.Href, nil
+}
+
+// StartUpgrade creates a Mollie first payment for the project's
+// owner and returns the checkout URL. It also writes a
+// pending_payment subscription row so the webhook handler can find
+// the project by Mollie payment ID later.
+//
+// Today only Pro is supported; the plan argument is kept to make
+// future Team / Enterprise tiers a one-line addition.
+func (s *Service) StartUpgrade(ctx context.Context, projectID, ownerID, ownerEmail, ownerName, plan string) (string, error) {
+	if plan != PlanPro {
+		return "", fmt.Errorf("unsupported plan: %q", plan)
+	}
+
+	customerID, err := s.EnsureCustomer(ctx, ownerID, ownerEmail, ownerName)
+	if err != nil {
+		return "", fmt.Errorf("ensure customer: %w", err)
+	}
+
+	payment, err := s.mollie.CreateFirstPayment(ctx, FirstPaymentRequest{
+		AmountEUR:   ProPriceEUR,
+		CustomerID:  customerID,
+		RedirectURL: fmt.Sprintf("%s/p/%s/billing?status=return", s.consoleURL, projectID),
+		WebhookURL:  fmt.Sprintf("%s/webhooks/mollie", s.webhookURL),
+		Description: ProDescription,
+		Metadata: map[string]string{
+			"project_id": projectID,
+			"plan":       plan,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Persist the pending-payment row keyed by the Mollie payment ID so
+	// the webhook handler can find the project to upgrade.
+	_, err = s.pool.Exec(ctx,
+		`INSERT INTO public.subscriptions (project_id, mollie_subscription_id, plan, status, current_period_start)
+		 VALUES ($1, NULL, $2, $3, now())
+		 ON CONFLICT DO NOTHING`,
+		projectID, plan, StatusPending,
+	)
+	if err != nil {
+		slog.Warn("failed to insert pending subscription row", "project", projectID, "error", err)
+	}
+
+	if s.audit != nil {
+		s.audit.Log(ctx, projectID, ownerID, ownerEmail,
+			audit.ActionSubscriptionCreated,
+			audit.WithMetadata(map[string]any{
+				"plan":           plan,
+				"mollie_payment": payment.ID,
+				"status":         StatusPending,
+			}))
+	}
+
+	return payment.Links.Checkout.Href, nil
+}
+
+// Cancel flips cancel_at_period_end=true on the active subscription
+// and asks Mollie to stop further charges. The customer keeps Pro
+// features until current_period_end; the dunning sweeper does the
+// actual downgrade.
+func (s *Service) Cancel(ctx context.Context, projectID, actorID, actorEmail string) error {
+	var mollieCustomerID, mollieSubID *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT pu.mollie_customer_id, s.mollie_subscription_id
+		 FROM public.subscriptions s
+		 JOIN public.projects p   ON p.id = s.project_id
+		 JOIN public.platform_users pu ON pu.id = p.owner_id
+		 WHERE s.project_id = $1 AND s.status IN ($2, $3)
+		 ORDER BY s.created_at DESC LIMIT 1`,
+		projectID, StatusActive, StatusGrace,
+	).Scan(&mollieCustomerID, &mollieSubID)
+	if err == pgx.ErrNoRows {
+		return fmt.Errorf("no active subscription")
+	}
+	if err != nil {
+		return fmt.Errorf("lookup subscription: %w", err)
+	}
+
+	if mollieCustomerID != nil && *mollieCustomerID != "" &&
+		mollieSubID != nil && *mollieSubID != "" {
+		if err := s.mollie.CancelSubscription(ctx, *mollieCustomerID, *mollieSubID); err != nil {
+			return fmt.Errorf("mollie cancel: %w", err)
+		}
+	}
+
+	_, err = s.pool.Exec(ctx,
+		`UPDATE public.subscriptions
+		 SET cancel_at_period_end = true, status = $2
+		 WHERE project_id = $1 AND status IN ($3, $4)`,
+		projectID, StatusProUntilPeriodEnd, StatusActive, StatusGrace,
+	)
+	if err != nil {
+		return fmt.Errorf("flag cancel_at_period_end: %w", err)
+	}
+
+	if s.audit != nil {
+		s.audit.Log(ctx, projectID, actorID, actorEmail,
+			audit.ActionSubscriptionCancelled,
+			audit.WithMetadata(map[string]any{
+				"effective_until_period_end": true,
+			}))
+	}
+	return nil
+}
+
+// ProjectProvisioner is what the billing service calls back into when
+// it needs to materialise a pending_projects row into a real
+// public.projects row on first-payment-paid (#70). The tenant
+// package supplies this so internal/billing doesn't need to depend
+// on internal/tenant.
+type ProjectProvisioner func(ctx context.Context, pendingProjectID string) (projectID string, err error)
+
+// SetProjectProvisioner wires in the callback used by the
+// pending-project materialisation path. Safe to leave unset for
+// tests that don't exercise the pending-projects branch.
+func (s *Service) SetProjectProvisioner(fn ProjectProvisioner) { s.provisionPending = fn }
+
+// ApplyPaymentEvent is the workhorse of the webhook handler. Given a
+// payment ID (which Mollie hands us in the webhook body), it pulls
+// the authoritative state from Mollie and reconciles the
+// subscription + project plan + audit log. Safe to call multiple
+// times for the same payment ID — idempotency comes from
+// ON CONFLICT DO NOTHING on invoices and from the status-machine
+// transitions being no-ops when the state already matches.
+func (s *Service) ApplyPaymentEvent(ctx context.Context, paymentID string) error {
+	payment, err := s.mollie.GetPayment(ctx, paymentID)
+	if err != nil {
+		return fmt.Errorf("fetch payment: %w", err)
+	}
+	projectID := payment.Metadata["project_id"]
+	// Pending-project flow (#70): no project exists yet, materialise
+	// from pending_projects when the payment first lands as paid.
+	if projectID == "" {
+		if pendingID := payment.Metadata["pending_project_id"]; pendingID != "" && payment.Status == "paid" && s.provisionPending != nil {
+			created, perr := s.provisionPending(ctx, pendingID)
+			if perr != nil {
+				return fmt.Errorf("provision pending project: %w", perr)
+			}
+			projectID = created
+			// Delete the pending row now that the real project exists.
+			_, _ = s.pool.Exec(ctx, `DELETE FROM public.pending_projects WHERE id = $1`, pendingID)
+		} else if pendingID := payment.Metadata["pending_project_id"]; pendingID != "" && (payment.Status == "failed" || payment.Status == "expired" || payment.Status == "canceled") {
+			// Customer abandoned checkout or the payment failed before
+			// we could provision. Drop the reservation so the slug is
+			// freed up for them to try again (or pick a different name).
+			_, _ = s.pool.Exec(ctx, `DELETE FROM public.pending_projects WHERE id = $1`, pendingID)
+			return nil
+		} else {
+			return fmt.Errorf("payment %s has no project_id metadata", paymentID)
+		}
+	}
+
+	// Record the invoice unconditionally — failed / refunded
+	// payments still get a row so the operator can see the attempt.
+	paidAt := time.Time{}
+	if payment.PaidAt != nil {
+		paidAt = *payment.PaidAt
+	}
+	amountCents := euroStringToCents(payment.Amount.Value)
+	_, _ = s.pool.Exec(ctx,
+		`INSERT INTO public.invoices
+		   (project_id, mollie_payment_id, amount_cents, currency, status, paid_at)
+		 VALUES ($1, $2, $3, $4, $5, NULLIF($6, '0001-01-01 00:00:00+00'::timestamptz))
+		 ON CONFLICT (mollie_payment_id) DO UPDATE
+		   SET status = EXCLUDED.status,
+		       paid_at = EXCLUDED.paid_at`,
+		projectID, payment.ID, amountCents, payment.Amount.Currency,
+		payment.Status, paidAt,
+	)
+
+	switch payment.Status {
+	case "paid":
+		return s.handlePaymentPaid(ctx, projectID, payment)
+	case "failed", "expired", "canceled":
+		return s.handlePaymentFailed(ctx, projectID, payment)
+	default:
+		// "open" / "pending" — nothing to do; we'll see another
+		// webhook when the state moves.
+		return nil
+	}
+}
+
+// handlePaymentPaid promotes the project to Pro. Covers two cases:
+// (a) first payment captured a mandate → create the recurring
+//     subscription in Mollie + flip status to active.
+// (b) subsequent monthly charge → already in active; just re-up the
+//     period_end and leave grace_until null (cleared from any prior
+//     dunning).
+func (s *Service) handlePaymentPaid(ctx context.Context, projectID string, payment *MolliePayment) error {
+	mollieSubID := payment.SubscriptionID
+	if mollieSubID == "" {
+		// First payment — we need to actually create the recurring
+		// subscription now. The mandate was captured by sequenceType=first.
+		sub, err := s.mollie.CreateSubscription(ctx, payment.CustomerID, ProPriceEUR, ProDescription,
+			fmt.Sprintf("%s/webhooks/mollie", s.webhookURL))
+		if err != nil {
+			slog.Error("create mollie subscription failed after first payment paid",
+				"project", projectID, "payment", payment.ID, "error", err)
+			return err
+		}
+		mollieSubID = sub.ID
+	}
+
+	periodEnd := time.Now().AddDate(0, 1, 0)
+	_, err := s.pool.Exec(ctx,
+		`UPDATE public.subscriptions
+		 SET status = $2, mollie_subscription_id = $3,
+		     current_period_start = now(),
+		     current_period_end = $4,
+		     grace_until = NULL
+		 WHERE project_id = $1 AND status IN ($5, $6, $7)`,
+		projectID, StatusActive, mollieSubID, periodEnd,
+		StatusPending, StatusGrace, StatusActive,
+	)
+	if err != nil {
+		return fmt.Errorf("update subscription to active: %w", err)
+	}
+
+	_, err = s.pool.Exec(ctx,
+		`UPDATE public.projects SET plan = $2 WHERE id = $1 AND plan <> $2`,
+		projectID, PlanPro,
+	)
+	if err != nil {
+		return fmt.Errorf("flip project plan to pro: %w", err)
+	}
+
+	if s.audit != nil {
+		md, _ := json.Marshal(map[string]any{
+			"mollie_payment":      payment.ID,
+			"mollie_subscription": mollieSubID,
+			"amount_eur":          payment.Amount.Value,
+		})
+		s.audit.Log(ctx, projectID, "", "", audit.ActionPaymentSucceeded,
+			audit.WithTarget("payment", payment.ID),
+			audit.WithMetadata(map[string]any{"raw": string(md)}))
+		s.audit.Log(ctx, projectID, "", "", audit.ActionPlanChanged,
+			audit.WithMetadata(map[string]any{"from": PlanFree, "to": PlanPro}))
+	}
+	return nil
+}
+
+// handlePaymentFailed starts (or extends) grace. Mollie keeps
+// retrying the charge for up to 21 days; we give the customer 3 days
+// of grace, then downgrade. The dunning sweeper performs the actual
+// downgrade — this function only sets grace_until.
+func (s *Service) handlePaymentFailed(ctx context.Context, projectID string, payment *MolliePayment) error {
+	graceUntil := time.Now().Add(GracePeriodHours * time.Hour)
+	_, err := s.pool.Exec(ctx,
+		`UPDATE public.subscriptions
+		 SET status = $2, grace_until = $3
+		 WHERE project_id = $1 AND status IN ($4, $5)`,
+		projectID, StatusGrace, graceUntil, StatusActive, StatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("flip subscription to grace: %w", err)
+	}
+
+	if s.audit != nil {
+		s.audit.Log(ctx, projectID, "", "", audit.ActionPaymentFailed,
+			audit.WithTarget("payment", payment.ID),
+			audit.WithMetadata(map[string]any{
+				"grace_until":     graceUntil.Format(time.RFC3339),
+				"mollie_payment":  payment.ID,
+				"payment_status":  payment.Status,
+			}))
+	}
+	return nil
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+// euroStringToCents converts Mollie's decimal-string amount ("9.00") to
+// integer cents (900). Mollie never returns more than 2 decimals for
+// EUR. On a malformed value we return 0 + log; downstream callers
+// treat zero amounts as "we recorded the attempt but the auditor will
+// need to reconcile against Mollie".
+func euroStringToCents(v string) int {
+	v = strings.TrimSpace(v)
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return 0
+	}
+	whole := 0
+	for _, r := range parts[0] {
+		if r < '0' || r > '9' {
+			slog.Warn("malformed mollie amount", "value", v)
+			return 0
+		}
+		whole = whole*10 + int(r-'0')
+	}
+	cents := 0
+	if len(parts) == 2 {
+		fr := parts[1]
+		if len(fr) > 2 {
+			fr = fr[:2]
+		}
+		for _, r := range fr {
+			if r < '0' || r > '9' {
+				slog.Warn("malformed mollie amount", "value", v)
+				return 0
+			}
+			cents = cents*10 + int(r-'0')
+		}
+		if len(fr) == 1 {
+			cents *= 10
+		}
+	}
+	return whole*100 + cents
+}

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -1,0 +1,328 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/eurobase/euroback/internal/audit"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Service-level tests. These require a Postgres with the migration
+// surface up-to-date (000055 + 000056). Skipped under -short to match
+// every other DB-backed test in the codebase.
+
+func openServicePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		url = "postgres://eurobase_api:localdev@localhost:5433/eurobase?sslmode=disable"
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Skipf("cannot connect: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("cannot ping: %v", err)
+	}
+	return pool
+}
+
+// stubMollie returns a Mollie client wired to an httptest server that
+// returns the given payment JSON for any GetPayment call. Service
+// tests use this so ApplyPaymentEvent can be driven end-to-end without
+// touching real Mollie.
+func stubMollie(t *testing.T, paymentJSON, subscriptionJSON string) *MollieClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && len(r.URL.Path) > len("/payments/") && r.URL.Path[:len("/payments/")] == "/payments/":
+			_, _ = w.Write([]byte(paymentJSON))
+		case r.Method == "POST" && len(r.URL.Path) > len("/customers/") && r.URL.Path[len(r.URL.Path)-len("/subscriptions"):] == "/subscriptions":
+			_, _ = w.Write([]byte(subscriptionJSON))
+		case r.Method == "DELETE":
+			w.WriteHeader(200)
+		case r.URL.Path == "/customers":
+			_, _ = w.Write([]byte(`{"id":"cst_test","email":"o@e.com","name":"O"}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := NewMollieClient("test_x", "wh")
+	c.baseURL = srv.URL
+	return c
+}
+
+func setupSubscriptionFixture(t *testing.T, pool *pgxpool.Pool) (projectID, ownerID string, cleanup func()) {
+	t.Helper()
+	ctx := context.Background()
+	// Owner
+	var oid string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.platform_users (email, password_hash)
+		 VALUES ('billtest+' || gen_random_uuid()::text || '@example.com', 'x')
+		 RETURNING id::text`).Scan(&oid); err != nil {
+		t.Skipf("seed platform user: %v", err)
+	}
+	// Project
+	var pid string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.projects (name, slug, schema_name, owner_id, plan)
+		 VALUES ('billtest', 'billtest-' || substr(gen_random_uuid()::text, 1, 8),
+		         'tenant_billtest_' || substr(gen_random_uuid()::text, 1, 8),
+		         $1, 'free')
+		 RETURNING id::text`, oid).Scan(&pid); err != nil {
+		_, _ = pool.Exec(ctx, `DELETE FROM public.platform_users WHERE id = $1`, oid)
+		t.Skipf("seed project: %v", err)
+	}
+	cleanup = func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM public.subscriptions WHERE project_id = $1`, pid)
+		_, _ = pool.Exec(ctx, `DELETE FROM public.invoices WHERE project_id = $1`, pid)
+		_, _ = pool.Exec(ctx, `DELETE FROM public.projects WHERE id = $1`, pid)
+		_, _ = pool.Exec(ctx, `DELETE FROM public.platform_users WHERE id = $1`, oid)
+	}
+	return pid, oid, cleanup
+}
+
+// TestApplyPaymentEvent_FreeToProOnPaid is the happy path that the
+// dashboard depends on. payment.status = paid → projects.plan flips
+// to pro, subscription row flips to active, invoice row written,
+// audit log carries the plan-change event.
+func TestApplyPaymentEvent_FreeToProOnPaid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openServicePool(t)
+	defer pool.Close()
+
+	pid, _, cleanup := setupSubscriptionFixture(t, pool)
+	defer cleanup()
+
+	// Insert the pending_payment row that StartUpgrade would have written.
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO public.subscriptions (project_id, plan, status, current_period_start)
+		 VALUES ($1, 'pro', 'pending_payment', now())`, pid); err != nil {
+		t.Fatalf("seed pending subscription: %v", err)
+	}
+
+	paymentJSON := `{
+		"id":"tr_paid",
+		"status":"paid",
+		"amount":{"currency":"EUR","value":"9.00"},
+		"customerId":"cst_test",
+		"paidAt":"2026-05-25T10:00:00Z",
+		"metadata":{"project_id":"` + pid + `","plan":"pro"}
+	}`
+	subJSON := `{"id":"sub_xyz","status":"active","amount":{"currency":"EUR","value":"9.00"},"interval":"1 month"}`
+	mollie := stubMollie(t, paymentJSON, subJSON)
+	auditSvc := audit.NewService(pool)
+	svc := NewService(pool, mollie, auditSvc, "http://console", "http://api")
+
+	if err := svc.ApplyPaymentEvent(context.Background(), "tr_paid"); err != nil {
+		t.Fatalf("ApplyPaymentEvent: %v", err)
+	}
+
+	// projects.plan must be pro.
+	var plan string
+	_ = pool.QueryRow(context.Background(),
+		`SELECT plan FROM public.projects WHERE id = $1`, pid).Scan(&plan)
+	if plan != PlanPro {
+		t.Errorf("projects.plan: got %q want pro", plan)
+	}
+	// subscription.status must be active + mollie_subscription_id set.
+	var status string
+	var mollieSubID *string
+	_ = pool.QueryRow(context.Background(),
+		`SELECT status, mollie_subscription_id FROM public.subscriptions WHERE project_id = $1`, pid).
+		Scan(&status, &mollieSubID)
+	if status != StatusActive {
+		t.Errorf("subscription.status: got %q want active", status)
+	}
+	if mollieSubID == nil || *mollieSubID != "sub_xyz" {
+		t.Errorf("mollie_subscription_id: got %v want sub_xyz", mollieSubID)
+	}
+	// invoice row must exist.
+	var invoiceCount int
+	_ = pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM public.invoices WHERE project_id = $1 AND status = 'paid'`, pid).
+		Scan(&invoiceCount)
+	if invoiceCount != 1 {
+		t.Errorf("invoice rows: got %d want 1", invoiceCount)
+	}
+}
+
+// TestApplyPaymentEvent_FailedStartsGrace covers the dunning entry
+// edge: payment.status=failed flips the subscription to grace with a
+// grace_until ~72h out, but does NOT downgrade the project plan yet.
+func TestApplyPaymentEvent_FailedStartsGrace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openServicePool(t)
+	defer pool.Close()
+
+	pid, _, cleanup := setupSubscriptionFixture(t, pool)
+	defer cleanup()
+
+	// Subscription was active prior to the failed renewal.
+	_, _ = pool.Exec(context.Background(),
+		`UPDATE public.projects SET plan = 'pro' WHERE id = $1`, pid)
+	_, _ = pool.Exec(context.Background(),
+		`INSERT INTO public.subscriptions (project_id, mollie_subscription_id, plan, status, current_period_start, current_period_end)
+		 VALUES ($1, 'sub_was_active', 'pro', 'active', now() - interval '20 days', now() + interval '10 days')`, pid)
+
+	paymentJSON := `{
+		"id":"tr_failed",
+		"status":"failed",
+		"amount":{"currency":"EUR","value":"9.00"},
+		"customerId":"cst_test",
+		"metadata":{"project_id":"` + pid + `","plan":"pro"}
+	}`
+	mollie := stubMollie(t, paymentJSON, "")
+	svc := NewService(pool, mollie, audit.NewService(pool), "http://console", "http://api")
+
+	if err := svc.ApplyPaymentEvent(context.Background(), "tr_failed"); err != nil {
+		t.Fatalf("ApplyPaymentEvent: %v", err)
+	}
+
+	var plan string
+	_ = pool.QueryRow(context.Background(),
+		`SELECT plan FROM public.projects WHERE id = $1`, pid).Scan(&plan)
+	if plan != PlanPro {
+		t.Errorf("project plan should stay pro during grace, got %q", plan)
+	}
+
+	var status string
+	var graceUntil *string
+	_ = pool.QueryRow(context.Background(),
+		`SELECT status, grace_until::text FROM public.subscriptions WHERE project_id = $1`, pid).
+		Scan(&status, &graceUntil)
+	if status != StatusGrace {
+		t.Errorf("subscription.status: got %q want grace", status)
+	}
+	if graceUntil == nil {
+		t.Error("grace_until should be set on failed-payment transition")
+	}
+}
+
+// TestRunDunningSweep_DowngradesAfterGraceExpiry is the close of the
+// dunning loop: a subscription whose grace_until is in the past gets
+// downgraded by the sweeper, projects.plan flips to free, and an
+// audit row is emitted.
+func TestRunDunningSweep_DowngradesAfterGraceExpiry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openServicePool(t)
+	defer pool.Close()
+
+	pid, _, cleanup := setupSubscriptionFixture(t, pool)
+	defer cleanup()
+
+	_, _ = pool.Exec(context.Background(),
+		`UPDATE public.projects SET plan = 'pro' WHERE id = $1`, pid)
+	_, _ = pool.Exec(context.Background(),
+		`INSERT INTO public.subscriptions (project_id, mollie_subscription_id, plan, status, grace_until, current_period_start)
+		 VALUES ($1, 'sub_exp', 'pro', 'grace', now() - interval '1 hour', now() - interval '5 days')`, pid)
+
+	mollie := stubMollie(t, "{}", "")
+	svc := NewService(pool, mollie, audit.NewService(pool), "http://console", "http://api")
+
+	downgraded, finalised, err := svc.RunDunningSweep(context.Background())
+	if err != nil {
+		t.Fatalf("RunDunningSweep: %v", err)
+	}
+	if downgraded < 1 {
+		t.Errorf("expected at least 1 grace-downgrade, got %d", downgraded)
+	}
+	_ = finalised
+
+	var plan, status string
+	_ = pool.QueryRow(context.Background(),
+		`SELECT projects.plan, subscriptions.status
+		 FROM public.projects
+		 JOIN public.subscriptions ON subscriptions.project_id = projects.id
+		 WHERE projects.id = $1`, pid).Scan(&plan, &status)
+	if plan != PlanFree {
+		t.Errorf("plan should be free after grace expiry, got %q", plan)
+	}
+	if status != StatusCancelled {
+		t.Errorf("subscription.status: got %q want cancelled", status)
+	}
+}
+
+// TestApplyPaymentEvent_IsIdempotent — receiving the same payment ID
+// twice must not double-create invoices or double-flip plan.
+func TestApplyPaymentEvent_IsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openServicePool(t)
+	defer pool.Close()
+
+	pid, _, cleanup := setupSubscriptionFixture(t, pool)
+	defer cleanup()
+	_, _ = pool.Exec(context.Background(),
+		`INSERT INTO public.subscriptions (project_id, plan, status, current_period_start)
+		 VALUES ($1, 'pro', 'pending_payment', now())`, pid)
+
+	paymentJSON := `{
+		"id":"tr_dup",
+		"status":"paid",
+		"amount":{"currency":"EUR","value":"9.00"},
+		"customerId":"cst_test",
+		"paidAt":"2026-05-25T10:00:00Z",
+		"metadata":{"project_id":"` + pid + `","plan":"pro"}
+	}`
+	subJSON := `{"id":"sub_dup","status":"active","amount":{"currency":"EUR","value":"9.00"},"interval":"1 month"}`
+	mollie := stubMollie(t, paymentJSON, subJSON)
+	svc := NewService(pool, mollie, audit.NewService(pool), "http://console", "http://api")
+
+	for i := 0; i < 3; i++ {
+		if err := svc.ApplyPaymentEvent(context.Background(), "tr_dup"); err != nil {
+			t.Fatalf("apply #%d: %v", i, err)
+		}
+	}
+
+	var invoiceCount int
+	_ = pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM public.invoices WHERE project_id = $1`, pid).Scan(&invoiceCount)
+	if invoiceCount != 1 {
+		t.Errorf("invoices should be deduped by ON CONFLICT, got %d rows", invoiceCount)
+	}
+}
+
+// TestSubscriptionView_PendingFreshProject — a project with no
+// subscription row gets a synthetic free view, never an error.
+func TestSubscriptionView_FreshProjectReturnsFree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	pool := openServicePool(t)
+	defer pool.Close()
+
+	pid, _, cleanup := setupSubscriptionFixture(t, pool)
+	defer cleanup()
+
+	svc := NewService(pool, NewMollieClient("test_x", "wh"), audit.NewService(pool), "", "")
+	v, err := svc.GetSubscription(context.Background(), pid)
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+	if v.Plan != PlanFree || v.Status != PlanFree {
+		t.Errorf("fresh project: got %+v, want plan=free status=free", v)
+	}
+
+	// Sanity-check JSON shape since the view is what the handler returns.
+	b, _ := json.Marshal(v)
+	if !json.Valid(b) {
+		t.Error("subscription view did not marshal to valid JSON")
+	}
+}

--- a/internal/gateway/integration_test.go
+++ b/internal/gateway/integration_test.go
@@ -149,7 +149,10 @@ func setupTestServer(t *testing.T, pool *pgxpool.Pool) *httptest.Server {
 	// V1 routes with test auth.
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(testAuthMiddleware)
-		r.Post("/tenants", tenant.HandleCreateProject(pool, tenantSvc))
+		// nil CheckoutStarter → Pro requests fall back to immediate
+		// creation (the pre-#70 behaviour). This integration test
+		// doesn't exercise the Mollie path.
+		r.Post("/tenants", tenant.HandleCreateProject(pool, tenantSvc, nil))
 		r.Get("/tenants", tenant.HandleListProjects(pool, tenantSvc))
 	})
 

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eurobase/euroback/internal/audit"
 	"github.com/eurobase/euroback/internal/auth"
+	"github.com/eurobase/euroback/internal/billing"
 	"github.com/eurobase/euroback/internal/compliance"
 	"github.com/eurobase/euroback/internal/cron"
 	"github.com/eurobase/euroback/internal/email"
@@ -89,6 +90,38 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 	isDev := len(devMode) > 0 && devMode[0]
 
 	// Health check (unauthenticated).
+	// ── Mollie billing — singleton service ─────────────────────────────────
+	// Constructed once at boot so the webhook handler and the per-project
+	// handlers share the same client. Configured() returns false if either
+	// env is unset; in that case the routes are still mounted but every
+	// handler short-circuits with 503 so a forgotten env var fails closed.
+	mollieClient := billing.NewMollieClient(
+		os.Getenv("MOLLIE_API_KEY"),
+		os.Getenv("MOLLIE_WEBHOOK_SECRET"),
+	)
+	billingConsoleURL := os.Getenv("CONSOLE_URL")
+	if billingConsoleURL == "" {
+		billingConsoleURL = "http://localhost:5173"
+	}
+	billingWebhookBase := os.Getenv("PUBLIC_GATEWAY_URL")
+	if billingWebhookBase == "" {
+		billingWebhookBase = "https://api.eurobase.app"
+	}
+	auditSvcForBilling := audit.NewService(pool)
+	billingSvc := billing.NewService(pool, mollieClient, auditSvcForBilling, billingConsoleURL, billingWebhookBase)
+	if !mollieClient.Configured() {
+		slog.Warn("billing: Mollie not configured (MOLLIE_API_KEY / MOLLIE_WEBHOOK_SECRET unset) — /billing endpoints will 503")
+	} else if mollieClient.TestMode() {
+		slog.Warn("billing: Mollie TEST mode active — production should use a live_ key")
+	}
+
+	// Mollie webhook receiver — top-level, unauthenticated by design.
+	// Signature verification + Mollie API roundtrip inside the handler.
+	// See internal/billing/handler.go HandleWebhook for the threat model.
+	// The pending-project materialiser callback is wired further down
+	// once tenantSvc is in scope.
+	r.Post("/webhooks/mollie", billing.HandleWebhook(billingSvc))
+
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -113,6 +146,35 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 
 	// Tenant service.
 	tenantSvc := tenant.NewTenantService(pool)
+
+	// #70: wire the pending-project materialiser so a paid Mollie
+	// checkout for a deferred Pro project triggers real project
+	// creation inside the webhook handler. Avoids a tenant→billing
+	// import cycle by handing the billing service a callback. Safe
+	// to wire even when Mollie isn't configured — the callback is
+	// never invoked in that case because the pending-projects
+	// reservation never gets a payment ID written to it.
+	billingSvc.SetProjectProvisioner(func(ctx context.Context, pendingProjectID string) (string, error) {
+		var ownerID, name, slug, region, plan string
+		err := pool.QueryRow(ctx,
+			`SELECT owner_id::text, name, slug, region, plan
+			 FROM public.pending_projects WHERE id = $1`,
+			pendingProjectID,
+		).Scan(&ownerID, &name, &slug, &region, &plan)
+		if err != nil {
+			return "", fmt.Errorf("load pending project %s: %w", pendingProjectID, err)
+		}
+		var ownerEmail string
+		_ = pool.QueryRow(ctx,
+			`SELECT email FROM public.platform_users WHERE id = $1`, ownerID,
+		).Scan(&ownerEmail)
+		req := tenant.CreateProjectRequest{Name: name, Slug: slug, Region: region, Plan: plan}
+		project, err := tenantSvc.CreateProject(ctx, ownerID, ownerEmail, req)
+		if err != nil {
+			return "", fmt.Errorf("provision project from pending row: %w", err)
+		}
+		return project.ID, nil
+	})
 
 	// Audit service — shared across all route groups that need to log actions.
 	auditSvc := audit.NewService(pool)
@@ -331,6 +393,16 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			r.With(tenant.RequireMinRole("admin")).Get("/compliance/exports", compliance.HandleListExports(exportSvc))
 			r.With(tenant.RequireMinRole("admin")).Get("/compliance/exports/{exportId}", compliance.HandleGetExport(exportSvc))
 
+			// Billing — Mollie subscription flow (#2). Reads → viewer
+			// (a viewer can see the plan + invoice list); mutations
+			// → admin (settings-shaped capability per the #50 mapping).
+			// The webhook is mounted at top-level above; this is the
+			// per-project surface only.
+			r.With(tenant.RequireMinRole("viewer")).Get("/billing/subscription", billing.HandleGetSubscription(billingSvc))
+			r.With(tenant.RequireMinRole("viewer")).Get("/billing/invoices", billing.HandleListInvoices(billingSvc))
+			r.With(tenant.RequireMinRole("admin")).Post("/billing/checkout", billing.HandleCheckout(billingSvc))
+			r.With(tenant.RequireMinRole("admin")).Post("/billing/cancel", billing.HandleCancel(billingSvc))
+
 			// Team members (invite, remove, change role).
 			var sendEmailFn func(ctx context.Context, to, subject, html string) error
 			if emailService != nil {
@@ -441,7 +513,17 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			})
 		})
 
-		r.Post("/", tenant.HandleCreateProject(pool, tenantSvc, limitsSvc))
+		// #70 fix: when the request asks for plan="pro" AND Mollie is
+		// configured, the handler defers project creation to the
+		// webhook-paid path. Pass the billing service's
+		// StartUpgradeForPending as the CheckoutStarter; pass nil
+		// when Mollie is unconfigured (dev/test) so Pro requests
+		// fall back to immediate creation.
+		var checkoutStarter tenant.CheckoutStarter
+		if mollieClient.Configured() {
+			checkoutStarter = billingSvc.StartUpgradeForPending
+		}
+		r.Post("/", tenant.HandleCreateProject(pool, tenantSvc, checkoutStarter, limitsSvc))
 		r.Get("/", tenant.HandleListProjects(pool, tenantSvc))
 		r.Patch("/{id}", tenant.HandleUpdateProject(pool, tenantSvc))
 		r.Delete("/{id}", tenant.HandleDeleteProject(pool, tenantSvc))

--- a/internal/tenant/handler.go
+++ b/internal/tenant/handler.go
@@ -2,6 +2,7 @@
 package tenant
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -116,11 +117,25 @@ func slugify(name string) string {
 	return s
 }
 
+// CheckoutStarter is what HandleCreateProject calls when a Pro plan
+// is requested. Returns the Mollie payment ID + checkout URL. Wired
+// in from the billing package (gateway/router.go composes both).
+// Pass nil to disable the pending-project flow — in which case Pro
+// requests fall back to immediate creation (the pre-#70 behaviour).
+type CheckoutStarter func(ctx context.Context, pendingProjectID, ownerID, ownerEmail, ownerName, plan string) (paymentID, checkoutURL string, err error)
+
 // HandleCreateProject returns an http.HandlerFunc that creates a new project
 // (tenant) for the authenticated platform user.
 //
 // POST /v1/tenants
-func HandleCreateProject(pool *pgxpool.Pool, svc *TenantService, limitsSvc ...*plans.LimitsService) http.HandlerFunc {
+//
+// #70: when the caller requests plan="pro" AND a CheckoutStarter is
+// configured, the project is NOT created immediately. Instead a
+// pending_projects reservation is written, a Mollie checkout is
+// started, and the response carries { status: "pending_payment",
+// checkout_url, pending_project_id }. The real public.projects row
+// is materialised by the webhook handler on payment.paid.
+func HandleCreateProject(pool *pgxpool.Pool, svc *TenantService, startCheckout CheckoutStarter, limitsSvc ...*plans.LimitsService) http.HandlerFunc {
 	_ = pool // pool is held by svc; kept in signature for consistency
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -190,6 +205,68 @@ func HandleCreateProject(pool *pgxpool.Pool, svc *TenantService, limitsSvc ...*p
 		// Default plan.
 		if req.Plan == "" {
 			req.Plan = "free"
+		}
+
+		// #70 fix: when Pro is requested AND billing is configured,
+		// defer creation. Reserve the slug in pending_projects so a
+		// second user can't grab it during the payment window, start
+		// Mollie checkout, and return a `pending_payment` response.
+		// The project is created in the webhook handler on the
+		// payment.paid event via the provisioner callback wired in
+		// router.go. Falls through to immediate creation if Mollie
+		// is not configured (dev/test).
+		if req.Plan == "pro" && startCheckout != nil {
+			slog.Info("create project: deferring Pro creation pending payment",
+				"name", req.Name, "owner_id", claims.Subject)
+
+			// Derive slug if not provided so the pending row holds a
+			// definite one (matches what svc.CreateProject would do).
+			slug := req.Slug
+			if slug == "" {
+				slug = slugify(req.Name)
+			}
+
+			var pendingID string
+			err := pool.QueryRow(r.Context(),
+				`INSERT INTO public.pending_projects (owner_id, name, slug, region, plan)
+				 VALUES ($1, $2, $3, $4, $5)
+				 RETURNING id::text`,
+				claims.Subject, req.Name, slug, req.Region, req.Plan,
+			).Scan(&pendingID)
+			if err != nil {
+				if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+					http.Error(w, `{"error":"This project URL is already taken (pending payment from another attempt). Please pick a different name."}`, http.StatusConflict)
+					return
+				}
+				slog.Error("pending project insert failed", "error", err, "user_id", claims.Subject)
+				http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+				return
+			}
+
+			paymentID, checkoutURL, err := startCheckout(r.Context(), pendingID, claims.Subject, claims.Email, claims.Email, req.Plan)
+			if err != nil {
+				// Rollback the reservation so the user can retry
+				// without their slug being orphaned for 24h.
+				_, _ = pool.Exec(r.Context(), `DELETE FROM public.pending_projects WHERE id = $1`, pendingID)
+				slog.Error("pending project checkout start failed", "error", err, "pending", pendingID)
+				http.Error(w, `{"error":"failed to start checkout"}`, http.StatusBadGateway)
+				return
+			}
+			// Save the Mollie payment ID so the webhook can find this
+			// row by either ID. The payment metadata also carries
+			// pending_project_id so either lookup path works.
+			_, _ = pool.Exec(r.Context(),
+				`UPDATE public.pending_projects SET mollie_payment_id = $2 WHERE id = $1`,
+				pendingID, paymentID)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status":             "pending_payment",
+				"pending_project_id": pendingID,
+				"checkout_url":       checkoutURL,
+			})
+			return
 		}
 
 		// #70 diagnostic: log right before the INSERT so we can see if

--- a/migrations/000055_billing_state.down.sql
+++ b/migrations/000055_billing_state.down.sql
@@ -1,0 +1,8 @@
+-- 000055_billing_state.down.sql
+
+DROP INDEX IF EXISTS public.idx_subscriptions_pending_cancel;
+DROP INDEX IF EXISTS public.idx_subscriptions_grace_active;
+
+ALTER TABLE public.subscriptions
+    DROP COLUMN IF EXISTS grace_until,
+    DROP COLUMN IF EXISTS cancel_at_period_end;

--- a/migrations/000055_billing_state.up.sql
+++ b/migrations/000055_billing_state.up.sql
@@ -1,0 +1,29 @@
+-- 000055_billing_state.up.sql
+--
+-- Add the state fields the dunning + cancel-at-period-end flows need.
+-- Existing `subscriptions` table (from migration 000001) tracks plan +
+-- status but has no way to mark a subscription as "user requested
+-- cancellation, ride out the paid period" or "payment failed, in grace
+-- before downgrade". These two columns close that gap.
+--
+-- No explicit BEGIN/COMMIT — golang-migrate wraps each file in its own
+-- transaction. Inline COMMIT would commit the runner's outer tx early
+-- (same footgun as #121 / #145's migration 000052).
+
+ALTER TABLE public.subscriptions
+    ADD COLUMN IF NOT EXISTS cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS grace_until TIMESTAMPTZ NULL;
+
+-- Hourly dunning sweep scans for subscriptions that have exited grace
+-- without recovering payment. The partial index keeps the scan tight
+-- (matches only the small set of currently-in-grace rows).
+CREATE INDEX IF NOT EXISTS idx_subscriptions_grace_active
+    ON public.subscriptions (grace_until)
+    WHERE grace_until IS NOT NULL;
+
+-- Companion index for cancel-at-period-end sweeps. Tiny set in practice
+-- so a partial index is cheap and stays out of the way of the other
+-- subscription queries.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_pending_cancel
+    ON public.subscriptions (current_period_end)
+    WHERE cancel_at_period_end = true;

--- a/migrations/000056_pending_projects.down.sql
+++ b/migrations/000056_pending_projects.down.sql
@@ -1,0 +1,3 @@
+-- 000056_pending_projects.down.sql
+
+DROP TABLE IF EXISTS public.pending_projects;

--- a/migrations/000056_pending_projects.up.sql
+++ b/migrations/000056_pending_projects.up.sql
@@ -1,0 +1,46 @@
+-- 000056_pending_projects.up.sql
+--
+-- Closes #70. Selecting "Pro" at project creation used to write a row
+-- with plan='pro' without charging the user, then the project sat
+-- there free-with-pro-label. The new flow: when plan='pro' is
+-- requested at signup, we hold the project intent in pending_projects,
+-- start a Mollie checkout, and provision the real public.projects row
+-- only when the payment.paid webhook lands.
+--
+-- This table is the parking spot. Owned by the migrator role to match
+-- the rest of public.* (gateway role gets DML grants further down).
+
+CREATE TABLE IF NOT EXISTS public.pending_projects (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id            UUID NOT NULL REFERENCES public.platform_users(id) ON DELETE CASCADE,
+    name                TEXT NOT NULL,
+    slug                TEXT NOT NULL,
+    region              TEXT NOT NULL DEFAULT 'fr-par',
+    plan                TEXT NOT NULL,
+    mollie_payment_id   TEXT NULL UNIQUE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '24 hours')
+);
+
+-- Lookup path on the webhook: given a Mollie payment ID, find the
+-- pending row to materialise. Unique constraint on mollie_payment_id
+-- prevents double-provisioning if the webhook arrives twice.
+CREATE INDEX IF NOT EXISTS idx_pending_projects_payment
+    ON public.pending_projects (mollie_payment_id);
+
+-- Sweeper scan path. The expires_at default of 24h gives the user a
+-- generous window to complete checkout; rows past that are orphaned
+-- intent and get hard-deleted by the dunning worker.
+CREATE INDEX IF NOT EXISTS idx_pending_projects_expires
+    ON public.pending_projects (expires_at);
+
+-- Slug uniqueness against materialised projects is enforced by the
+-- existing public.projects.slug unique constraint at provision time;
+-- here we only guarantee no two pending rows hold the same slug for
+-- the same owner concurrently (collisions surface as a constraint
+-- violation at INSERT time and the handler maps that to a 409).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_projects_owner_slug
+    ON public.pending_projects (owner_id, slug);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.pending_projects TO eurobase_gateway;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.pending_projects TO eurobase_developer;

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -372,6 +372,44 @@ import type {
 } from '@eurobase/sdk'
 ```
 
+## Testing
+
+The query builder is **thenable** — `QueryBuilder` implements `PromiseLike`, so you can `await` any chain directly without a terminal call:
+
+```ts
+// Both of these work identically. The first form is recommended.
+const { data, error } = await eb.db.from('todos').select('*').eq('completed', false)
+const { data, error } = await eb.db.from('todos').select('*').eq('completed', false).execute()
+```
+
+Under the hood, the builder's `then()` calls `execute()` the first time the Promise machinery touches it (`await`, `.then`, `Promise.all`, etc.).
+
+### Writing test mocks
+
+If you replace the SDK with a mock in your tests, the mock has to be thenable too — otherwise `await mock.from(...).select(...)` resolves to the mock object instead of the `{ data, error }` shape your code expects. Make every chain method return `this` *and* implement `then()`:
+
+```ts
+class MockQueryBuilder {
+  constructor(private result: { data: any; error: string | null }) {}
+
+  from()   { return this }
+  select() { return this }
+  eq()     { return this }
+  // …add any other methods your code under test calls
+
+  // The crucial piece: thenable. Without this, await returns `this`.
+  then(onFulfilled?: any, onRejected?: any) {
+    return Promise.resolve(this.result).then(onFulfilled, onRejected)
+  }
+}
+
+const mockEb = {
+  db: { from: () => new MockQueryBuilder({ data: [{ id: 1 }], error: null }) },
+}
+```
+
+A mock that supports chaining without `then()` will appear to work — the chain compiles and runs — but every `await` returns the builder object itself, which is the most common surprise when migrating tests from a v1-style SDK that required an explicit `.execute()`.
+
 ## EU Sovereignty
 
 All data processed through the Eurobase SDK stays in EU jurisdiction (Scaleway, France). GDPR-compliant by design.


### PR DESCRIPTION
Closes #2, #70, #157, #158, #159, #160, #161, #162.

Schema tables existed since migration 000001 (`subscriptions`, `invoices`, `platform_users.mollie_customer_id`). This PR ships the code that turns them into a working payment system end-to-end.

## What landed

### Backend
- **`internal/billing/mollie.go`** — typed Mollie REST v2 client, zero new deps. 5 calls: `EnsureCustomer`, `CreateFirstPayment` (captures mandate via `sequenceType=first`), `CreateSubscription`, `CancelSubscription`, `GetPayment`. Plus `VerifyWebhookSignature` (HMAC-SHA256 against `MOLLIE_WEBHOOK_SECRET`).
- **`internal/billing/service.go`** — orchestrates DB + Mollie. `StartUpgrade`, `StartUpgradeForPending` (#70 path), `ApplyPaymentEvent` (webhook reconciliation), `Cancel`. Audit log row on every state transition.
- **`internal/billing/dunning.go`** — 3-day grace state machine + hourly sweeper. `failed payment → grace → downgrade` and `cancel → cancel_at_period_end → period elapsed → downgrade`. Idempotent.
- **`internal/billing/handler.go`** — 5 HTTP routes. Webhook always returns 200 so Mollie doesn't loop on retries; verifies via signature + Mollie API roundtrip before applying any state.
- **Migration 000055** — `cancel_at_period_end` + `grace_until` on `subscriptions` + two partial indexes for the sweep.
- **Migration 000056** — new `pending_projects` table (24h TTL, unique-per-owner-slug) for the #70 fix.
- **5 new audit action constants**: `billing.subscription.created/.cancelled`, `payment.succeeded/.failed`, `plan.changed`.

### #70 fix — defer Pro project creation until paid
`HandleCreateProject` now takes a `CheckoutStarter`. When `plan='pro'` AND Mollie is configured, the project is **NOT created immediately** — instead `pending_projects` reserves the slug, Mollie checkout starts, and the response is `{ status: 'pending_payment', pending_project_id, checkout_url }`. The real `public.projects` row is materialised by the webhook handler on `payment.paid` via a `ProjectProvisioner` callback (avoids a `tenant → billing` import cycle). Free signup flow is unchanged.

### Console
- **New `/p/[id]/billing` page** — subscription card, status badge, invoice list, Upgrade button, Cancel modal with grace-period explanation, `?autostart=1` deep-link support for the pricing-page CTA.
- **4 new API methods** + `SubscriptionView` / `Invoice` / `PendingProjectResponse` types. `createProject` return type widened to a union.

### Drive-by
- `sdk/js/README.md` Testing section documenting the thenable `QueryBuilder` pattern + `MockQueryBuilder` example (same bug another consumer just hit in their tests).

## Routes
| Method | Path | Auth |
|---|---|---|
| `POST` | `/platform/projects/{id}/billing/checkout` | admin |
| `GET`  | `/platform/projects/{id}/billing/subscription` | viewer |
| `POST` | `/platform/projects/{id}/billing/cancel` | admin |
| `GET`  | `/platform/projects/{id}/billing/invoices` | viewer |
| `POST` | `/webhooks/mollie` | public (signature-verified) |

## Tests
- **9 unit tests** against an httptest-mocked Mollie (`mollie_test.go`) — signature verification, error propagation, all client methods, amount parsing.
- **5 DB-backed tests** (`-short` skips) — free→pending→active, failed→grace, sweeper downgrade after grace expiry, idempotency on duplicate webhooks, fresh project returns synthetic free view.
- `internal/gateway/integration_test.go` updated to thread `nil` `CheckoutStarter` (pre-Mollie path preserved).

## Verification
- `go test -short ./...` → all 26 packages green incl. new `internal/billing`
- Console `npm run build` → 0 errors

## Operator action required before this is "live"

1. Sign up for a Mollie account, generate `test_*` API key
2. Generate webhook signing secret (`openssl rand -hex 32`)
3. Populate `eurobase-secrets` k8s Secret with `MOLLIE_API_KEY` + `MOLLIE_WEBHOOK_SECRET`
4. Configure webhook URL in Mollie dashboard: `https://api.eurobase.app/webhooks/mollie`
5. Smoke test with Mollie's test cards
6. Cutover from `test_` to `live_` key when ready to take real money

Full procedure in `docs/runbooks/billing-mollie.md`.

## Test plan

- [x] `go test -short ./...` — all packages green
- [x] Console builds
- [ ] CI green on this PR
- [ ] After merge: populate vault keys, configure Mollie webhook, smoke test against a test project (the runbook lists exact steps)
- [ ] Verify `/platform/projects/{id}/compliance/dpa-report` lists Mollie when a subscription row exists

## Out of scope (deferred follow-ups)

- Cross-page "Pro pending" banner on every project header (billing page surfaces state)
- CLI `eurobase admin billing reconcile <project>` (curl path documented)
- Mollie hosted customer-portal embed (we redirect to fresh checkout for card updates)
- Annual billing tier
- Edge function metering (#128), per-org Team tier (#131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)