### PR TITLE
Fix #198: CORS-allow localhost:3000 by default + log rejected origins

### DIFF
--- a/internal/gateway/cors.go
+++ b/internal/gateway/cors.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -49,6 +50,16 @@ func NewCORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler 
 				// Not allowed by global or per-project. For preflight
 				// respond 204 with no CORS headers so the browser
 				// rejects the real request.
+				//
+				// One greppable line per rejection (issue #198):
+				// without it the only symptom is a missing response
+				// header, invisible outside browser devtools.
+				projectID := ""
+				if pc, ok := auth.ProjectFromContext(r.Context()); ok && pc != nil {
+					projectID = pc.ProjectID
+				}
+				slog.Warn("CORS: origin not allowlisted, browser will block the response",
+					"origin", origin, "project_id", projectID, "path", r.URL.Path)
 				if r.Method == http.MethodOptions {
 					w.WriteHeader(http.StatusNoContent)
 					return

--- a/internal/gateway/cors_perproject_test.go
+++ b/internal/gateway/cors_perproject_test.go
@@ -140,3 +140,42 @@ func contains(haystack, needle string) bool {
 	}
 	return false
 }
+
+func TestCORS_FreshProjectWithEmptyAuthConfigAllowsLocalhost3000(t *testing.T) {
+	// Issue #198: a freshly-created project (empty/default auth_config)
+	// must be able to serve a localhost:3000 browser app out of the box —
+	// the scaffold and the default redirect_urls both target that origin.
+	cors := newPlatformGlobalCORS()
+	rr := httptest.NewRecorder()
+	handler := cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+
+	pc := &auth.ProjectContext{
+		ProjectID:  "p-fresh",
+		SchemaName: "tenant_fresh",
+		Slug:       "fresh",
+		AuthConfig: []byte("{}"), // never edited — ParseAuthConfig falls back to defaults
+	}
+	ctx := auth.ContextWithProject(context.Background(), pc)
+	handler.ServeHTTP(rr, makeReq(http.MethodOptions, "http://localhost:3000", ctx))
+
+	if rr.Header().Get("Access-Control-Allow-Origin") != "http://localhost:3000" {
+		t.Errorf("fresh project should CORS-allow localhost:3000 by default, got %q",
+			rr.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestCORS_StoredConfigWithoutCORSOriginsIsNotBackfilled(t *testing.T) {
+	// A project whose auth_config WAS edited (stored JSON, no cors_origins
+	// key) keeps its explicit empty list — the localhost default applies
+	// only to never-configured projects. Changing already-configured
+	// projects' CORS posture on upgrade would be a silent behaviour change.
+	cors := newPlatformGlobalCORS()
+	rr := httptest.NewRecorder()
+	handler := cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+
+	handler.ServeHTTP(rr, makeReq(http.MethodOptions, "http://localhost:3000", ctxWithProjectCORS()))
+
+	if rr.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Error("stored config without cors_origins should not gain localhost retroactively")
+	}
+}

--- a/internal/tenant/auth_config.go
+++ b/internal/tenant/auth_config.go
@@ -70,6 +70,13 @@ func DefaultAuthConfig() AuthConfig {
 		RequireEmailConfirmation: false,
 		SessionDuration:          "168h",
 		RedirectURLs:             []string{"http://localhost:3000"},
+		// Match RedirectURLs (issue #198): the scaffold targets a
+		// localhost:3000 browser app, and an origin trusted to receive
+		// OAuth redirects must also be CORS-allowed for API calls or
+		// every fresh browser app hits an opaque CORS wall. Remote
+		// sites cannot forge a localhost Origin header, so keeping
+		// this entry on production projects is not an exposure.
+		CORSOrigins: []string{"http://localhost:3000"},
 	}
 }
 

--- a/internal/tenant/cors_test.go
+++ b/internal/tenant/cors_test.go
@@ -109,3 +109,18 @@ func TestValidate_RejectsCORSOriginWithQueryOrFragment(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultAuthConfig_CORSMatchesRedirectURLs(t *testing.T) {
+	// Issue #198: the default redirect_urls and cors_origins must agree —
+	// an origin trusted for OAuth redirects must also be able to call the
+	// API from a browser, or the scaffold's own target origin is blocked.
+	cfg := DefaultAuthConfig()
+	for _, u := range cfg.RedirectURLs {
+		if !cfg.IsCORSOriginAllowed(u) {
+			t.Errorf("default redirect URL %q is not CORS-allowed by default", u)
+		}
+	}
+	if !cfg.IsCORSOriginAllowed("http://localhost:3000") {
+		t.Error("default config must CORS-allow http://localhost:3000")
+	}
+}


### PR DESCRIPTION
## Problem

`DefaultAuthConfig()` sets `RedirectURLs: ["http://localhost:3000"]` but left `CORSOrigins` empty — the exact origin the scaffold targets was trusted for OAuth redirects yet blocked for every browser API call (#198). A fresh Vite/React app fails on first fetch with no server-side signal: `curl` works (no CORS enforcement), so backend tests never see it.

## Fix

- **Defaults agree**: `DefaultAuthConfig` now sets `CORSOrigins` to match `RedirectURLs`. This applies to new projects and projects whose `auth_config` was never edited (`ParseAuthConfig` falls back to defaults for empty/`{}`/`null`). Projects with a stored config keep their explicit list — **no silent posture change on upgrade**. Keeping a localhost entry on production projects is not an exposure: remote sites cannot forge a localhost `Origin` header, and the SDK authenticates with bearer tokens, not ambient cookies.
- **Greppable signal** (issue fix 3): the CORS middleware logs one `slog.Warn` per rejected origin with `origin`, `project_id`, and `path` — previously the only symptom was a missing response header, invisible outside browser devtools.

## Tests

- every default redirect URL is CORS-allowed by the default config
- fresh project (empty auth_config) → preflight from `localhost:3000` succeeds
- stored config without `cors_origins` is **not** retroactively backfilled

## Follow-ups from the issue (not in this PR)

- `eurobase projects set-cors <origin>` CLI command (no CLI path to set CORS today)
- `PATCH /v1/tenants/{id}` replaces the whole `auth_config` — easy to clobber providers/session settings when only changing one field; deserves a merge-patch or dedicated endpoint

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)