### PR TITLE
CI: serialize main deploys with a concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,18 @@ jobs:
     needs: [test-go, test-console, test-mcp, test-functions-runner]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Serialize deploys. Without this, back-to-back merges to main run
+    # concurrent deploys that race on the migrate Job (delete → apply hits
+    # "field is immutable" when another run recreates it in between) and
+    # last-writer-wins on Deployment images regardless of commit order.
+    # cancel-in-progress stays false — killing a deploy mid-kubectl could
+    # leave a half-applied rollout. GitHub keeps at most one run queued per
+    # group and supersedes older pending ones, which is correct here: every
+    # deploy ships the full repo state, so the newest queued commit subsumes
+    # the skipped ones.
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

Four back-to-back merges to main (#194–#197) triggered four concurrent deploy jobs. The oldest one failed at the migrate step: another run recreated the `migrate` Job between this run's `kubectl delete` and `kubectl apply`, hitting `field is immutable` ([failed run](https://github.com/STGime/euroback/actions/runs/27264869170)). Beyond the visible failure, concurrent deploys are last-writer-wins on Deployment images regardless of commit order — this batch only ended up consistent because the newest commit's run happened to finish last.

## Fix

Job-level `concurrency` on the `deploy` job only:

```yaml
concurrency:
  group: deploy-production
  cancel-in-progress: false
```

- **Job-level, not workflow-level** — PR test runs stay fully parallel; only deploys serialize.
- **`cancel-in-progress: false`** — an in-flight deploy is never killed mid-`kubectl`, which could leave a half-applied rollout. GitHub instead queues the newest pending run and supersedes older *pending* ones — correct here, since every deploy ships the full repo state, so the newest queued commit subsumes any skipped intermediate ones (those show as cancelled, not failed).

With this, the #194-style race can't recur: each deploy's delete→apply→wait sequence on the migrate Job runs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)