### PR TITLE
Fix #192: CLI status/deploy must show and validate the active project

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -83,17 +83,16 @@ func LoginCmd() *cobra.Command {
 			cfg.Token = result.AccessToken
 			cfg.Email = email
 
-			// Try to fetch projects and auto-select if only one
+			// Fetch projects: auto-select a single-project account, and
+			// validate any previously stored active project against this
+			// account's list so a stale selection (other account, deleted
+			// project) can't silently receive deploys (issue #192).
 			client.Token = result.AccessToken
 			projectsData, err := client.Get("/v1/tenants")
 			if err == nil {
-				var projects []struct {
-					ID   string `json:"id"`
-					Slug string `json:"slug"`
-				}
-				if json.Unmarshal(projectsData, &projects) == nil && len(projects) == 1 {
-					cfg.ActiveProject = projects[0].ID
-					cfg.ProjectSlug = projects[0].Slug
+				var projects []ProjectRef
+				if json.Unmarshal(projectsData, &projects) == nil {
+					ReconcileActiveProject(cfg, projects)
 				}
 			}
 
@@ -103,7 +102,9 @@ func LoginCmd() *cobra.Command {
 
 			PrintSuccess(fmt.Sprintf("Logged in as %s", email))
 			if cfg.ActiveProject != "" {
-				PrintSuccess(fmt.Sprintf("Active project: %s", cfg.ProjectSlug))
+				PrintSuccess(fmt.Sprintf("Active project: %s", ProjectLabel(cfg)))
+			} else {
+				fmt.Println("No active project — run `eurobase switch <slug>` to select one.")
 			}
 			return nil
 		},

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -188,3 +188,45 @@ func RequireProject(cfg *Config) error {
 	}
 	return nil
 }
+
+// ProjectLabel returns a human-readable identifier for the active project,
+// e.g. `predwell (0515e4e2-…)`, or just the ID when the slug is unknown.
+// Mutating commands print this so the target of a deploy/delete is always
+// visible (issue #192).
+func ProjectLabel(cfg *Config) string {
+	if cfg.ProjectSlug != "" {
+		return fmt.Sprintf("%s (%s)", cfg.ProjectSlug, cfg.ActiveProject)
+	}
+	return cfg.ActiveProject
+}
+
+// ProjectRef is the minimal identity of a project as returned by /v1/tenants.
+type ProjectRef struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+}
+
+// ReconcileActiveProject updates cfg's active project against the account's
+// project list at login time (issue #192). A single-project account is
+// auto-selected. Otherwise a previously stored selection is kept only if it
+// still exists in this account's list (healing a stale or missing slug);
+// a selection pointing at another account's or a deleted project is cleared
+// so later mutating commands fail fast instead of silently targeting it.
+func ReconcileActiveProject(cfg *Config, projects []ProjectRef) {
+	if len(projects) == 1 {
+		cfg.ActiveProject = projects[0].ID
+		cfg.ProjectSlug = projects[0].Slug
+		return
+	}
+	if cfg.ActiveProject == "" {
+		return
+	}
+	for _, p := range projects {
+		if p.ID == cfg.ActiveProject {
+			cfg.ProjectSlug = p.Slug
+			return
+		}
+	}
+	cfg.ActiveProject = ""
+	cfg.ProjectSlug = ""
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import "testing"
+
+// Issue #192: a stale active project (deleted, or belonging to a different
+// account) silently received deploys after login. ReconcileActiveProject is
+// the login-time guard against that.
+
+func TestReconcileActiveProject_SingleProjectAutoSelected(t *testing.T) {
+	cfg := &Config{ActiveProject: "stale-id", ProjectSlug: "stale"}
+	ReconcileActiveProject(cfg, []ProjectRef{{ID: "p1", Slug: "predwell"}})
+	if cfg.ActiveProject != "p1" || cfg.ProjectSlug != "predwell" {
+		t.Fatalf("expected auto-select of the only project, got %q (%q)", cfg.ProjectSlug, cfg.ActiveProject)
+	}
+}
+
+func TestReconcileActiveProject_StaleSelectionCleared(t *testing.T) {
+	cfg := &Config{ActiveProject: "other-account-id", ProjectSlug: "newtek"}
+	ReconcileActiveProject(cfg, []ProjectRef{
+		{ID: "p1", Slug: "predwell"},
+		{ID: "p2", Slug: "demo"},
+	})
+	if cfg.ActiveProject != "" || cfg.ProjectSlug != "" {
+		t.Fatalf("expected stale selection to be cleared, got %q (%q)", cfg.ProjectSlug, cfg.ActiveProject)
+	}
+}
+
+func TestReconcileActiveProject_ValidSelectionKeptAndSlugHealed(t *testing.T) {
+	cfg := &Config{ActiveProject: "p2"} // slug missing, e.g. written by an older CLI
+	ReconcileActiveProject(cfg, []ProjectRef{
+		{ID: "p1", Slug: "predwell"},
+		{ID: "p2", Slug: "demo"},
+	})
+	if cfg.ActiveProject != "p2" || cfg.ProjectSlug != "demo" {
+		t.Fatalf("expected selection kept with slug healed, got %q (%q)", cfg.ProjectSlug, cfg.ActiveProject)
+	}
+}
+
+func TestReconcileActiveProject_NoSelectionStaysEmpty(t *testing.T) {
+	cfg := &Config{}
+	ReconcileActiveProject(cfg, []ProjectRef{
+		{ID: "p1", Slug: "predwell"},
+		{ID: "p2", Slug: "demo"},
+	})
+	if cfg.ActiveProject != "" {
+		t.Fatalf("expected no auto-select with multiple projects, got %q", cfg.ActiveProject)
+	}
+}
+
+func TestReconcileActiveProject_EmptyListClearsSelection(t *testing.T) {
+	// Zero projects: nothing to validate against — clear the selection,
+	// the account provably has no project with that ID.
+	cfg := &Config{ActiveProject: "p9", ProjectSlug: "ghost"}
+	ReconcileActiveProject(cfg, []ProjectRef{})
+	if cfg.ActiveProject != "" || cfg.ProjectSlug != "" {
+		t.Fatalf("expected selection cleared for empty project list, got %q (%q)", cfg.ProjectSlug, cfg.ActiveProject)
+	}
+}
+
+func TestProjectLabel(t *testing.T) {
+	withSlug := &Config{ActiveProject: "0515e4e2", ProjectSlug: "predwell"}
+	if got := ProjectLabel(withSlug); got != "predwell (0515e4e2)" {
+		t.Fatalf("ProjectLabel with slug = %q", got)
+	}
+	idOnly := &Config{ActiveProject: "0515e4e2"}
+	if got := ProjectLabel(idOnly); got != "0515e4e2" {
+		t.Fatalf("ProjectLabel without slug = %q", got)
+	}
+}

--- a/internal/cli/edge_functions.go
+++ b/internal/cli/edge_functions.go
@@ -154,11 +154,11 @@ func efDeployCmd() *cobra.Command {
 				if createErr != nil {
 					return createErr
 				}
-				PrintSuccess(fmt.Sprintf("Function %q created and deployed", args[0]))
+				PrintSuccess(fmt.Sprintf("Function %q created and deployed to %s", args[0], ProjectLabel(cfg)))
 				return nil
 			}
 
-			PrintSuccess(fmt.Sprintf("Function %q deployed", args[0]))
+			PrintSuccess(fmt.Sprintf("Function %q deployed to %s", args[0], ProjectLabel(cfg)))
 			return nil
 		},
 	}
@@ -226,7 +226,7 @@ func efDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			PrintSuccess(fmt.Sprintf("Function %q deleted", args[0]))
+			PrintSuccess(fmt.Sprintf("Function %q deleted from %s", args[0], ProjectLabel(cfg)))
 			return nil
 		},
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -31,34 +31,40 @@ func StatusCmd() *cobra.Command {
 				return err
 			}
 
-			var usage struct {
-				ProjectName string  `json:"project_name"`
-				ProjectSlug string  `json:"project_slug"`
-				Plan        string  `json:"plan"`
-				DbUsageMB   float64 `json:"db_usage_mb"`
-				DbLimitMB   float64 `json:"db_limit_mb"`
-				StorageMB   float64 `json:"storage_usage_mb"`
-				StorageMax  float64 `json:"storage_limit_mb"`
-				MAU         int     `json:"mau"`
-				MAULimit    int     `json:"mau_limit"`
+			// The endpoint (internal/plans/handler.go HandleGetUsage)
+			// returns {usage: {...}, limits: {...}} — the CLI previously
+			// expected a flat shape that matched nothing, so status
+			// printed `Project:  ()` with zeroed bars (issue #192).
+			var resp struct {
+				Usage struct {
+					DatabaseSizeMB float64 `json:"database_size_mb"`
+					StorageSizeMB  float64 `json:"storage_size_mb"`
+					MAUCount       int     `json:"mau_count"`
+				} `json:"usage"`
+				Limits struct {
+					Plan      string `json:"plan"`
+					DBSizeMB  int    `json:"db_size_mb"`
+					StorageMB int    `json:"storage_mb"`
+					MAULimit  int    `json:"mau_limit"`
+				} `json:"limits"`
 			}
-			if err := json.Unmarshal(data, &usage); err != nil {
+			if err := json.Unmarshal(data, &resp); err != nil {
 				return fmt.Errorf("parsing response: %w", err)
 			}
 
 			jsonOut, _ := cmd.Flags().GetBool("json")
 			if jsonOut {
-				PrintJSON(usage)
+				PrintJSON(resp)
 				return nil
 			}
 
-			fmt.Printf("%sProject:%s %s (%s)\n", colorBold, colorReset, usage.ProjectName, usage.ProjectSlug)
-			fmt.Printf("%sPlan:%s    %s\n", colorBold, colorReset, usage.Plan)
+			fmt.Printf("%sProject:%s %s\n", colorBold, colorReset, ProjectLabel(cfg))
+			fmt.Printf("%sPlan:%s    %s\n", colorBold, colorReset, resp.Limits.Plan)
 			fmt.Println()
 
-			printBar("Database", usage.DbUsageMB, usage.DbLimitMB, "MB")
-			printBar("Storage", usage.StorageMB, usage.StorageMax, "MB")
-			printBarInt("MAU", usage.MAU, usage.MAULimit)
+			printBar("Database", resp.Usage.DatabaseSizeMB, float64(resp.Limits.DBSizeMB), "MB")
+			printBar("Storage", resp.Usage.StorageSizeMB, float64(resp.Limits.StorageMB), "MB")
+			printBarInt("MAU", resp.Usage.MAUCount, resp.Limits.MAULimit)
 
 			return nil
 		},


### PR DESCRIPTION
## Root cause

Not a missing-project fallback — `RequireProject` was already enforced on every mutating command. Two compounding bugs made the misfire invisible (#192):

1. **`login` keeps a stale `active_project`.** It only auto-selects when the account has exactly one project; otherwise it silently leaves whatever was in `~/.eurobase/config.json` — even a project from another account or a deleted one. That's how the deploy landed in `newtek`.
2. **`eurobase status` was unusable for checking context.** It parsed a flat `{project_name, db_usage_mb, ...}` shape, but the endpoint (`internal/plans/handler.go` → `HandleGetUsage`) returns `{usage: {...}, limits: {...}}` — nothing matched, so it always printed `Project:  ()` with zeroed bars, for everyone.

## Fixes

- **login** reconciles the stored selection against the account's project list (new `ReconcileActiveProject`): single-project accounts auto-select as before; a selection not in the list is **cleared**, so subsequent mutating commands fail fast with ``no active project — run `eurobase switch <slug>` first``; a valid selection gets its slug healed. Login prints the active project, or `No active project — run `eurobase switch <slug>` to select one.`
- **status** parses the real `{usage, limits}` shape (plan from limits) and shows the active project from the local config via the new `ProjectLabel` helper — slug + ID.
- **edge-functions deploy/delete** output names the target: `✓ Function "free-report" deployed to predwell (0515e4e2…)`.

## Tests

First unit tests for `internal/cli`: reconciliation (auto-select, stale-clear, slug-heal, multi-project no-select, empty list) and `ProjectLabel`. `go build` / `go vet` / `go test ./internal/cli/` pass.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)