### PR TITLE
Fix #188: set end-user/service RLS GUCs in function-runner SQL

### DIFF
--- a/functions-runner/role.ts
+++ b/functions-runner/role.ts
@@ -15,9 +15,11 @@
 // SQL via double-quote wrapping. Letters, digits, underscores; leads
 // with letter/underscore; max 63 bytes (Postgres's NAMEDATALEN-1
 // default). Schemas the gateway forwards always conform to this shape;
-// the runner validates again so a forged X-Schema-Name header (until
-// HMAC verification ships in PR 3c) cannot smuggle quote characters or
-// SQL fragments.
+// gateway→runner traffic is HMAC-signed and verified (see
+// authenticateRequest in server.ts), and the runner validates the shape
+// again as defence-in-depth so a forged X-Schema-Name header cannot
+// smuggle quote characters or SQL fragments even if that signing is ever
+// weakened by misconfiguration.
 export const validIdentRe = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
 
 // tenantFuncRole returns the per-tenant Postgres role name. Created at
@@ -51,6 +53,15 @@ export function quoteIdent(s: string): string {
 // the service branch — same as gateway secret-key traffic. The 'anon'
 // branch is deliberately not mirrored: anonymous *end-user* access only
 // makes sense for client-issued queries, not for tenant-deployed code.
+//
+// SECURITY: X-User-ID now drives the RLS *identity* (app.end_user_id +
+// the authenticated role), not just ctx.user, so a forged value would
+// impersonate that user at the row-security layer for every table. This
+// is only safe because gateway→runner traffic is HMAC-signed (X-User-ID
+// is in the canonical message) AND the runner runs in strict mode
+// (FUNCTIONS_RUNNER_HMAC_REQUIRE_SIGNED=true in deploy/k8s/functions.yaml).
+// Do not relax HMAC verification to soft mode without accounting for the
+// fact that it now governs database row security, not only ctx.user.
 export function rlsContextStatements(
   userId: string,
 ): Array<{ sql: string; params: string[] }> {

--- a/functions-runner/role.ts
+++ b/functions-runner/role.ts
@@ -38,3 +38,38 @@ export function tenantFuncRole(schemaName: string): string {
 export function quoteIdent(s: string): string {
   return '"' + s.replaceAll('"', '""') + '"';
 }
+
+// rlsContextStatements returns the per-transaction set_config statements
+// that mirror the gateway's RLS context (internal/query/engine.go,
+// applyRLSContext) so auth_uid() / is_service_role() behave identically
+// in edge functions and gateway REST (closes #188).
+//
+// With an end-user (gateway sets X-User-ID from verified claims, covered
+// by the HMAC signature) the function acts as that user: policies see
+// app.end_user_role='authenticated' and auth_uid() = the user. Without
+// one, function code is developer-authored server-side code, so it gets
+// the service branch — same as gateway secret-key traffic. The 'anon'
+// branch is deliberately not mirrored: anonymous *end-user* access only
+// makes sense for client-issued queries, not for tenant-deployed code.
+export function rlsContextStatements(
+  userId: string,
+): Array<{ sql: string; params: string[] }> {
+  if (userId) {
+    return [
+      {
+        sql: "SELECT set_config('app.end_user_id', $1, true)",
+        params: [userId],
+      },
+      {
+        sql: "SELECT set_config('app.end_user_role', 'authenticated', true)",
+        params: [],
+      },
+    ];
+  }
+  return [
+    {
+      sql: "SELECT set_config('app.end_user_role', 'service', true)",
+      params: [],
+    },
+  ];
+}

--- a/functions-runner/role_test.ts
+++ b/functions-runner/role_test.ts
@@ -8,7 +8,7 @@
 // behavior against a real Postgres.
 
 import { assertEquals, assertStrictEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { quoteIdent, tenantFuncRole, validIdentRe } from "./role.ts";
+import { quoteIdent, rlsContextStatements, tenantFuncRole, validIdentRe } from "./role.ts";
 
 Deno.test("tenantFuncRole appends _func suffix", () => {
   assertEquals(tenantFuncRole("tenant_abc"), "tenant_abc_func");
@@ -67,6 +67,43 @@ Deno.test("quoteIdent does NOT need escaping for normal underscore/digit identif
   // The role names we generate at runtime always pass validIdentRe so
   // never have quote characters. This is the common path.
   assertEquals(quoteIdent("tenant_b24e9fa8_func"), `"tenant_b24e9fa8_func"`);
+});
+
+Deno.test("rlsContextStatements with an end-user sets authenticated + end_user_id (issue #188)", () => {
+  const stmts = rlsContextStatements("8f4a2c1e-0000-4000-8000-000000000001");
+  assertEquals(stmts, [
+    {
+      sql: "SELECT set_config('app.end_user_id', $1, true)",
+      params: ["8f4a2c1e-0000-4000-8000-000000000001"],
+    },
+    {
+      sql: "SELECT set_config('app.end_user_role', 'authenticated', true)",
+      params: [],
+    },
+  ]);
+});
+
+Deno.test("rlsContextStatements without an end-user sets the service role (issue #188)", () => {
+  // No end-user JWT → tenant-deployed code runs as service, mirroring
+  // gateway secret-key traffic, so is_service_role() is true and the
+  // DDL presets' service branch applies.
+  const stmts = rlsContextStatements("");
+  assertEquals(stmts, [
+    {
+      sql: "SELECT set_config('app.end_user_role', 'service', true)",
+      params: [],
+    },
+  ]);
+});
+
+Deno.test("rlsContextStatements never interpolates the user id into SQL text", () => {
+  // The user id travels as a bind parameter; a hostile value can't
+  // change the SQL shape.
+  const stmts = rlsContextStatements("'; SET ROLE postgres; --");
+  for (const s of stmts) {
+    assertStrictEquals(s.sql.includes("postgres"), false);
+  }
+  assertEquals(stmts[0].params, ["'; SET ROLE postgres; --"]);
 });
 
 Deno.test("the full tenantFuncRole → quoteIdent pipeline produces safe SQL fragments", () => {

--- a/functions-runner/server.ts
+++ b/functions-runner/server.ts
@@ -206,7 +206,8 @@ async function executeFunction(
   // Defence-in-depth: validate schema name shape before it reaches SQL.
   // The gateway already validates this, but the runner is on the cluster
   // network and a future misconfiguration could expose it more broadly
-  // (cf. PR 3c which adds HMAC verification of these headers).
+  // (these headers are HMAC-verified in authenticateRequest below; this
+  // shape check is the second layer).
   if (!validIdentRe.test(schemaName)) {
     return jsonResponse({ error: "invalid schema name", requestId }, 400);
   }

--- a/functions-runner/server.ts
+++ b/functions-runner/server.ts
@@ -8,7 +8,7 @@
  * is NEVER exposed to the public internet. Only the Gateway can reach it.
  */
 
-import { quoteIdent, tenantFuncRole, validIdentRe } from "./role.ts";
+import { quoteIdent, rlsContextStatements, tenantFuncRole, validIdentRe } from "./role.ts";
 import type {
   ParentToWorker,
   SerializedRequest,
@@ -231,6 +231,12 @@ async function executeFunction(
     return await db.begin(async (tx: any) => {
       await tx.unsafe(setRoleSQL);
       await tx.unsafe(setPathSQL);
+      // Mirror the gateway's RLS context so auth_uid() /
+      // is_service_role() behave the same in functions as in gateway
+      // REST — see rlsContextStatements in role.ts. Closes #188.
+      for (const stmt of rlsContextStatements(userId)) {
+        await tx.unsafe(stmt.sql, stmt.params);
+      }
       return await tx.unsafe(query, params);
     });
   }


### PR DESCRIPTION
## Problem

The runner's per-invocation transaction set only `SET LOCAL ROLE <schema>_func` + `search_path`, never `app.end_user_id` / `app.end_user_role`. Inside any edge function:

- `public.is_service_role()` was **false** (it checks `app.end_user_role = 'service'`, migration 000038)
- `auth_uid()` was **NULL**, even for `verify_jwt=true` functions where the gateway forwards `X-User-ID`

So `ctx.db.sql` satisfied **no branch** of the RLS policies the platform's DDL presets generate (`public.is_service_role() OR <owner> = auth_uid()`) — functions couldn't read or write preset-protected tables at all, and tenants had to hand-write policy branches naming the runner's role convention (#188).

## Fix

`runDBSql` now mirrors the gateway's RLS context (`internal/query/engine.go` → `applyRLSContext`), via a new testable `rlsContextStatements` helper in `role.ts`:

- **`X-User-ID` present** → `app.end_user_id = <user>`, `app.end_user_role = 'authenticated'`. The header is trustworthy: the gateway only sets it from verified end-user claims, and the HMAC signature covers it.
- **No end-user** → `app.end_user_role = 'service'`, mirroring gateway secret-key traffic — function code is developer-authored server-side code.

The `anon` branch is deliberately not mirrored: anonymous end-user semantics make sense for client-issued queries, not tenant-deployed code.

The user id always travels as a bind parameter, never interpolated into SQL text.

## Tests

New Deno tests in `role_test.ts` cover the authenticated branch, the service branch, and an injection-shaped user id (same local-runnable pattern as the existing role tests; CI doesn't run Deno tests). Syntax verified with esbuild.

After deploy, the repro from the issue (DDL-preset table + function inserting with `ctx.user.id` under a valid end-user JWT) should succeed instead of `row-level security policy denied this operation`, and the `current_user = 'tenant_<id>_func'` workaround branches can be dropped.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)