### PR TITLE
Add #welcome / #rules message poster for the Discord server

### DIFF
--- a/scripts/discord/README.md
+++ b/scripts/discord/README.md
@@ -50,6 +50,19 @@ Everything lives in `config.js`:
 
 Edit, save, re-run. Only new items are created.
 
+## Welcome & rules messages
+
+After the server exists, post the pinned `#welcome` and `#rules` messages:
+
+```bash
+DISCORD_TOKEN=your_bot_token DISCORD_GUILD_ID=your_guild_id node post-messages.js
+```
+
+Edit the copy in `messages.js` and re-run — it's idempotent: in each channel
+it **edits its previous post** instead of adding a duplicate (first run sends +
+pins). The bot needs **Send Messages**, **Read Message History**, and (to pin)
+**Manage Messages** in those channels.
+
 ## Integrations
 
 Three automations post into the server. Each needs a **channel webhook URL**,

--- a/scripts/discord/messages.js
+++ b/scripts/discord/messages.js
@@ -1,0 +1,83 @@
+// Content for the #welcome and #rules channels, posted by post-messages.js.
+// Edit freely and re-run `node post-messages.js` — it edits its previous
+// post in each channel rather than adding a duplicate.
+//
+// Each entry maps a channel name to a Discord embed. Colors are hex ints.
+
+const EUROBASE_GREEN = 0x2ecc71;
+const EUROBASE_BLUE = 0x3498db;
+
+const messages = {
+  welcome: {
+    embed: {
+      color: EUROBASE_GREEN,
+      title: "👋 Welcome to Eurobase",
+      description: [
+        "The **EU-sovereign Backend-as-a-Service** — a Firebase/Supabase",
+        "alternative hosted entirely in the EU (Scaleway, France). Auth,",
+        "Postgres, storage, edge functions and realtime, with GDPR built in",
+        "and no CLOUD Act exposure.",
+        "",
+        "This is the community hub for builders, questions, and feedback.",
+      ].join("\n"),
+      fields: [
+        {
+          name: "🧭 Find your way around",
+          value: [
+            "• **#introductions** — say hi and tell us what you're building",
+            "• **#help** — questions and troubleshooting",
+            "• **#showcase** — show off what you shipped on Eurobase",
+            "• **#feature-requests** / **#bug-reports** — shape the roadmap",
+            "• **#gdpr-compliance** / **#data-residency** — sovereignty talk",
+          ].join("\n"),
+        },
+        {
+          name: "🚀 Get started",
+          value: [
+            "• Console → https://console.eurobase.app",
+            "• Read **#rules** before posting",
+            "• Grab a role / introduce yourself, then dive in",
+          ].join("\n"),
+        },
+      ],
+      footer: { text: "Built in the EU 🇪🇺 · Your data stays in the EU" },
+    },
+  },
+
+  rules: {
+    embed: {
+      color: EUROBASE_BLUE,
+      title: "📋 Community Rules",
+      description: "Keep this a useful, friendly place for everyone building on Eurobase.",
+      fields: [
+        {
+          name: "1 · Be respectful",
+          value: "No harassment, hate, or personal attacks. Assume good faith.",
+        },
+        {
+          name: "2 · Stay on topic",
+          value: "Use the right channel. Keep #general light; technical Qs go in #help.",
+        },
+        {
+          name: "3 · No spam or unsolicited promotion",
+          value: "Share your project in **#showcase**, not via DMs or drive-by links.",
+        },
+        {
+          name: "4 · Never share secrets",
+          value: "Don't paste API keys, service keys, tokens, `DATABASE_URL`s, or customer data. Redact before asking for help.",
+        },
+        {
+          name: "5 · Search before asking",
+          value: "Check pinned messages and recent history first — it's faster for you too.",
+        },
+        {
+          name: "6 · No illegal or abusive use",
+          value: "Don't use Eurobase or this server for anything unlawful or that violates Discord's ToS.",
+        },
+      ],
+      footer: { text: "Breaking these may result in removal. Questions? Ask the team." },
+    },
+  },
+};
+
+module.exports = { messages };

--- a/scripts/discord/package.json
+++ b/scripts/discord/package.json
@@ -5,7 +5,8 @@
   "description": "Idempotent setup script for the Eurobase community Discord server.",
   "type": "commonjs",
   "scripts": {
-    "setup": "node setup.js"
+    "setup": "node setup.js",
+    "messages": "node post-messages.js"
   },
   "//lockfile": "package-lock.json pins lodash@4.18.1 (a transitive dep via @sapphire/shapeshift). 4.18.1 IS published on registry.npmjs.org and is the current latest as of 2026 — verified: `npm ci` exits 0 and `npm view lodash version` returns 4.18.1. Do not 'fix' this to 4.17.21; that baseline is stale. See PR #185.",
   "dependencies": {

--- a/scripts/discord/post-messages.js
+++ b/scripts/discord/post-messages.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Post (or update) the #welcome and #rules messages defined in messages.js.
+ *
+ * Idempotent: in each target channel it looks for a message it previously
+ * authored and EDITS it to the latest content, rather than posting a
+ * duplicate. First run sends + pins; later runs edit in place.
+ *
+ * Usage:
+ *   DISCORD_TOKEN=... DISCORD_GUILD_ID=... node post-messages.js
+ *
+ * The bot needs, in each target channel: View Channel, Send Messages,
+ * Read Message History, and (to pin) Manage Messages.
+ */
+
+const {
+  Client,
+  Events,
+  GatewayIntentBits,
+  ChannelType,
+} = require("discord.js");
+const { messages } = require("./messages");
+
+const TOKEN = process.env.DISCORD_TOKEN;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+if (!TOKEN || !GUILD_ID) {
+  console.error(
+    "Missing env vars. Run with:\n" +
+      "  DISCORD_TOKEN=<bot token> DISCORD_GUILD_ID=<server id> node post-messages.js"
+  );
+  process.exit(1);
+}
+
+const client = new Client({
+  // GuildMessages lets us fetch existing messages to find our prior post.
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+});
+
+async function upsertMessage(channel, embed) {
+  // Find a message we authored previously in this channel.
+  const recent = await channel.messages.fetch({ limit: 50 });
+  const mine = recent.find((m) => m.author.id === client.user.id);
+
+  if (mine) {
+    await mine.edit({ embeds: [embed] });
+    console.log(`  ~ updated existing message in #${channel.name}`);
+    return mine;
+  }
+
+  const sent = await channel.send({ embeds: [embed] });
+  console.log(`  + posted new message in #${channel.name}`);
+  try {
+    await sent.pin();
+    console.log(`    📌 pinned`);
+  } catch {
+    console.log(`    (couldn't pin — bot needs Manage Messages; skipping)`);
+  }
+  return sent;
+}
+
+client.once(Events.ClientReady, async () => {
+  try {
+    const guild = await client.guilds.fetch(GUILD_ID);
+    await guild.channels.fetch();
+    console.log(`Posting messages in "${guild.name}"\n`);
+
+    for (const [channelName, def] of Object.entries(messages)) {
+      const channel = guild.channels.cache.find(
+        (c) => c.type === ChannelType.GuildText && c.name === channelName
+      );
+      if (!channel) {
+        console.log(`  ! channel #${channelName} not found — skipping`);
+        continue;
+      }
+      await upsertMessage(channel, def.embed);
+    }
+
+    console.log("\nDone.");
+  } catch (err) {
+    console.error("\nFailed:", err.message);
+    process.exitCode = 1;
+  } finally {
+    client.destroy();
+  }
+});
+
+client.login(TOKEN);


### PR DESCRIPTION
## What

Companion to `scripts/discord/setup.js` (merged in #185): posts and pins the `#welcome` and `#rules` messages once the server exists.

- **`messages.js`** — editable embed content for both channels:
  - `#welcome`: what Eurobase is (EU-sovereign BaaS), a channel guide, and getting-started links.
  - `#rules`: 6 community rules — be respectful, stay on topic, no spam/promo outside `#showcase`, **never share secrets/keys/`DATABASE_URL`s**, search before asking, no illegal/abusive use.
- **`post-messages.js`** — idempotent poster (discord.js). In each channel it **edits its own prior message** instead of posting a duplicate; first run sends + pins. Uses the `Events.ClientReady` enum and fetches channels before matching, consistent with `setup.js`.
- **`package.json`** — adds `npm run messages`.
- **`README.md`** — usage + required bot permissions (Send Messages, Read Message History, Manage Messages to pin).

## How to run

```bash
cd scripts/discord
DISCORD_TOKEN=<bot token> DISCORD_GUILD_ID=<server id> node post-messages.js
```

Re-runnable: edit `messages.js`, run again, and it updates the existing posts in place.

## Notes

- No application code; standalone ops/community tooling under `scripts/discord/`.
- `node --check` passes on both new files; `messages.js` loads and exposes the `welcome` + `rules` content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)