### PR TITLE
Fix #188 (follow-up): grant func roles access to public RLS helpers

### DIFF
--- a/migrations/000060_func_role_public_grants.down.sql
+++ b/migrations/000060_func_role_public_grants.down.sql
@@ -1,0 +1,253 @@
+-- Reverts the issue #188 follow-up grants and restores provision_tenant
+-- to the 000057 body. Note: revoking re-breaks RLS policy evaluation for
+-- edge functions (the bug this migration fixes).
+
+-- ── 1. Revoke from existing tenants' func roles ────────────────────────
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_role   TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL
+    LOOP
+        v_role := v_schema || '_func';
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = v_role) THEN
+            EXECUTE format('REVOKE EXECUTE ON FUNCTION public.is_internal_auth_path() FROM %I', v_role);
+            EXECUTE format('REVOKE EXECUTE ON FUNCTION public.current_end_user_id() FROM %I', v_role);
+            EXECUTE format('REVOKE EXECUTE ON FUNCTION public.is_service_role() FROM %I', v_role);
+            EXECUTE format('REVOKE USAGE ON SCHEMA public FROM %I', v_role);
+        END IF;
+    END LOOP;
+END$$;
+
+-- ── 2. Restore provision_tenant to the 000057 body ─────────────────────
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+    v_func_role   TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+    v_func_role   := v_schema_name || '_func';
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL UNIQUE,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    -- vault_secrets: secret/nonce (correct, restored by 000056) plus the
+    -- NEW key_version column (this migration). Existing-tenant rows are
+    -- backfilled to 0 above; new tenants start every row at the column
+    -- default 0 until the first write seals it at the current version.
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            key_version smallint    NOT NULL DEFAULT 0,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    -- Sensitive tables stay on the stricter intent GUC (from 000055/#164).
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+         $_$', v_schema_name, v_schema_name
+    );
+
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    -- ── Per-tenant function-runner role (000047) ──
+    EXECUTE format('CREATE ROLE %I NOLOGIN INHERIT', v_func_role);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT USAGE, SELECT ON SEQUENCES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format('GRANT %I TO eurobase_function_runner', v_func_role);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;

--- a/migrations/000060_func_role_public_grants.up.sql
+++ b/migrations/000060_func_role_public_grants.up.sql
@@ -1,0 +1,284 @@
+-- Issue #188 follow-up: per-tenant func roles cannot evaluate the RLS
+-- helper functions.
+--
+-- 000047 granted `USAGE ON SCHEMA public` and EXECUTE on the helper
+-- functions only to `eurobase_function_runner` — but each invocation does
+-- `SET LOCAL ROLE <schema>_func`, and the func role does NOT inherit the
+-- runner's own grants (membership goes runner → func role, not the other
+-- way). Verified from inside a function: `SELECT public.is_service_role()`
+-- → `permission denied for schema public`.
+--
+-- Consequence: any RLS policy that merely REFERENCES
+-- public.is_service_role() / public.current_end_user_id() — i.e. every
+-- policy the platform's DDL presets generate — fails at expression init
+-- under the runner, even after PR #195 fixed the GUC context.
+--
+-- Fix: grant the func roles USAGE on schema public plus EXECUTE on the
+-- three GUC-reading helpers. None of these grants leak data: the helpers
+-- only read transaction-local GUCs, and USAGE on public alone confers no
+-- table access (the func role has no table grants there).
+-- is_internal_auth_path() is included so policies on the sensitive auth
+-- tables (000055) evaluate to a clean `false` deny for the func role
+-- instead of erroring.
+--
+--   1. Backfill every existing tenant's func role.
+--   2. Recreate provision_tenant (000057 body + the new grants) so new
+--      tenants get them at provisioning time.
+
+-- ── 1. Backfill existing tenants ────────────────────────────────────────
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_role   TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT schema_name FROM public.projects WHERE schema_name IS NOT NULL
+    LOOP
+        v_role := v_schema || '_func';
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = v_role) THEN
+            EXECUTE format('GRANT USAGE ON SCHEMA public TO %I', v_role);
+            EXECUTE format('GRANT EXECUTE ON FUNCTION public.is_service_role() TO %I', v_role);
+            EXECUTE format('GRANT EXECUTE ON FUNCTION public.current_end_user_id() TO %I', v_role);
+            EXECUTE format('GRANT EXECUTE ON FUNCTION public.is_internal_auth_path() TO %I', v_role);
+            RAISE NOTICE 'granted public helper access to %', v_role;
+        END IF;
+    END LOOP;
+END$$;
+
+-- ── 2. provision_tenant: 000057 body + public helper grants ────────────
+CREATE OR REPLACE FUNCTION public.provision_tenant(
+    p_project_id   UUID,
+    p_display_name TEXT,
+    p_plan         TEXT DEFAULT 'free'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $fn$
+DECLARE
+    v_schema_name TEXT;
+    v_func_role   TEXT;
+BEGIN
+    v_schema_name := 'tenant_' || replace(p_project_id::text, '-', '_');
+    v_func_role   := v_schema_name || '_func';
+
+    EXECUTE format('CREATE SCHEMA %I', v_schema_name);
+    EXECUTE format('SET search_path TO %I', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.users (
+            id                 UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            email              TEXT        UNIQUE,
+            phone              TEXT,
+            password_hash      TEXT,
+            display_name       TEXT,
+            avatar_url         TEXT,
+            metadata           JSONB       DEFAULT ''{}''::jsonb,
+            provider           TEXT        DEFAULT ''email'',
+            provider_user_id   TEXT,
+            email_confirmed_at TIMESTAMPTZ,
+            phone_confirmed_at TIMESTAMPTZ,
+            last_sign_in_at    TIMESTAMPTZ,
+            banned_at          TIMESTAMPTZ,
+            created_at         TIMESTAMPTZ DEFAULT now(),
+            updated_at         TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_provider ON %I.users(provider, provider_user_id) WHERE provider_user_id IS NOT NULL', v_schema_name);
+    EXECUTE format('CREATE UNIQUE INDEX idx_users_phone ON %I.users(phone) WHERE phone IS NOT NULL', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.user_identities (
+            id               UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id          UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            provider         TEXT        NOT NULL,
+            provider_user_id TEXT        NOT NULL,
+            identity_data    JSONB       DEFAULT ''{}''::jsonb,
+            last_sign_in_at  TIMESTAMPTZ,
+            created_at       TIMESTAMPTZ DEFAULT now(),
+            updated_at       TIMESTAMPTZ DEFAULT now(),
+            UNIQUE(provider, provider_user_id)
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_user_identities_user_id ON %I.user_identities(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.refresh_tokens (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id    UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash TEXT        NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_token_hash ON %I.refresh_tokens(token_hash)', v_schema_name);
+    EXECUTE format('CREATE INDEX idx_refresh_tokens_user_id ON %I.refresh_tokens(user_id)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.email_tokens (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            user_id     UUID        NOT NULL REFERENCES %I.users(id) ON DELETE CASCADE,
+            token_hash  TEXT        NOT NULL,
+            token_type  TEXT        NOT NULL CHECK (token_type IN (''verification'',''password_reset'',''magic_link'',''phone_verification'')),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            used_at     TIMESTAMPTZ,
+            created_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+    EXECUTE format('CREATE INDEX idx_email_tokens_hash ON %I.email_tokens(token_hash)', v_schema_name);
+
+    EXECUTE format(
+        'CREATE TABLE %I.storage_objects (
+            id            UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            key           TEXT        NOT NULL UNIQUE,
+            content_type  TEXT,
+            size_bytes    BIGINT,
+            uploaded_by   UUID        REFERENCES %I.users(id),
+            metadata      JSONB       DEFAULT ''{}''::jsonb,
+            created_at    TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name, v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE TABLE %I.todos (
+            id         UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            title      TEXT        NOT NULL,
+            completed  BOOLEAN     DEFAULT false,
+            created_at TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+    EXECUTE format(
+        'INSERT INTO %I.todos (title, completed) VALUES
+            (''Learn about Eurobase'', true),
+            (''Build my first EU-sovereign app'', false),
+            (''Deploy to production'', false)',
+        v_schema_name
+    );
+
+    -- vault_secrets: secret/nonce (correct, restored by 000056) plus the
+    -- NEW key_version column (this migration). Existing-tenant rows are
+    -- backfilled to 0 above; new tenants start every row at the column
+    -- default 0 until the first write seals it at the current version.
+    EXECUTE format(
+        'CREATE TABLE %I.vault_secrets (
+            id          UUID        PRIMARY KEY DEFAULT public.uuid_generate_v4(),
+            name        TEXT        UNIQUE NOT NULL,
+            secret      BYTEA       NOT NULL,
+            nonce       BYTEA       NOT NULL,
+            key_version smallint    NOT NULL DEFAULT 0,
+            description TEXT        DEFAULT '''',
+            created_at  TIMESTAMPTZ DEFAULT now(),
+            updated_at  TIMESTAMPTZ DEFAULT now()
+        )',
+        v_schema_name
+    );
+
+    EXECUTE format('ALTER TABLE %I.users ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.user_identities ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.refresh_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.email_tokens ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.storage_objects ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.todos ENABLE ROW LEVEL SECURITY', v_schema_name);
+    EXECUTE format('ALTER TABLE %I.vault_secrets ENABLE ROW LEVEL SECURITY', v_schema_name);
+
+    EXECUTE format(
+        'CREATE POLICY user_self_access ON %I.users
+         USING (public.is_service_role() OR id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR id = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY user_identities_policy ON %I.user_identities
+         USING (public.is_service_role() OR user_id = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR user_id = public.current_end_user_id())',
+        v_schema_name
+    );
+    -- Sensitive tables stay on the stricter intent GUC (from 000055/#164).
+    EXECUTE format(
+        'CREATE POLICY refresh_tokens_policy ON %I.refresh_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY email_tokens_policy ON %I.email_tokens
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+    EXECUTE format(
+        'CREATE POLICY storage_owner_access ON %I.storage_objects
+         USING (public.is_service_role() OR uploaded_by = public.current_end_user_id())
+         WITH CHECK (public.is_service_role() OR uploaded_by = public.current_end_user_id())',
+        v_schema_name
+    );
+    EXECUTE format('CREATE POLICY public_todos ON %I.todos FOR ALL USING (true)', v_schema_name);
+    EXECUTE format(
+        'CREATE POLICY vault_secrets_policy ON %I.vault_secrets
+         USING (public.is_internal_auth_path())
+         WITH CHECK (public.is_internal_auth_path())',
+        v_schema_name
+    );
+
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_uid() RETURNS uuid
+         LANGUAGE sql STABLE AS $_$
+           SELECT public.current_end_user_id();
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_role() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT COALESCE(current_setting(''app.end_user_role'', true), ''anon'');
+         $_$', v_schema_name
+    );
+    EXECUTE format(
+        'CREATE OR REPLACE FUNCTION %I.auth_email() RETURNS text
+         LANGUAGE sql STABLE AS $_$
+           SELECT email FROM %I.users WHERE id = public.current_end_user_id();
+         $_$', v_schema_name, v_schema_name
+    );
+
+    EXECUTE format('GRANT USAGE, CREATE ON SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO eurobase_gateway', v_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_schema_name);
+
+    -- ── Per-tenant function-runner role (000047) ──
+    EXECUTE format('CREATE ROLE %I NOLOGIN INHERIT', v_func_role);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', v_schema_name, v_func_role);
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+        v_schema_name, v_func_role
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE eurobase_migrator IN SCHEMA %I
+         GRANT USAGE, SELECT ON SEQUENCES TO %I',
+        v_schema_name, v_func_role
+    );
+    -- Issue #188 follow-up: USAGE on public + EXECUTE on the GUC-reading
+    -- helpers, or every preset RLS policy fails at expression init under
+    -- SET LOCAL ROLE (the func role does not inherit the runner's grants).
+    EXECUTE format('GRANT USAGE ON SCHEMA public TO %I', v_func_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION public.is_service_role() TO %I', v_func_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION public.current_end_user_id() TO %I', v_func_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION public.is_internal_auth_path() TO %I', v_func_role);
+    EXECUTE format('GRANT %I TO eurobase_function_runner', v_func_role);
+
+    UPDATE public.projects SET schema_name = v_schema_name WHERE id = p_project_id;
+    SET search_path TO public;
+END;
+$fn$;
+
+ALTER FUNCTION public.provision_tenant(UUID, TEXT, TEXT) OWNER TO eurobase_migrator;


### PR DESCRIPTION
## Problem

PR #195 fixed the GUC half of #188, but live testing on predwell surfaced a second gap: migration 000047 granted `USAGE ON SCHEMA public` and EXECUTE on the RLS helper functions only to `eurobase_function_runner` — and the per-tenant `<schema>_func` role does **not** inherit those (membership goes runner → func role, not the other way). After `SET LOCAL ROLE <schema>_func`, any RLS policy that merely *references* `public.is_service_role()` or `public.current_end_user_id()` — i.e. every policy the platform's DDL presets generate — fails at expression init with `permission denied for schema public`.

## Fix — migration 000060

1. **Backfill**: grants `USAGE ON SCHEMA public` + `EXECUTE` on `is_service_role()`, `current_end_user_id()`, and `is_internal_auth_path()` to every existing tenant's func role.
2. **provision_tenant**: re-created with the 000057 body + the same grants, so new tenants get them at provisioning time (the established wholesale-re-create pattern from 000050/52/55/56/57).

`is_internal_auth_path()` is included so policies on the sensitive auth tables (000055) evaluate to a clean `false`-deny for the func role instead of erroring. None of the grants leak data: the helpers only read transaction-local GUCs, and `USAGE` on `public` alone confers no table access (the func roles have no table grants there).

## Verification

- Down migration restores the 000057 `provision_tenant` body — **diff-verified byte-identical**.
- Up migration's `provision_tenant` is 000057's body plus exactly the four grant lines — diff-verified.
- No live Postgres available locally; the CI migrate Job gates the rollout (fails before any Deployment rolls).

After deploy, predwell's `current_user = 'tenant_<id>_func'` policy workarounds can be dropped and the DDL-preset policies work from edge functions.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)