### PR TITLE
Tier-1 #3: tamper-evident append-only audit log (hash chain)

### DIFF
--- a/docs/compliance/audit-log.md
+++ b/docs/compliance/audit-log.md
@@ -1,0 +1,95 @@
+# Audit Log — Tamper-Evident Integrity
+
+> GDPR Art. 5(2) (accountability), Art. 30 (records), Art. 32 (integrity)
+> (Tier-1 #3). How `public.audit_log` is made tamper-evident and append-only,
+> and how to verify it.
+
+## What is recorded
+
+`public.audit_log` records sensitive platform operations — auth-config
+changes, API-key regeneration, vault secret set/update/delete/**rekey**,
+member changes, DSAR exports, project create/delete, and MCP SQL execution.
+Each row has `actor_id` / `actor_email`, `action`, optional `target`,
+`metadata`, `ip_address`, and `created_at`. Action constants live in
+`internal/audit/service.go`.
+
+> Logging of end-user **data access** (who read which personal-data rows) is a
+> separate, higher-volume stream — see the data-access log work (#169).
+
+## Integrity model (migration 000058)
+
+The log is both **tamper-evident** (you can prove if it was altered) and
+**tamper-resistant** (the runtime roles cannot alter it).
+
+### Hash chain
+Every row stores:
+
+```
+row_hash = SHA-256( prev_hash || canonical(row) )
+```
+
+- `prev_hash` is the `row_hash` of the previous row in the **same project's**
+  chain (`NULL` for the first row; rows with no project share one chain).
+- `canonical(row)` is a fixed, separator-delimited encoding of the row's
+  fields with `created_at` rendered at **UTC**, computed by the IMMUTABLE
+  function `public.audit_row_hash(...)`. Both the insert path and the verifier
+  call that one function, so the bytes are identical on both sides.
+- A dedicated monotonic `seq` orders the chain, so integrity holds even if two
+  rows share a `created_at` microsecond.
+
+Any alteration, deletion, reordering, or mid-chain insertion changes a hash
+and breaks the chain.
+
+### Concurrency
+Appends are serialized per project with a transaction advisory lock
+(`pg_advisory_xact_lock`) so the read-chain-head-then-insert step is atomic
+and never forks under concurrent writes (`internal/audit/service.go` `Log`).
+Audit writes are low-frequency, so the lock is not a hot path.
+
+### Append-only enforcement
+Migration 000058 runs `REVOKE UPDATE, DELETE ON public.audit_log` from
+`eurobase_gateway` and `eurobase_developer`. The runtime can only `INSERT`
+and `SELECT`. Only `eurobase_migrator` (deploy-only) keeps full rights, by
+necessity — schema changes need it.
+
+> An owner-level actor (migrator) could still rewrite the whole forward chain.
+> The independent defence is the off-box **WORM dump** (signed, append-only
+> object-store export) shipping in the SIEM-export / retention work
+> (#170/#171) — once a hash is exported off-box, in-DB rewriting is detectable
+> against the external copy.
+
+## Verifying
+
+```
+GET /platform/projects/{id}/compliance/audit-log/verify     (admin)
+```
+
+Returns:
+
+```json
+{ "ok": true, "checked": 128 }
+```
+
+or, on a broken chain:
+
+```json
+{ "ok": false, "checked": 42, "broken_at_id": "…", "reason": "row hash mismatch — a field was altered" }
+```
+
+`Verify` (`internal/audit/verifier.go`) walks the chain in `seq` order and,
+per row, checks (1) the stored `row_hash` matches a fresh recompute of the
+row's fields, and (2) the row's `prev_hash` matches the previous row's
+`row_hash`. The first failure is reported with the offending row id. An empty
+chain verifies as OK.
+
+## Testing
+
+`internal/audit/verifier_test.go` (integration, runs in CI `test-go`):
+appends entries, verifies clean, then mutates and deletes rows directly in the
+DB and asserts `Verify` flags both — the content-tamper and the
+linkage-break paths.
+
+## Retention & export
+1-year retention and the vendor-neutral SIEM export (webhook / syslog / signed
+object dump) are documented in
+[`audit-export.md`](./audit-export.md) once those PRs land (#170, #171).

--- a/docs/compliance/audit-log.md
+++ b/docs/compliance/audit-log.md
@@ -44,19 +44,35 @@ and breaks the chain.
 Appends are serialized per project with a transaction advisory lock
 (`pg_advisory_xact_lock`) so the read-chain-head-then-insert step is atomic
 and never forks under concurrent writes (`internal/audit/service.go` `Log`).
-Audit writes are low-frequency, so the lock is not a hot path.
+Audit writes are low-frequency, so the lock is not a hot path — but note that
+audited write latency is now **lock-bound per project**: a burst of audited
+operations on the same project serializes on that lock.
 
 ### Append-only enforcement
 Migration 000058 runs `REVOKE UPDATE, DELETE ON public.audit_log` from
-`eurobase_gateway` and `eurobase_developer`. The runtime can only `INSERT`
-and `SELECT`. Only `eurobase_migrator` (deploy-only) keeps full rights, by
-necessity — schema changes need it.
+`eurobase_gateway`. The audit service connects as **gateway** (the gateway
+pool), so this is the enforcement that matters: the runtime can only `INSERT`
+and `SELECT`.
 
-> An owner-level actor (migrator) could still rewrite the whole forward chain.
-> The independent defence is the off-box **WORM dump** (signed, append-only
-> object-store export) shipping in the SIEM-export / retention work
-> (#170/#171) — once a hash is exported off-box, in-DB rewriting is detectable
-> against the external copy.
+The migration also revokes from `eurobase_developer`, but that is
+**defence-in-depth, not the main guard**: platform/developer transactions run
+`SET LOCAL ROLE eurobase_migrator` (see `CLAUDE.md`), so developer-path code
+executes with migrator privileges and never touches `audit_log` as
+`eurobase_developer`. `eurobase_migrator` (deploy-only, table owner) keeps
+full rights by necessity.
+
+### What the in-DB chain does and does NOT cover
+The chain catches **modification, deletion, and reordering** of existing rows.
+It does **not** catch, on its own:
+
+- A **migrator/owner-level** actor rewriting the entire forward chain.
+- A **compromised gateway forging new appends** — gateway retains `INSERT` and
+  could write rows with attacker-chosen `prev_hash`/`row_hash`/`seq`.
+
+The independent defence for both is the off-box **WORM dump** (signed,
+append-only object-store export) shipping in the SIEM-export / retention work
+(#170/#171): once hashes are exported off-box, in-DB rewriting or forgery is
+detectable against the external copy.
 
 ## Verifying
 
@@ -81,6 +97,10 @@ per row, checks (1) the stored `row_hash` matches a fresh recompute of the
 row's fields, and (2) the row's `prev_hash` matches the previous row's
 `row_hash`. The first failure is reported with the offending row id. An empty
 chain verifies as OK.
+
+> `Verify` walks the **entire** project chain in one pass (no pagination). On
+> a multi-year log this is a heavy interactive call; a bounded/streaming or
+> checkpointed variant is a likely future addition.
 
 ## Testing
 

--- a/internal/audit/handler.go
+++ b/internal/audit/handler.go
@@ -41,3 +41,25 @@ func HandleList(svc *Service) http.HandlerFunc {
 		json.NewEncoder(w).Encode(result)
 	}
 }
+
+// HandleVerify walks the project's audit-log hash chain and reports whether
+// it is intact (Tier-1 #3 tamper-evidence).
+// GET /platform/projects/{id}/compliance/audit-log/verify
+func HandleVerify(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		if projectID == "" {
+			http.Error(w, `{"error":"missing project id"}`, http.StatusBadRequest)
+			return
+		}
+
+		result, err := svc.Verify(r.Context(), projectID)
+		if err != nil {
+			http.Error(w, `{"error":"failed to verify audit log"}`, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	}
+}

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -112,6 +112,11 @@ func (s *Service) Log(ctx context.Context, projectID, actorID, actorEmail, actio
 	// under concurrent writes, serialize per-project with a transaction
 	// advisory lock; the hash itself is computed in SQL by
 	// public.audit_row_hash so it is byte-identical to Verify().
+	//
+	// Trade-off vs the previous single Exec: audited write latency is now
+	// lock-bound per project — a burst of audited operations on the same
+	// project serializes. Acceptable because audit writes are low-frequency
+	// (sensitive admin actions), not a hot path.
 	chainKey := projectID
 	if chainKey == "" {
 		chainKey = "__global__" // NULL-project rows share one chain

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -15,25 +15,25 @@ import (
 
 // Action constants used across the codebase.
 const (
-	ActionAuthConfigUpdated  = "auth_config.updated"
-	ActionAPIKeysRegenerated = "api_keys.regenerated"
-	ActionProjectCreated     = "project.created"
-	ActionProjectDeleted     = "project.deleted"
+	ActionAuthConfigUpdated   = "auth_config.updated"
+	ActionAPIKeysRegenerated  = "api_keys.regenerated"
+	ActionProjectCreated      = "project.created"
+	ActionProjectDeleted      = "project.deleted"
 	ActionVaultSecretSet      = "vault.secret_set"
 	ActionVaultSecretUpdated  = "vault.secret_updated"
 	ActionVaultSecretDeleted  = "vault.secret_deleted"
 	ActionVaultSecretAccessed = "vault.secret_accessed"
 	ActionVaultRekeyed        = "vault.rekeyed"
-	ActionOAuthSecretSet     = "oauth.secret_set"
-	ActionDataExported       = "data.exported"
-	ActionMemberInvited      = "member.invited"
-	ActionMemberRemoved      = "member.removed"
-	ActionMemberRoleChanged  = "member.role_changed"
-	ActionFunctionCreated    = "function.created"
-	ActionFunctionDeleted    = "function.deleted"
-	ActionAllowlistAdded     = "allowlist.added"
-	ActionAllowlistRemoved   = "allowlist.removed"
-	ActionAllowlistEmailed   = "allowlist.emailed"
+	ActionOAuthSecretSet      = "oauth.secret_set"
+	ActionDataExported        = "data.exported"
+	ActionMemberInvited       = "member.invited"
+	ActionMemberRemoved       = "member.removed"
+	ActionMemberRoleChanged   = "member.role_changed"
+	ActionFunctionCreated     = "function.created"
+	ActionFunctionDeleted     = "function.deleted"
+	ActionAllowlistAdded      = "allowlist.added"
+	ActionAllowlistRemoved    = "allowlist.removed"
+	ActionAllowlistEmailed    = "allowlist.emailed"
 	// Compliance / DSAR export lifecycle. Closes #100. Tenant +
 	// per-user exports run on the platform admin path; self-serve
 	// is an end-user-initiated export of their own data.
@@ -49,8 +49,8 @@ const (
 	// so operators can filter for MCP-origin traffic and notice
 	// unusual patterns (e.g. a Cursor session that queried
 	// `vault_secrets` before the policy gated it).
-	ActionMCPSQLExecuted          = "mcp.sql.executed"
-	ActionMCPSQLRejectedReadOnly  = "mcp.sql.rejected_write_in_readonly"
+	ActionMCPSQLExecuted         = "mcp.sql.executed"
+	ActionMCPSQLRejectedReadOnly = "mcp.sql.rejected_write_in_readonly"
 )
 
 // Entry represents a single audit log row.
@@ -106,11 +106,46 @@ func (s *Service) Log(ctx context.Context, projectID, actorID, actorEmail, actio
 		}
 	}
 
-	_, err := s.pool.Exec(ctx,
+	// The row is linked into a per-project hash chain (migration 000058).
+	// row_hash = SHA-256(prev_hash || canonical(row)), prev_hash = the
+	// current chain head's hash. To keep the read-head-then-append atomic
+	// under concurrent writes, serialize per-project with a transaction
+	// advisory lock; the hash itself is computed in SQL by
+	// public.audit_row_hash so it is byte-identical to Verify().
+	chainKey := projectID
+	if chainKey == "" {
+		chainKey = "__global__" // NULL-project rows share one chain
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		slog.Error("audit log write failed", "action", action, "project_id", projectID, "actor", actorEmail, "error", err)
+		return
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, chainKey); err != nil {
+		slog.Error("audit log write failed (lock)", "action", action, "project_id", projectID, "error", err)
+		return
+	}
+
+	_, err = tx.Exec(ctx,
 		`INSERT INTO public.audit_log
-		   (project_id, actor_id, actor_email, action, target_type, target_id, metadata, ip_address)
-		 VALUES
-		   (NULLIF($1,'')::uuid, NULLIF($2,'')::uuid, $3, $4, $5, $6, $7, $8)`,
+		   (project_id, actor_id, actor_email, action, target_type, target_id, metadata, ip_address, created_at, prev_hash, row_hash)
+		 SELECT v.project_id, v.actor_id, v.actor_email, v.action, v.target_type, v.target_id, v.metadata, v.ip_address, v.created_at,
+		        p.h,
+		        public.audit_row_hash(p.h, v.project_id, v.actor_id, v.actor_email, v.action,
+		                              v.target_type, v.target_id, v.metadata, v.ip_address, v.created_at)
+		 FROM (
+		     SELECT NULLIF($1,'')::uuid AS project_id, NULLIF($2,'')::uuid AS actor_id,
+		            $3::text AS actor_email, $4::text AS action, $5::text AS target_type,
+		            $6::text AS target_id, $7::jsonb AS metadata, $8::text AS ip_address, now() AS created_at
+		 ) v
+		 LEFT JOIN LATERAL (
+		     SELECT row_hash AS h FROM public.audit_log
+		     WHERE project_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		     ORDER BY seq DESC LIMIT 1
+		 ) p ON true`,
 		projectID, actorID, actorEmail, action,
 		o.targetType, o.targetID, metaJSON, o.ipAddress,
 	)
@@ -121,6 +156,11 @@ func (s *Service) Log(ctx context.Context, projectID, actorID, actorEmail, actio
 			"actor", actorEmail,
 			"error", err,
 		)
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		slog.Error("audit log write failed (commit)", "action", action, "project_id", projectID, "error", err)
 	}
 }
 

--- a/internal/audit/verifier.go
+++ b/internal/audit/verifier.go
@@ -1,0 +1,72 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+)
+
+// VerifyResult is the outcome of walking a project's audit-log hash chain.
+type VerifyResult struct {
+	OK         bool   `json:"ok"`
+	Checked    int    `json:"checked"`                // number of rows walked
+	BrokenAtID string `json:"broken_at_id,omitempty"` // first row whose integrity failed
+	Reason     string `json:"reason,omitempty"`       // why it failed
+}
+
+// Verify walks a project's audit-log hash chain in order and reports whether
+// it is intact. It performs two independent checks per row:
+//
+//  1. Content: the stored row_hash must equal audit_row_hash recomputed from
+//     the row's own columns + its stored prev_hash. A mismatch means a field
+//     was altered.
+//  2. Linkage: the row's prev_hash must equal the previous row's row_hash. A
+//     mismatch means a row was inserted, deleted, or reordered.
+//
+// Either failure is reported with the offending row id. An empty chain (no
+// rows) verifies as OK. The recompute happens in SQL via the same
+// public.audit_row_hash function used on insert, so the comparison is exact.
+func (s *Service) Verify(ctx context.Context, projectID string) (*VerifyResult, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, prev_hash, row_hash,
+		        public.audit_row_hash(prev_hash, project_id, actor_id, actor_email, action,
+		                              target_type, target_id, metadata, ip_address, created_at) AS recomputed
+		 FROM public.audit_log
+		 WHERE project_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
+		 ORDER BY seq ASC`,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query audit chain: %w", err)
+	}
+	defer rows.Close()
+
+	var prev []byte // previous row's row_hash; nil before the first row
+	checked := 0
+	for rows.Next() {
+		var id string
+		var prevHash, rowHash, recomputed []byte
+		if err := rows.Scan(&id, &prevHash, &rowHash, &recomputed); err != nil {
+			return nil, fmt.Errorf("scan audit chain row: %w", err)
+		}
+		checked++
+
+		// 1. Content integrity.
+		if !bytes.Equal(recomputed, rowHash) {
+			return &VerifyResult{OK: false, Checked: checked, BrokenAtID: id,
+				Reason: "row hash mismatch — a field was altered"}, nil
+		}
+		// 2. Chain linkage. bytes.Equal treats nil and empty as equal, which
+		// is correct for the first row (prev_hash IS NULL, prev is nil).
+		if !bytes.Equal(prevHash, prev) {
+			return &VerifyResult{OK: false, Checked: checked, BrokenAtID: id,
+				Reason: "chain link mismatch — a row was inserted, deleted, or reordered"}, nil
+		}
+		prev = rowHash
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate audit chain: %w", err)
+	}
+
+	return &VerifyResult{OK: true, Checked: checked}, nil
+}

--- a/internal/audit/verifier_test.go
+++ b/internal/audit/verifier_test.go
@@ -1,0 +1,151 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// setupAuditTest creates an isolated project to scope a hash chain to, and
+// returns the audit service, that project id, the pool (for tamper
+// injection), and a cleanup. Skips when no test database is reachable.
+// Mirrors internal/vault/service_test.go's setup but skips tenant
+// provisioning — audit_log lives in the public schema.
+func setupAuditTest(t *testing.T) (*Service, string, *pgxpool.Pool) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = "postgres://eurobase_api:localdev@localhost:5433/eurobase?sslmode=disable"
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Skipf("cannot connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("cannot ping test database: %v", err)
+	}
+
+	hankoUserID := fmt.Sprintf("test-audit-%d", os.Getpid())
+	var ownerID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO platform_users (hanko_user_id, email)
+		 VALUES ($1, $2)
+		 ON CONFLICT (hanko_user_id) DO UPDATE SET email = EXCLUDED.email
+		 RETURNING id`,
+		hankoUserID, "audittest@eurobase.app",
+	).Scan(&ownerID); err != nil {
+		pool.Close()
+		t.Skipf("cannot create test platform user: %v", err)
+	}
+
+	slug := fmt.Sprintf("test-audit-%d", os.Getpid())
+	var projectID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO projects (owner_id, name, slug, schema_name, s3_bucket, region, plan, status)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, 'provisioning')
+		 RETURNING id`,
+		ownerID, "Audit Test", slug, "tenant_test_audit", "eurobase-test-audit", "fr-par", "free",
+	).Scan(&projectID); err != nil {
+		pool.Close()
+		t.Skipf("cannot create test project: %v", err)
+	}
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		// eurobase_api (the default test role) retains DELETE; the runtime
+		// roles do not. Remove the chain rows before the project so they
+		// don't fall back to NULL project and pollute the global chain.
+		_, _ = pool.Exec(ctx, `DELETE FROM public.audit_log WHERE project_id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, projectID)
+		_, _ = pool.Exec(ctx, `DELETE FROM platform_users WHERE hanko_user_id = $1`, hankoUserID)
+		pool.Close()
+	})
+
+	return NewService(pool), projectID, pool
+}
+
+// TestAuditChain_VerifyCleanAndDetectTamper appends a few entries, confirms
+// the chain verifies clean, then mutates a row directly in the DB and
+// confirms Verify flags the break — the core tamper-evidence guarantee.
+func TestAuditChain_VerifyCleanAndDetectTamper(t *testing.T) {
+	svc, projectID, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "test.one")
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "test.two",
+		WithMetadata(map[string]interface{}{"k": "v"}))
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "test.three", WithIP("203.0.113.7"))
+
+	res, err := svc.Verify(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Verify (clean): %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("clean chain reported broken at %s: %s", res.BrokenAtID, res.Reason)
+	}
+	if res.Checked != 3 {
+		t.Errorf("Checked = %d, want 3", res.Checked)
+	}
+
+	// Tamper: alter a row's action in place. The test role retains UPDATE;
+	// the runtime roles are revoked in migration 000058. If this environment
+	// also revokes it for the test role, skip the detection assertion.
+	tag, err := pool.Exec(ctx,
+		`UPDATE public.audit_log SET action = 'tampered' WHERE project_id = $1 AND action = 'test.two'`,
+		projectID)
+	if err != nil {
+		t.Skipf("cannot inject tamper (UPDATE denied for test role): %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("expected to tamper exactly 1 row, affected %d", tag.RowsAffected())
+	}
+
+	res2, err := svc.Verify(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Verify (tampered): %v", err)
+	}
+	if res2.OK {
+		t.Error("Verify did not detect the tampered row")
+	}
+	if res2.BrokenAtID == "" {
+		t.Error("Verify reported a break but no offending row id")
+	}
+}
+
+// TestAuditChain_DetectDeletion confirms that removing a row mid-chain breaks
+// the linkage check (the next row's prev_hash no longer matches).
+func TestAuditChain_DetectDeletion(t *testing.T) {
+	svc, projectID, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "del.one")
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "del.two")
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "del.three")
+
+	tag, err := pool.Exec(ctx,
+		`DELETE FROM public.audit_log WHERE project_id = $1 AND action = 'del.two'`, projectID)
+	if err != nil {
+		t.Skipf("cannot inject deletion (DELETE denied for test role): %v", err)
+	}
+	if tag.RowsAffected() != 1 {
+		t.Fatalf("expected to delete exactly 1 row, deleted %d", tag.RowsAffected())
+	}
+
+	res, err := svc.Verify(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Verify (after deletion): %v", err)
+	}
+	if res.OK {
+		t.Error("Verify did not detect the mid-chain deletion")
+	}
+}

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -319,6 +319,7 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, platformAuth *au
 			r.With(tenant.RequireMinRole("viewer")).Get("/compliance/sub-processors", compliance.HandleSubProcessors(complianceSvc))
 
 			r.With(tenant.RequireMinRole("viewer")).Get("/compliance/audit-log", audit.HandleList(auditSvc))
+			r.With(tenant.RequireMinRole("admin")).Get("/compliance/audit-log/verify", audit.HandleVerify(auditSvc))
 
 			// DSAR exports (tenant-level and per-user). Triggering an
 			// export pulls every row from every tenant table, so this

--- a/migrations/000058_audit_hash_chain.down.sql
+++ b/migrations/000058_audit_hash_chain.down.sql
@@ -1,0 +1,25 @@
+-- 000058_audit_hash_chain.down.sql
+--
+-- Reverts the audit_log hash chain. Restores UPDATE/DELETE to the runtime
+-- roles and drops the chain columns + sequence + hash function.
+--
+-- WARNING: this removes the tamper-evidence guarantee. Only the off-box
+-- WORM dump (if configured) remains as integrity evidence afterwards.
+
+-- Restore runtime write access first.
+GRANT UPDATE, DELETE ON public.audit_log TO eurobase_gateway;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'eurobase_developer') THEN
+        EXECUTE 'GRANT UPDATE, DELETE ON public.audit_log TO eurobase_developer';
+    END IF;
+END$$;
+
+DROP INDEX IF EXISTS public.idx_audit_log_seq;
+ALTER TABLE public.audit_log ALTER COLUMN seq DROP DEFAULT;
+ALTER TABLE public.audit_log DROP COLUMN IF EXISTS row_hash;
+ALTER TABLE public.audit_log DROP COLUMN IF EXISTS prev_hash;
+ALTER TABLE public.audit_log DROP COLUMN IF EXISTS seq;
+DROP SEQUENCE IF EXISTS public.audit_log_seq;
+
+DROP FUNCTION IF EXISTS public.audit_row_hash(bytea,uuid,uuid,text,text,text,text,jsonb,text,timestamptz);

--- a/migrations/000058_audit_hash_chain.up.sql
+++ b/migrations/000058_audit_hash_chain.up.sql
@@ -1,0 +1,117 @@
+-- 000058_audit_hash_chain.up.sql
+--
+-- Tier-1 GDPR #3 (immutable audit logging — Art. 5(2), 30, 32). Makes
+-- public.audit_log tamper-EVIDENT via a per-project hash chain, and
+-- tamper-RESISTANT by revoking UPDATE/DELETE from the runtime roles.
+--
+-- Model
+-- =====
+--   * Each row stores row_hash = SHA-256(prev_hash || canonical(row)), where
+--     prev_hash is the row_hash of the previous row in the SAME project's
+--     chain (NULL for the first row). Altering, deleting, reordering, or
+--     inserting a row breaks the chain and is detected by Verify().
+--   * `seq` (a dedicated monotonic sequence) gives the chain a total order
+--     that is robust to created_at collisions under concurrent writes.
+--   * The hash is computed by an IMMUTABLE function so INSERT and Verify use
+--     byte-identical logic. created_at is rendered at UTC so the hash does
+--     not depend on the session timezone.
+--
+-- Tamper resistance: runtime roles (gateway, developer) lose UPDATE/DELETE —
+-- they may only INSERT/SELECT. Only eurobase_migrator (deploy-only) retains
+-- full rights, by necessity. The independent off-box WORM copy (signed
+-- object-store dump) ships in the SIEM-export / retention PRs and is the
+-- defence against an owner-level tamper.
+--
+-- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its own tx.
+
+-- ── 1. Canonical row-hash function (shared by INSERT and Verify) ───────
+CREATE OR REPLACE FUNCTION public.audit_row_hash(
+    p_prev        bytea,
+    p_project_id  uuid,
+    p_actor_id    uuid,
+    p_actor_email text,
+    p_action      text,
+    p_target_type text,
+    p_target_id   text,
+    p_metadata    jsonb,
+    p_ip_address  text,
+    p_created_at  timestamptz
+) RETURNS bytea
+LANGUAGE sql IMMUTABLE AS $$
+    SELECT sha256(
+        COALESCE(p_prev, ''::bytea) ||
+        convert_to(
+            COALESCE(p_project_id::text, '')                                              || E'\x1e' ||
+            COALESCE(p_actor_id::text, '')                                                || E'\x1e' ||
+            COALESCE(p_actor_email, '')                                                   || E'\x1e' ||
+            COALESCE(p_action, '')                                                        || E'\x1e' ||
+            COALESCE(p_target_type, '')                                                   || E'\x1e' ||
+            COALESCE(p_target_id, '')                                                     || E'\x1e' ||
+            COALESCE(p_metadata::text, '{}')                                              || E'\x1e' ||
+            COALESCE(p_ip_address, '')                                                    || E'\x1e' ||
+            -- UTC + explicit format so the hash is timezone-independent.
+            COALESCE(to_char(p_created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US'), ''),
+        'UTF8')
+    )
+$$;
+
+ALTER FUNCTION public.audit_row_hash(bytea,uuid,uuid,text,text,text,text,jsonb,text,timestamptz)
+    OWNER TO eurobase_migrator;
+GRANT EXECUTE ON FUNCTION public.audit_row_hash(bytea,uuid,uuid,text,text,text,text,jsonb,text,timestamptz)
+    TO eurobase_gateway;
+
+-- ── 2. New columns ─────────────────────────────────────────────────────
+ALTER TABLE public.audit_log ADD COLUMN seq       bigint;
+ALTER TABLE public.audit_log ADD COLUMN prev_hash bytea;
+ALTER TABLE public.audit_log ADD COLUMN row_hash  bytea;
+
+-- ── 3. Assign a total order to existing rows, then attach the sequence ─
+WITH ordered AS (
+    SELECT id, row_number() OVER (ORDER BY created_at, id) AS rn
+    FROM public.audit_log
+)
+UPDATE public.audit_log a SET seq = o.rn FROM ordered o WHERE a.id = o.id;
+
+CREATE SEQUENCE public.audit_log_seq OWNED BY public.audit_log.seq;
+SELECT setval('public.audit_log_seq', COALESCE((SELECT max(seq) FROM public.audit_log), 0) + 1, false);
+ALTER TABLE public.audit_log ALTER COLUMN seq SET DEFAULT nextval('public.audit_log_seq');
+ALTER TABLE public.audit_log ALTER COLUMN seq SET NOT NULL;
+CREATE UNIQUE INDEX idx_audit_log_seq ON public.audit_log(seq);
+-- gateway inserts rows, so it needs the sequence.
+GRANT USAGE, SELECT ON SEQUENCE public.audit_log_seq TO eurobase_gateway;
+
+-- ── 4. Backfill the hash chain in seq order, per project ───────────────
+DO $$
+DECLARE
+    r       RECORD;
+    v_prev  bytea := NULL;
+    v_proj  uuid;
+    v_first boolean := true;
+    v_hash  bytea;
+BEGIN
+    FOR r IN SELECT * FROM public.audit_log ORDER BY seq ASC LOOP
+        -- New chain whenever the project changes (NULL-project rows form
+        -- their own chain, matching IS NOT DISTINCT FROM semantics).
+        IF v_first OR r.project_id IS DISTINCT FROM v_proj THEN
+            v_prev  := NULL;
+            v_proj  := r.project_id;
+            v_first := false;
+        END IF;
+        v_hash := public.audit_row_hash(v_prev, r.project_id, r.actor_id, r.actor_email,
+                                        r.action, r.target_type, r.target_id, r.metadata,
+                                        r.ip_address, r.created_at);
+        UPDATE public.audit_log SET prev_hash = v_prev, row_hash = v_hash WHERE id = r.id;
+        v_prev := v_hash;
+    END LOOP;
+END$$;
+
+ALTER TABLE public.audit_log ALTER COLUMN row_hash SET NOT NULL;
+
+-- ── 5. Make it append-only for the runtime roles ──────────────────────
+REVOKE UPDATE, DELETE ON public.audit_log FROM eurobase_gateway;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'eurobase_developer') THEN
+        EXECUTE 'REVOKE UPDATE, DELETE ON public.audit_log FROM eurobase_developer';
+    END IF;
+END$$;

--- a/migrations/000058_audit_hash_chain.up.sql
+++ b/migrations/000058_audit_hash_chain.up.sql
@@ -16,11 +16,21 @@
 --     byte-identical logic. created_at is rendered at UTC so the hash does
 --     not depend on the session timezone.
 --
--- Tamper resistance: runtime roles (gateway, developer) lose UPDATE/DELETE —
--- they may only INSERT/SELECT. Only eurobase_migrator (deploy-only) retains
--- full rights, by necessity. The independent off-box WORM copy (signed
--- object-store dump) ships in the SIEM-export / retention PRs and is the
--- defence against an owner-level tamper.
+-- Tamper resistance: the REAL enforcement is on eurobase_gateway — the role
+-- the audit service actually connects as (router.go wires audit to the
+-- gateway pool). It loses UPDATE/DELETE and may only INSERT/SELECT.
+--
+-- The eurobase_developer revoke below is pure defence-in-depth, NOT the main
+-- guard: platform/developer transactions run `SET LOCAL ROLE
+-- eurobase_migrator` (see CLAUDE.md), so developer-path code executes with
+-- migrator privileges and never touches audit_log as eurobase_developer.
+-- migrator (deploy-only, table owner) necessarily retains full rights. So an
+-- owner/migrator-equivalent actor — and a compromised gateway forging NEW
+-- appends with attacker-chosen prev_hash/row_hash — are NOT caught by the
+-- in-DB chain. The independent off-box WORM copy (signed object-store dump,
+-- shipping in the SIEM-export / retention PRs #170/#171) is the defence
+-- against both. The in-DB chain catches modification, deletion, and
+-- reordering of existing rows.
 --
 -- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its own tx.
 


### PR DESCRIPTION
Closes #168. Tier-1 GDPR #3 (immutable audit logging — Art. 5(2)/30/32).

> **Stacked on #179** (per-tenant keys) so migrations stay ordered `000057` → `000058`. Base is `tier1/01-per-tenant-keys`; GitHub will retarget to `main` once #179 merges. Review the [last commit](../commits) for this PR's diff only.

## What changes
Makes `public.audit_log` **tamper-evident** (you can prove if it was altered) and **append-only** (runtime roles can't alter it).

### Hash chain (migration `000058`)
- Each row stores `row_hash = SHA-256(prev_hash || canonical(row))`, `prev_hash` = the previous row's hash in the **same project's** chain.
- `canonical(row)` is computed by an **IMMUTABLE** `public.audit_row_hash(...)` (UTC-rendered `created_at`), so insert and verify use byte-identical logic.
- A dedicated monotonic `seq` orders the chain, robust to `created_at` collisions under concurrent writes.
- Existing rows are backfilled into valid chains.

### Append-only
- `REVOKE UPDATE, DELETE ON public.audit_log` from `eurobase_gateway` + `eurobase_developer`. Runtime can only `INSERT`/`SELECT`. Only `eurobase_migrator` (deploy-only) keeps full rights.
- Owner-level tamper is covered by the off-box **WORM dump** in #170/#171 (documented).

### Code
- `audit.Log` appends through the chain under a **per-project advisory lock** (atomic read-head-then-insert); hash computed in SQL.
- `audit.Verify` + `GET /platform/projects/{id}/compliance/audit-log/verify` (admin) — walks the chain, checks content hash + linkage, returns `{ok, checked, broken_at_id?, reason?}`.
- `docs/compliance/audit-log.md`.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt` clean.
- **Integration tests** (`verifier_test.go`, run in CI `test-go` when a DB is present): clean verify, content-tamper detection, mid-chain-deletion detection.
- **Migration SQL validated read-only against the live Postgres**: confirmed `sha256()` builtin (empty-input hash matches the known constant `e3b0c442…`), the full row-hash expression computes, `pg_advisory_xact_lock(hashtext(...))` resolves, `eurobase_developer` exists, and `eurobase_gateway` retains INSERT. (CI only applies migrations on the deploy job, so this read-only check is the pre-merge gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
