### PR TITLE
Fix #193: embed IANA tzdata in gateway and worker binaries

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	// Embed IANA tzdata so time.LoadLocation works in the alpine runtime
+	// image, which ships no /usr/share/zoneinfo (schedules API timezones).
+	_ "time/tzdata"
 
 	"github.com/eurobase/euroback/internal/auth"
 	"github.com/eurobase/euroback/internal/compliance"

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -9,6 +9,9 @@ import (
 	"syscall"
 
 	"time"
+	// Embed IANA tzdata so time.LoadLocation works in the alpine runtime
+	// image, which ships no /usr/share/zoneinfo (cron schedule timezones).
+	_ "time/tzdata"
 
 	"github.com/eurobase/euroback/internal/cron"
 	"github.com/eurobase/euroback/internal/db"


### PR DESCRIPTION
## Problem

`eb.functions.schedules.createOrUpdate(name, { cron, timezone: 'Europe/Berlin' })` failed with `invalid timezone "Europe/Berlin": unknown time zone Europe/Berlin` (#193).

The schedules API validates timezones with `time.LoadLocation`, which reads `/usr/share/zoneinfo` at runtime. Both runtime images (`Dockerfile.gateway`, `Dockerfile.worker`) are bare `alpine:3.20` without the `tzdata` package, so every non-UTC IANA timezone was rejected.

## Fix

Blank-import `time/tzdata` in `cmd/gateway/main.go` and `cmd/worker/main.go` to embed the IANA zone database at build time (~450 KB per binary):

- **gateway** — validates `timezone` on schedule create/update (`internal/cron/service.go`)
- **worker** — resolves the timezone when computing next-run times in the cron executor (`internal/cron/executor.go`)

Chose the embed over installing the `tzdata` apk so the fix can't regress on a future base-image change and needs no Dockerfile edits.

## Verification

`go build` + `go vet` on both binaries pass. After deploy: `schedules.createOrUpdate` with `timezone: 'Europe/Berlin'` should be accepted and next-run times computed in local time.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)