### PR TITLE
Tier-1 #2: per-tenant vault encryption keys (HKDF) + rotation

### DIFF
--- a/docs/compliance/encryption-keys.md
+++ b/docs/compliance/encryption-keys.md
@@ -1,0 +1,86 @@
+# Vault Encryption Keys — Per-Tenant Derivation & Rotation
+
+> GDPR Art. 32 / Art. 25 (Tier-1 #2). How Eurobase encrypts tenant secrets at
+> rest, why each tenant has a distinct key, and how keys rotate.
+
+## What is encrypted
+
+Every secret in a tenant's `vault_secrets` table (`internal/vault`) is sealed
+with **AES-256-GCM** before it touches disk: API credentials, OAuth
+`client_secret`s, and any value a customer stores via the Vault SDK/console.
+Rows store the ciphertext (`secret`), the GCM `nonce`, and now a `key_version`.
+
+## Key model
+
+A single base64 32-byte master secret, `VAULT_ENCRYPTION_KEY`, is supplied via
+the `eurobase-secrets` Kubernetes Secret. The master is **never used directly**
+to seal new rows. Instead a `KeyProvider` (`internal/vault/keyprovider.go`)
+derives a **distinct key per tenant**:
+
+```
+tenant_key = HKDF-SHA256(
+    secret = VAULT_ENCRYPTION_KEY,
+    salt   = <tenant schema name>,   // per-tenant separation
+    info   = "eurobase-vault-v<N>",  // N = key version (rotation)
+    len    = 32,
+)
+```
+
+- **Per-tenant separation** — the salt is the tenant schema, so tenant A's key
+  cannot open tenant B's ciphertext (proved in `keyprovider_test.go`).
+- **Rotation** — the version is mixed into `info`, so bumping the version
+  yields a fresh, independent key without affecting older rows.
+
+### Versions
+
+| `key_version` | Meaning |
+|---|---|
+| `0` | **Legacy.** Row was sealed with the shared master key verbatim, before per-tenant derivation existed. The provider returns the master key for v0 so these rows keep decrypting. Existing rows are backfilled to 0 by migration `000057`. |
+| `1` | First HKDF-derived, per-tenant key. All **new** writes use the current version (starts at 1). |
+| `≥2` | Reserved for future rotations. |
+
+Decryption always dispatches on the row's stored `key_version`, so multiple
+versions coexist safely. A `Set`/`Update` re-seals at the current version, so
+rows migrate to per-tenant keys naturally as they're written.
+
+## Rotation
+
+`POST /platform/projects/{id}/vault/rekey` (admin-only) re-encrypts every
+secret in the project's vault under the current key version, including legacy
+v0 rows. It runs synchronously in one service-role transaction
+(`VaultService.RekeySchema`) — vaults hold few secrets per tenant, so this is
+cheap; audited as `vault.rekeyed`.
+
+To rotate the whole platform onto a new version: bump the provider's current
+version, deploy, then call rekey per project (or let writes migrate rows
+lazily).
+
+## Sovereignty & limits — honest scope
+
+This is **app-layer per-tenant key derivation**, not "the platform cannot
+decrypt your data" BYOK. The platform still holds the master secret and can
+derive any tenant key. It delivers what GDPR/DSK call for in *per-tenant
+cryptographic separation* and *key rotation*, but a German DSK reviewer asking
+for **client-held keys** wants more.
+
+The `KeyProvider` interface is the upgrade path. Because every ciphertext is
+tagged with its `key_version`, a future provider can own a distinct version
+range and coexist with HKDF rows — **no re-encryption of historic data
+required**:
+
+- **Scaleway Key Manager (KMS)** — envelope encryption with a managed,
+  EU-sovereign master key (rotation + access audit handled by Scaleway).
+- **Customer HYOK** — per-tenant key supplied/hosted by the customer (e.g.
+  self-hosted HashiCorp Vault in the EU) so the platform genuinely cannot
+  decrypt for that tenant.
+
+Both are tracked for enterprise; neither changes the on-disk format.
+
+## Operations
+
+- **Master rotation** is a bigger operation than version rotation: re-wrapping
+  every tenant key. Today, changing `VAULT_ENCRYPTION_KEY` breaks v0 rows and
+  changes all derived keys — so do it only alongside a full rekey to a new
+  version. Generate with `openssl rand -base64 32`.
+- **Backups:** ciphertext is useless without the master secret; keep the
+  `eurobase-secrets` Secret backed up separately from DB dumps.

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -23,6 +23,7 @@ const (
 	ActionVaultSecretUpdated  = "vault.secret_updated"
 	ActionVaultSecretDeleted  = "vault.secret_deleted"
 	ActionVaultSecretAccessed = "vault.secret_accessed"
+	ActionVaultRekeyed        = "vault.rekeyed"
 	ActionOAuthSecretSet     = "oauth.secret_set"
 	ActionDataExported       = "data.exported"
 	ActionMemberInvited      = "member.invited"

--- a/internal/vault/handler.go
+++ b/internal/vault/handler.go
@@ -37,11 +37,36 @@ const (
 func Routes(svc *VaultService, pool *pgxpool.Pool) chi.Router {
 	r := chi.NewRouter()
 	r.Get("/", handlePlatformList(svc, pool))
+	r.Post("/rekey", handlePlatformRekey(svc, pool))
 	r.Get("/{name}", handlePlatformGet(svc, pool))
 	r.Post("/", handlePlatformSet(svc, pool))
 	r.Patch("/{name}", handlePlatformUpdate(svc, pool))
 	r.Delete("/{name}", handlePlatformDelete(svc, pool))
 	return r
+}
+
+// handlePlatformRekey re-encrypts every secret in the project's vault under
+// the current key version (Tier-1 #2 key rotation). Admin-only — the mount
+// in router.go already gates /vault behind RequireMinRole("admin").
+func handlePlatformRekey(svc *VaultService, pool *pgxpool.Pool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID, schemaName, err := resolveSchema(r, pool)
+		if err != nil {
+			jsonError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
+		rekeyed, err := svc.RekeySchema(r.Context(), schemaName)
+		if err != nil {
+			slog.Error("vault rekey failed", "error", err, "project_id", projectID)
+			jsonError(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		slog.Info("vault rekeyed", "project_id", projectID, "rekeyed", rekeyed)
+		auditVault(r, projectID, audit.ActionVaultRekeyed, "")
+		jsonResponse(w, map[string]any{"rekeyed": rekeyed}, http.StatusOK)
+	}
 }
 
 // resolveSchema looks up the schema_name for a project the authenticated user

--- a/internal/vault/handler.go
+++ b/internal/vault/handler.go
@@ -64,7 +64,16 @@ func handlePlatformRekey(svc *VaultService, pool *pgxpool.Pool) http.HandlerFunc
 		}
 
 		slog.Info("vault rekeyed", "project_id", projectID, "rekeyed", rekeyed)
-		auditVault(r, projectID, audit.ActionVaultRekeyed, "")
+		// Rekey is schema-wide, not per-secret, so there's no single target
+		// name — record the count in metadata instead, keeping the entry
+		// self-describing.
+		if asvc := audit.FromContext(r.Context()); asvc != nil {
+			actorID, actorEmail := audit.ActorFromContext(r.Context())
+			asvc.Log(r.Context(), projectID, actorID, actorEmail, audit.ActionVaultRekeyed,
+				audit.WithMetadata(map[string]any{"rekeyed": rekeyed}),
+				audit.WithIP(r.RemoteAddr),
+			)
+		}
 		jsonResponse(w, map[string]any{"rekeyed": rekeyed}, http.StatusOK)
 	}
 }

--- a/internal/vault/keyprovider.go
+++ b/internal/vault/keyprovider.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	"context"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+)
+
+// KeyProvider supplies the AES-256 key used to seal/open a tenant's vault
+// secrets. It exists so the encryption key can be made per-tenant and
+// rotated without re-encrypting historic rows: every ciphertext stores the
+// key_version it was sealed with, and decryption asks the provider for the
+// key at that version.
+//
+// The interface is deliberately pluggable. Today the only implementation is
+// hkdfKeyProvider (app-layer per-tenant derivation from a master secret).
+// Future implementations — a Scaleway Key Manager envelope provider, or a
+// customer Hold-Your-Own-Key provider backed by a tenant-supplied key — can
+// be dropped in without touching call sites or migrating existing data, as
+// long as they own a distinct, non-overlapping version range.
+//
+// See docs/compliance/encryption-keys.md.
+type KeyProvider interface {
+	// DeriveKey returns the 32-byte AES-256 key for a tenant at a given
+	// version. `tenant` is a stable per-tenant identifier (the tenant
+	// schema name); it must be the same value on seal and open.
+	DeriveKey(ctx context.Context, tenant string, version int16) ([]byte, error)
+
+	// CurrentVersion is the key version new writes should be sealed with.
+	CurrentVersion() int16
+}
+
+// legacyKeyVersion (0) means "the row predates per-tenant keys and was sealed
+// with the shared master key verbatim". Rows created before migration
+// 000057 default to this version, so they keep decrypting unchanged.
+const legacyKeyVersion int16 = 0
+
+// hkdfKeyProvider derives a distinct key per (tenant, version) from a single
+// master secret using HKDF-SHA256. No external service, no new
+// infrastructure — the per-tenant separation and rotation are achieved
+// entirely in-process.
+//
+// This is NOT "platform-cannot-decrypt" BYOK: the platform still holds the
+// master secret and can derive any tenant key. It satisfies "per-tenant
+// cryptographic separation" and "key rotation"; true BYOK/HYOK requires a
+// different KeyProvider (tracked for enterprise).
+type hkdfKeyProvider struct {
+	master  []byte // 32-byte master secret (VAULT_ENCRYPTION_KEY, decoded)
+	current int16  // version used for new writes (>= 1)
+}
+
+// firstDerivedKeyVersion (1) is the first HKDF-derived, per-tenant version.
+const firstDerivedKeyVersion int16 = 1
+
+func newHKDFKeyProvider(master []byte) *hkdfKeyProvider {
+	return &hkdfKeyProvider{master: master, current: firstDerivedKeyVersion}
+}
+
+func (p *hkdfKeyProvider) CurrentVersion() int16 { return p.current }
+
+func (p *hkdfKeyProvider) DeriveKey(_ context.Context, tenant string, version int16) ([]byte, error) {
+	if version == legacyKeyVersion {
+		// Back-compat: rows sealed with the shared master key before
+		// per-tenant derivation existed.
+		return p.master, nil
+	}
+	if tenant == "" {
+		return nil, fmt.Errorf("vault: empty tenant identifier for key derivation")
+	}
+	// salt = tenant identifier (per-tenant separation), info = versioned
+	// label (rotation: bumping the version yields an independent key).
+	info := "eurobase-vault-v" + strconv.Itoa(int(version))
+	key, err := hkdf.Key(sha256.New, p.master, []byte(tenant), info, 32)
+	if err != nil {
+		return nil, fmt.Errorf("vault: derive tenant key: %w", err)
+	}
+	return key, nil
+}

--- a/internal/vault/keyprovider_test.go
+++ b/internal/vault/keyprovider_test.go
@@ -1,0 +1,118 @@
+package vault
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func testMaster() []byte {
+	m := make([]byte, 32)
+	for i := range m {
+		m[i] = byte(i)
+	}
+	return m
+}
+
+// Version 0 must return the master key verbatim so rows sealed before
+// per-tenant derivation existed keep decrypting unchanged.
+func TestHKDFProvider_LegacyVersionReturnsMaster(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	got, err := p.DeriveKey(context.Background(), "tenant_abc", legacyKeyVersion)
+	if err != nil {
+		t.Fatalf("DeriveKey v0: %v", err)
+	}
+	if !bytes.Equal(got, testMaster()) {
+		t.Errorf("v0 key = %x, want master %x", got, testMaster())
+	}
+}
+
+// Derivation must be deterministic: same (tenant, version) -> same 32-byte key.
+func TestHKDFProvider_Deterministic(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	ctx := context.Background()
+	k1, err := p.DeriveKey(ctx, "tenant_abc", 1)
+	if err != nil {
+		t.Fatalf("DeriveKey: %v", err)
+	}
+	k2, err := p.DeriveKey(ctx, "tenant_abc", 1)
+	if err != nil {
+		t.Fatalf("DeriveKey: %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Errorf("derivation not deterministic: %x != %x", k1, k2)
+	}
+	if len(k1) != 32 {
+		t.Errorf("derived key length = %d, want 32", len(k1))
+	}
+}
+
+// Different tenants must get different keys (per-tenant cryptographic
+// separation), and a derived key must never equal the master.
+func TestHKDFProvider_PerTenantSeparation(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	ctx := context.Background()
+	a, _ := p.DeriveKey(ctx, "tenant_a", 1)
+	b, _ := p.DeriveKey(ctx, "tenant_b", 1)
+	if bytes.Equal(a, b) {
+		t.Error("two tenants derived the same key")
+	}
+	if bytes.Equal(a, testMaster()) {
+		t.Error("derived per-tenant key equals the master key")
+	}
+}
+
+// Bumping the version (rotation) must yield an independent key for the same
+// tenant.
+func TestHKDFProvider_VersionRotation(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	ctx := context.Background()
+	v1, _ := p.DeriveKey(ctx, "tenant_a", 1)
+	v2, _ := p.DeriveKey(ctx, "tenant_a", 2)
+	if bytes.Equal(v1, v2) {
+		t.Error("v1 and v2 keys are identical; rotation would be a no-op")
+	}
+}
+
+func TestHKDFProvider_CurrentVersionIsDerived(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	if p.CurrentVersion() != firstDerivedKeyVersion {
+		t.Errorf("CurrentVersion = %d, want %d (HKDF, not legacy)", p.CurrentVersion(), firstDerivedKeyVersion)
+	}
+	if p.CurrentVersion() == legacyKeyVersion {
+		t.Error("new writes must not use the legacy master-key version")
+	}
+}
+
+func TestHKDFProvider_EmptyTenantRejected(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	if _, err := p.DeriveKey(context.Background(), "", 1); err == nil {
+		t.Error("expected error deriving a non-legacy key with empty tenant")
+	}
+}
+
+// End-to-end at the crypto layer: a value sealed under a derived key opens
+// back to the same plaintext, and a different tenant's key fails to open it.
+func TestSealOpen_RoundTripAndIsolation(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	ctx := context.Background()
+	keyA, _ := p.DeriveKey(ctx, "tenant_a", 1)
+	keyB, _ := p.DeriveKey(ctx, "tenant_b", 1)
+
+	ct, nonce, err := encryptWith(keyA, "hunter2")
+	if err != nil {
+		t.Fatalf("encryptWith: %v", err)
+	}
+
+	got, err := decryptWith(keyA, ct, nonce)
+	if err != nil {
+		t.Fatalf("decryptWith (same key): %v", err)
+	}
+	if got != "hunter2" {
+		t.Errorf("round-trip = %q, want %q", got, "hunter2")
+	}
+
+	if _, err := decryptWith(keyB, ct, nonce); err == nil {
+		t.Error("tenant B's key decrypted tenant A's ciphertext — separation broken")
+	}
+}

--- a/internal/vault/service.go
+++ b/internal/vault/service.go
@@ -45,12 +45,14 @@ type Secret struct {
 
 // VaultService provides encrypted secret storage backed by PostgreSQL.
 type VaultService struct {
-	pool *pgxpool.Pool
-	key  []byte // 32-byte AES-256 key
+	pool     *pgxpool.Pool
+	provider KeyProvider
 }
 
 // NewVaultService creates a new VaultService. The encryptionKey must be a
-// base64-encoded 32-byte key for AES-256-GCM.
+// base64-encoded 32-byte master secret. Per-tenant keys are derived from it
+// (see KeyProvider / hkdfKeyProvider); the master secret is never used
+// directly to seal new rows.
 func NewVaultService(pool *pgxpool.Pool, encryptionKey string) (*VaultService, error) {
 	key, err := base64.StdEncoding.DecodeString(encryptionKey)
 	if err != nil {
@@ -59,17 +61,40 @@ func NewVaultService(pool *pgxpool.Pool, encryptionKey string) (*VaultService, e
 	if len(key) != 32 {
 		return nil, fmt.Errorf("VAULT_ENCRYPTION_KEY must be 32 bytes (got %d)", len(key))
 	}
-	return &VaultService{pool: pool, key: key}, nil
+	return &VaultService{pool: pool, provider: newHKDFKeyProvider(key)}, nil
 }
 
 // Configured returns true if the vault service is ready to use.
 func (s *VaultService) Configured() bool {
-	return s != nil && len(s.key) == 32
+	return s != nil && s.provider != nil
 }
 
-// encrypt using AES-256-GCM.
-func (s *VaultService) encrypt(plaintext string) (ciphertext, nonce []byte, err error) {
-	block, err := aes.NewCipher(s.key)
+// seal encrypts plaintext for a tenant using the provider's current key
+// version, returning the ciphertext, nonce, and the version used so the
+// caller can persist it alongside the row.
+func (s *VaultService) seal(ctx context.Context, schemaName, plaintext string) (ciphertext, nonce []byte, version int16, err error) {
+	version = s.provider.CurrentVersion()
+	key, err := s.provider.DeriveKey(ctx, schemaName, version)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	ciphertext, nonce, err = encryptWith(key, plaintext)
+	return ciphertext, nonce, version, err
+}
+
+// open decrypts a row's ciphertext using the key for the version it was
+// sealed with.
+func (s *VaultService) open(ctx context.Context, schemaName string, ciphertext, nonce []byte, version int16) (string, error) {
+	key, err := s.provider.DeriveKey(ctx, schemaName, version)
+	if err != nil {
+		return "", err
+	}
+	return decryptWith(key, ciphertext, nonce)
+}
+
+// encryptWith seals plaintext under a 32-byte AES-256-GCM key.
+func encryptWith(key []byte, plaintext string) (ciphertext, nonce []byte, err error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,9 +110,9 @@ func (s *VaultService) encrypt(plaintext string) (ciphertext, nonce []byte, err 
 	return ciphertext, nonce, nil
 }
 
-// decrypt using AES-256-GCM.
-func (s *VaultService) decrypt(ciphertext, nonce []byte) (string, error) {
-	block, err := aes.NewCipher(s.key)
+// decryptWith opens AES-256-GCM ciphertext under the given key.
+func decryptWith(key, ciphertext, nonce []byte) (string, error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", err
 	}
@@ -130,14 +155,15 @@ func (s *VaultService) List(ctx context.Context, schemaName string) ([]Secret, e
 
 // Get returns a single decrypted secret by name.
 func (s *VaultService) Get(ctx context.Context, schemaName, name string) (*Secret, error) {
-	sql := `SELECT id, name, secret, nonce, description, created_at, updated_at
+	sql := `SELECT id, name, secret, nonce, key_version, description, created_at, updated_at
 		 FROM ` + vaultTable(schemaName) + ` WHERE name = $1`
 
 	var sec Secret
 	var encrypted, nonce []byte
+	var keyVersion int16
 	err := db.RunAsAuthService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
 		return tx.QueryRow(ctx, sql, name).Scan(
-			&sec.ID, &sec.Name, &encrypted, &nonce,
+			&sec.ID, &sec.Name, &encrypted, &nonce, &keyVersion,
 			&sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
 		)
 	})
@@ -148,9 +174,9 @@ func (s *VaultService) Get(ctx context.Context, schemaName, name string) (*Secre
 		return nil, fmt.Errorf("get vault secret: %w", err)
 	}
 
-	value, err := s.decrypt(encrypted, nonce)
+	value, err := s.open(ctx, schemaName, encrypted, nonce, keyVersion)
 	if err != nil {
-		slog.Error("vault decryption failed", "name", name, "error", err)
+		slog.Error("vault decryption failed", "name", name, "key_version", keyVersion, "error", err)
 		return nil, fmt.Errorf("decrypt vault secret: %w", err)
 	}
 	sec.Value = value
@@ -160,23 +186,24 @@ func (s *VaultService) Get(ctx context.Context, schemaName, name string) (*Secre
 
 // Set creates or updates (upserts) a secret.
 func (s *VaultService) Set(ctx context.Context, schemaName, name, value, description string) (*Secret, error) {
-	encrypted, nonce, err := s.encrypt(value)
+	encrypted, nonce, version, err := s.seal(ctx, schemaName, value)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt vault secret: %w", err)
 	}
 
-	sql := `INSERT INTO ` + vaultTable(schemaName) + ` (name, secret, nonce, description)
-		 VALUES ($1, $2, $3, $4)
+	sql := `INSERT INTO ` + vaultTable(schemaName) + ` (name, secret, nonce, key_version, description)
+		 VALUES ($1, $2, $3, $4, $5)
 		 ON CONFLICT (name) DO UPDATE SET
 		   secret = EXCLUDED.secret,
 		   nonce = EXCLUDED.nonce,
+		   key_version = EXCLUDED.key_version,
 		   description = EXCLUDED.description,
 		   updated_at = now()
 		 RETURNING id, name, description, created_at, updated_at`
 
 	var sec Secret
 	err = db.RunAsAuthService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
-		return tx.QueryRow(ctx, sql, name, encrypted, nonce, description).Scan(
+		return tx.QueryRow(ctx, sql, name, encrypted, nonce, version, description).Scan(
 			&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
 		)
 	})
@@ -193,9 +220,9 @@ func (s *VaultService) Update(ctx context.Context, schemaName, name string, newV
 		return nil, fmt.Errorf("nothing to update")
 	}
 
-	// If value is changing, re-encrypt.
+	// If value is changing, re-encrypt (at the current key version).
 	if newValue != nil {
-		encrypted, nonce, err := s.encrypt(*newValue)
+		encrypted, nonce, version, err := s.seal(ctx, schemaName, *newValue)
 		if err != nil {
 			return nil, fmt.Errorf("encrypt vault secret: %w", err)
 		}
@@ -203,14 +230,15 @@ func (s *VaultService) Update(ctx context.Context, schemaName, name string, newV
 		sql := `UPDATE ` + vaultTable(schemaName) + ` SET
 			   secret = $2,
 			   nonce = $3,
-			   description = COALESCE($4, description),
+			   key_version = $4,
+			   description = COALESCE($5, description),
 			   updated_at = now()
 			 WHERE name = $1
 			 RETURNING id, name, description, created_at, updated_at`
 
 		var sec Secret
 		err = db.RunAsAuthService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
-			return tx.QueryRow(ctx, sql, name, encrypted, nonce, newDescription).Scan(
+			return tx.QueryRow(ctx, sql, name, encrypted, nonce, version, newDescription).Scan(
 				&sec.ID, &sec.Name, &sec.Description, &sec.CreatedAt, &sec.UpdatedAt,
 			)
 		})
@@ -277,6 +305,75 @@ func (s *VaultService) Count(ctx context.Context, schemaName string) (int, error
 		return 0, fmt.Errorf("count vault secrets: %w", err)
 	}
 	return count, nil
+}
+
+// RekeySchema re-encrypts every secret in a tenant schema under the
+// provider's current key version. Rows already at the current version are
+// skipped. It returns the number of rows re-encrypted.
+//
+// This is the rotation path: bump the provider's current version (or swap in
+// a new KeyProvider) and run RekeySchema to migrate historic ciphertext —
+// including legacy version-0 rows still sealed with the shared master key —
+// onto the new per-tenant key. The whole schema is rekeyed in a single
+// service-role transaction so it is all-or-nothing.
+//
+// Vaults hold a small number of secrets per tenant (plan-capped, plus a
+// handful of machine-managed entries), so a synchronous re-encrypt is cheap.
+// If a tenant ever holds enough secrets that this blocks the request, move it
+// to a River job.
+func (s *VaultService) RekeySchema(ctx context.Context, schemaName string) (int, error) {
+	target := s.provider.CurrentVersion()
+	selectSQL := `SELECT id, secret, nonce, key_version FROM ` + vaultTable(schemaName) +
+		` WHERE key_version <> $1 FOR UPDATE`
+	updateSQL := `UPDATE ` + vaultTable(schemaName) +
+		` SET secret = $2, nonce = $3, key_version = $4, updated_at = now() WHERE id = $1`
+
+	var rekeyed int
+	err := db.RunAsAuthService(ctx, s.pool, func(ctx context.Context, tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, selectSQL, target)
+		if err != nil {
+			return fmt.Errorf("select secrets for rekey: %w", err)
+		}
+		type row struct {
+			id         string
+			ciphertext []byte
+			nonce      []byte
+			version    int16
+		}
+		var pending []row
+		for rows.Next() {
+			var rw row
+			if err := rows.Scan(&rw.id, &rw.ciphertext, &rw.nonce, &rw.version); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan secret for rekey: %w", err)
+			}
+			pending = append(pending, rw)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		for _, rw := range pending {
+			plaintext, err := s.open(ctx, schemaName, rw.ciphertext, rw.nonce, rw.version)
+			if err != nil {
+				return fmt.Errorf("decrypt secret %s (v%d) during rekey: %w", rw.id, rw.version, err)
+			}
+			newCT, newNonce, newVersion, err := s.seal(ctx, schemaName, plaintext)
+			if err != nil {
+				return fmt.Errorf("re-encrypt secret %s during rekey: %w", rw.id, err)
+			}
+			if _, err := tx.Exec(ctx, updateSQL, rw.id, newCT, newNonce, newVersion); err != nil {
+				return fmt.Errorf("update secret %s during rekey: %w", rw.id, err)
+			}
+			rekeyed++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return rekeyed, nil
 }
 
 // ── Raw helpers (no Secret struct, no description) ──

--- a/internal/vault/service_test.go
+++ b/internal/vault/service_test.go
@@ -254,3 +254,70 @@ func TestVaultRawHelpers_AreServiceScoped(t *testing.T) {
 		t.Errorf("DeleteRaw(existing) returned error: %v", err)
 	}
 }
+
+// TestVaultRekeySchema_LegacyToCurrent exercises the full rotation path
+// against a real database: a row sealed at the legacy version 0 (shared
+// master key, simulating a pre-#167 secret) is re-encrypted under the
+// current per-tenant version, while a row already at the current version is
+// left untouched. This covers the select-FOR UPDATE → decrypt-at-old-version
+// → re-seal-at-current → update transaction in RekeySchema — the rotation
+// path GDPR review depends on.
+func TestVaultRekeySchema_LegacyToCurrent(t *testing.T) {
+	svc, schema, _ := setupVaultTest(t)
+	ctx := context.Background()
+
+	hk, ok := svc.provider.(*hkdfKeyProvider)
+	if !ok {
+		t.Fatalf("expected *hkdfKeyProvider, got %T", svc.provider)
+	}
+
+	// Seal one secret at the legacy version 0 (shared master key) by
+	// temporarily pointing the provider's current version at 0, then
+	// restore it so subsequent writes use the per-tenant v1.
+	hk.current = legacyKeyVersion
+	if _, err := svc.Set(ctx, schema, "LEGACY", "v0-value", "from before per-tenant keys"); err != nil {
+		t.Fatalf("Set legacy secret: %v", err)
+	}
+	hk.current = firstDerivedKeyVersion
+
+	// A fresh secret is sealed at the current per-tenant version.
+	if _, err := svc.Set(ctx, schema, "MODERN", "v1-value", ""); err != nil {
+		t.Fatalf("Set modern secret: %v", err)
+	}
+
+	// First rekey: only the legacy (v0) row is below the current version,
+	// so exactly one row should be re-encrypted.
+	n, err := svc.RekeySchema(ctx, schema)
+	if err != nil {
+		t.Fatalf("RekeySchema: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("first RekeySchema rekeyed %d rows, want 1 (only the v0 row)", n)
+	}
+
+	// Both secrets must still decrypt to their original plaintext after the
+	// key change.
+	legacy, err := svc.Get(ctx, schema, "LEGACY")
+	if err != nil {
+		t.Fatalf("Get LEGACY after rekey: %v", err)
+	}
+	if legacy.Value != "v0-value" {
+		t.Errorf("LEGACY value after rekey = %q, want %q", legacy.Value, "v0-value")
+	}
+	modern, err := svc.Get(ctx, schema, "MODERN")
+	if err != nil {
+		t.Fatalf("Get MODERN after rekey: %v", err)
+	}
+	if modern.Value != "v1-value" {
+		t.Errorf("MODERN value after rekey = %q, want %q", modern.Value, "v1-value")
+	}
+
+	// Second rekey is a no-op: every row is now at the current version.
+	n2, err := svc.RekeySchema(ctx, schema)
+	if err != nil {
+		t.Fatalf("second RekeySchema: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second RekeySchema rekeyed %d rows, want 0 (all already current)", n2)
+	}
+}

--- a/migrations/000057_vault_key_version.down.sql
+++ b/migrations/000057_vault_key_version.down.sql
@@ -1,0 +1,244 @@
+-- 000057_vault_key_version.down.sql
+--
+-- Reverts per-tenant key_version support. Drops the column from every
+-- tenant schema and restores provision_tenant to the 000056 body.
+--
+-- WARNING: only safe if no row was sealed at a non-zero key_version.
+-- Dropping key_version discards the information needed to decrypt rows
+-- that were re-encrypted under a per-tenant key. If any vault write has
+-- happened since 000057 applied, run RekeySchema back to version 0 first,
+-- or those secrets become undecryptable.
+
+-- ── 1. Drop the column from existing tenant schemas ────────────────────
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL LOOP
+        EXECUTE format('ALTER TABLE %I.vault_secrets DROP COLUMN IF EXISTS key_version', rec.schema_name);
+    END LOOP;
+END$$;
+
+-- ── 2. Restore provision_tenant to the 000056 body (no key_version) ────
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+    v_func_role   TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+    v_func_role   := v_schema_name || '_func';
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL UNIQUE,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+         $_$', v_schema_name, v_schema_name
+    );
+
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    EXECUTE format('CREATE ROLE %I NOLOGIN INHERIT', v_func_role);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT USAGE, SELECT ON SEQUENCES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format('GRANT %I TO eurobase_function_runner', v_func_role);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;

--- a/migrations/000057_vault_key_version.up.sql
+++ b/migrations/000057_vault_key_version.up.sql
@@ -1,0 +1,266 @@
+-- 000057_vault_key_version.up.sql
+--
+-- Tier-1 GDPR #2 (per-tenant encryption keys). Adds a `key_version` column
+-- to every tenant's vault_secrets so each ciphertext records which key
+-- sealed it. This lets internal/vault derive a distinct per-tenant key
+-- (HKDF) for new writes and rotate keys later without re-encrypting
+-- historic rows.
+--
+-- Backward compatibility: existing rows default to key_version = 0, which
+-- the KeyProvider maps to "the shared master key, used verbatim" — exactly
+-- how they were sealed before this change. They keep decrypting unchanged.
+-- New writes use version 1 (the first HKDF-derived, per-tenant key).
+--
+-- Two parts:
+--   1. Backfill: add the column to every existing tenant schema.
+--   2. provision_tenant: new tenants get the column. The function body is
+--      IDENTICAL to 000056 (the regression fix) except that vault_secrets
+--      gains `key_version smallint NOT NULL DEFAULT 0`.
+--
+-- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its own
+-- transaction.
+
+-- ── 1. Backfill existing tenant schemas ────────────────────────────────
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.vault_secrets
+             ADD COLUMN IF NOT EXISTS key_version smallint NOT NULL DEFAULT 0',
+            rec.schema_name
+        );
+    END LOOP;
+END$$;
+
+-- ── 2. provision_tenant: new tenants get key_version ───────────────────
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+    v_func_role   TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+    v_func_role   := v_schema_name || '_func';
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL UNIQUE,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    -- vault_secrets: secret/nonce (correct, restored by 000056) plus the
+    -- NEW key_version column (this migration). Existing-tenant rows are
+    -- backfilled to 0 above; new tenants start every row at the column
+    -- default 0 until the first write seals it at the current version.
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            key_version smallint    NOT NULL DEFAULT 0,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    -- Sensitive tables stay on the stricter intent GUC (from 000055/#164).
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+         $_$', v_schema_name, v_schema_name
+    );
+
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    -- ── Per-tenant function-runner role (000047) ──
+    EXECUTE format('CREATE ROLE %I NOLOGIN INHERIT', v_func_role);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT USAGE, SELECT ON SEQUENCES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format('GRANT %I TO eurobase_function_runner', v_func_role);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;


### PR DESCRIPTION
Closes #167. Tier-1 GDPR #2 (Customer-Managed Encryption Keys). Builds on #178.

## What changes
Today every tenant's `vault_secrets` are encrypted with **one shared** `VAULT_ENCRYPTION_KEY`. This PR introduces **per-tenant keys** derived from that master via HKDF-SHA256, behind a pluggable `KeyProvider` interface, plus versioning so keys can rotate without re-encrypting historic rows.

```
tenant_key = HKDF-SHA256(master, salt=<tenant schema>, info="eurobase-vault-v<N>", 32)
```

- **Per-tenant separation** — salt = tenant schema, so tenant A's key can't open tenant B's ciphertext.
- **Rotation** — version mixed into `info`; bumping it yields an independent key.
- **Back-compat** — `key_version = 0` means "shared master key verbatim"; existing rows are backfilled to 0 and keep decrypting. New writes use v1.

## Changes
| File | What |
|---|---|
| `internal/vault/keyprovider.go` | `KeyProvider` interface + `hkdfKeyProvider`. Pluggable for future Scaleway KMS / customer HYOK. |
| `internal/vault/service.go` | `seal`/`open` go through the provider; `Get`/`Set`/`Update` read & persist `key_version`; new `RekeySchema()` re-encrypts a tenant onto the current version in one service-role tx. |
| `migrations/000057_vault_key_version.{up,down}.sql` | Add `key_version smallint NOT NULL DEFAULT 0` to every tenant `vault_secrets` (backfill + `provision_tenant`). Body identical to the #178 fix except the new column. |
| `internal/vault/handler.go` | `POST /platform/projects/{id}/vault/rekey` (admin-only) → `RekeySchema`. |
| `internal/audit/service.go` | new `vault.rekeyed` audit action. |
| `docs/compliance/encryption-keys.md` | Key model, rotation, and honest BYOK scope/limits. |

## Sovereignty / scope note
This is **app-layer per-tenant derivation**, not "platform-can't-decrypt" BYOK — the platform still holds the master. It satisfies *per-tenant cryptographic separation* + *rotation*. The `KeyProvider` interface + per-row `key_version` are the upgrade path to **Scaleway Key Manager** or **customer HYOK** with no re-encryption (tracked for enterprise). Documented in the DPA caveat.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./... -short` all clean.
- New unit tests (no DB): HKDF determinism, per-tenant separation, version rotation, legacy v0 = master key, seal/open round-trip + cross-tenant isolation — all pass.
- Uses **stdlib `crypto/hkdf`** (Go 1.24+) — no new dependency.
- Existing `vault` integration tests (round-trip Set/Get/Update/Delete) updated implicitly via the `key_version` column; they run against a real Postgres in CI.

## Dependency
Builds on #178 (provision_tenant regression fix) — the 000057 `provision_tenant` body extends the corrected 000056 one. #178 is merged to main; this branch is rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
