### PR TITLE
Fix #200: key the runner code cache by function version

### DIFF
--- a/functions-runner/cache_key.ts
+++ b/functions-runner/cache_key.ts
@@ -1,0 +1,19 @@
+// Cache-key derivation for the runner's in-memory code cache.
+//
+// Closes #200: the cache was keyed by function id alone with a 5-minute
+// TTL, so a redeploy kept serving stale code until the TTL expired. The
+// gateway (and the worker's cron invoker) now send X-Function-Version —
+// already looked up for the invoke — and the key includes it, so a
+// version bump is a guaranteed cache miss and redeploys take effect
+// immediately. Old-version entries age out via the existing LRU/TTL.
+//
+// The header is not HMAC-covered: a forged version can only cause a
+// cache miss — code is always loaded from the DB by id. An absent or
+// garbage version (older gateway during a rolling deploy) falls back to
+// the id-only key, i.e. the pre-#200 TTL-bounded behaviour.
+export function functionCacheKey(functionId: string, version: string | null): string {
+  if (version && /^[0-9]+$/.test(version)) {
+    return `${functionId}@v${version}`;
+  }
+  return functionId;
+}

--- a/functions-runner/cache_key_test.ts
+++ b/functions-runner/cache_key_test.ts
@@ -1,0 +1,25 @@
+// Tests for the code-cache key derivation (issue #200): a version bump
+// must produce a different key (immediate redeploy effect), while a
+// missing/garbage version falls back to the id-only key.
+
+import { assertEquals, assertNotEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { functionCacheKey } from "./cache_key.ts";
+
+const ID = "0a1b2c3d-0000-4000-8000-000000000001";
+
+Deno.test("version is part of the cache key — redeploy busts the cache (issue #200)", () => {
+  assertEquals(functionCacheKey(ID, "1"), `${ID}@v1`);
+  assertNotEquals(functionCacheKey(ID, "1"), functionCacheKey(ID, "2"));
+});
+
+Deno.test("missing version falls back to the id-only key (older gateway)", () => {
+  assertEquals(functionCacheKey(ID, null), ID);
+  assertEquals(functionCacheKey(ID, ""), ID);
+});
+
+Deno.test("non-numeric version is ignored, not interpolated", () => {
+  // The header isn't HMAC-covered; a garbage value must not produce
+  // unbounded distinct cache keys beyond what numbers already allow.
+  assertEquals(functionCacheKey(ID, "v2; DROP"), ID);
+  assertEquals(functionCacheKey(ID, "latest"), ID);
+});

--- a/functions-runner/server.ts
+++ b/functions-runner/server.ts
@@ -9,6 +9,7 @@
  */
 
 import { quoteIdent, rlsContextStatements, tenantFuncRole, validIdentRe } from "./role.ts";
+import { functionCacheKey } from "./cache_key.ts";
 import type {
   ParentToWorker,
   SerializedRequest,
@@ -128,8 +129,11 @@ async function getDB() {
 
 // ── Load function code ──
 
-async function loadFunction(functionId: string): Promise<CachedFunction | null> {
-  const cached = getCached(functionId);
+async function loadFunction(functionId: string, version: string | null = null): Promise<CachedFunction | null> {
+  // Key by id+version so a redeploy is effective immediately instead of
+  // after TTL expiry — see cache_key.ts (closes #200).
+  const cacheKey = functionCacheKey(functionId, version);
+  const cached = getCached(cacheKey);
   if (cached) return cached;
 
   try {
@@ -150,7 +154,7 @@ async function loadFunction(functionId: string): Promise<CachedFunction | null> 
       env_vars: typeof row.env_vars === "string" ? JSON.parse(row.env_vars) : row.env_vars,
       cachedAt: Date.now(),
     };
-    setCache(functionId, fn);
+    setCache(cacheKey, fn);
     return fn;
   } catch (err) {
     console.error("Failed to load function:", err);
@@ -587,6 +591,7 @@ Deno.serve({ port: PORT }, async (req: Request): Promise<Response> => {
   // Function invocation.
   if (url.pathname === "/invoke") {
     const functionId = req.headers.get("X-Function-ID");
+    const functionVersion = req.headers.get("X-Function-Version");
     const requestId = req.headers.get("X-Request-ID") ?? crypto.randomUUID();
     const plan = req.headers.get("X-Plan") ?? "free";
 
@@ -615,7 +620,7 @@ Deno.serve({ port: PORT }, async (req: Request): Promise<Response> => {
     }
 
     // Load function code.
-    const fn = await loadFunction(functionId);
+    const fn = await loadFunction(functionId, functionVersion);
     if (!fn) {
       return jsonResponse({ error: "Function not found or disabled", requestId }, 404);
     }

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -225,9 +225,10 @@ func (e *Executor) executeFunctionJob(ctx context.Context, job DueJob) error {
 
 	// Look up function row for X-Function-ID + verify it's active.
 	var fnID, fnStatus string
+	var fnVersion int
 	err := e.pool.QueryRow(ctx,
-		`SELECT id, status FROM edge_functions WHERE project_id = $1 AND name = $2`,
-		job.ProjectID, job.Action).Scan(&fnID, &fnStatus)
+		`SELECT id, status, version FROM edge_functions WHERE project_id = $1 AND name = $2`,
+		job.ProjectID, job.Action).Scan(&fnID, &fnStatus, &fnVersion)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return fmt.Errorf("function %q is not deployed", job.Action)
@@ -265,6 +266,9 @@ func (e *Executor) executeFunctionJob(ctx context.Context, job DueJob) error {
 	req.Header.Set("X-Schema-Name", job.SchemaName)
 	req.Header.Set("X-Function-Name", job.Action)
 	req.Header.Set("X-Function-ID", fnID)
+	// Runner cache key includes the version so redeploys take effect
+	// immediately (closes #200) — same as the gateway invoke path.
+	req.Header.Set("X-Function-Version", strconv.Itoa(fnVersion))
 	plan := job.Plan
 	if plan == "" {
 		plan = "free"

--- a/internal/functions/invoke.go
+++ b/internal/functions/invoke.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/eurobase/euroback/internal/auth"
@@ -77,6 +78,12 @@ func HandleInvoke(pool *pgxpool.Pool, svc *Service, runnerURL string, signer *Si
 		proxyReq.Header.Set("X-Schema-Name", projectCtx.SchemaName)
 		proxyReq.Header.Set("X-Function-Name", functionName)
 		proxyReq.Header.Set("X-Function-ID", fn.ID)
+		// The runner keys its code cache on id+version, so a redeploy
+		// (version bump) takes effect immediately instead of after the
+		// cache TTL (closes #200). Not HMAC-covered: a forged version
+		// can only cause a cache miss — code is always loaded from the
+		// DB by id.
+		proxyReq.Header.Set("X-Function-Version", strconv.Itoa(fn.Version))
 		proxyReq.Header.Set("X-Plan", projectCtx.Plan)
 		proxyReq.Header.Set("Content-Type", r.Header.Get("Content-Type"))
 


### PR DESCRIPTION
## Problem

The runner caches function code by id with a 5-minute TTL and nothing invalidates it on deploy — so for up to 5 minutes after a redeploy, invocations run stale code while the CLI/dashboard show the new version (#200). Post-#197 this also means stale *compiled* output.

## Fix (issue's option 1)

Both invocation paths already look up the function row, so they now pass the version they fetched:

- gateway `HandleInvoke` sends `X-Function-Version` from `fn.Version`
- the worker's cron invoker adds `version` to its existing id/status lookup and sends the same header

The runner keys its cache on `<id>@v<version>` (new `cache_key.ts`), so a version bump is a guaranteed cache miss — redeploys take effect immediately. Old-version entries age out via the existing LRU/TTL.

## Rollout / security notes

- The header is deliberately **not** HMAC-covered: a forged version can only cause a cache miss — code is always loaded from the DB by id, so there's no poisoning path. Non-numeric values are ignored.
- Missing version (older gateway during a rolling deploy) falls back to the id-only key — the previous TTL-bounded behaviour — so gateway/runner rollout order doesn't matter.

## Tests

`cache_key_test.ts` covers version-busts-cache, id-only fallback, and garbage-version handling (runs in CI's test-functions-runner job). `go build`/`vet`/`test` pass for the gateway and cron packages.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)