### PR TITLE
Fix #201: runner decrypts vault secrets with the right key_version

### DIFF
--- a/functions-runner/bridge.ts
+++ b/functions-runner/bridge.ts
@@ -53,8 +53,11 @@ export type ParentToWorker =
   // RPC result for `db.sql`. Mirrors the call's `id` so async handlers
   // route to the right Promise.
   | { type: "db.sql.result"; id: string; rows?: unknown; error?: string }
-  // RPC result for `vault.get`.
-  | { type: "vault.get.result"; id: string; value: string | null }
+  // RPC result for `vault.get`. `error` is set for platform-side
+  // failures (key unconfigured, lookup/decrypt failure, #201) and makes
+  // the worker's RPC layer throw; a missing secret is value: null with
+  // no error.
+  | { type: "vault.get.result"; id: string; value: string | null; error?: string }
   // RPC results for `ctx.storage.*` (closes #85).
   | { type: "storage.upload.result"; id: string; key?: string; size?: number; error?: string }
   | { type: "storage.signed_url.result"; id: string; url?: string; expiresAt?: string; error?: string }

--- a/functions-runner/server.ts
+++ b/functions-runner/server.ts
@@ -436,20 +436,29 @@ async function runUserHandlerInWorker(opts: {
         }
         case "vault.get.call": {
           // Closes #79: read the encrypted blob via the SECURITY DEFINER
-          // helper public.vault_get_for_runner (added by migration 000049)
-          // and decrypt locally with VAULT_ENCRYPTION_KEY. Failure modes
-          // (missing secret, no encryption key, decrypt failure) all
-          // resolve to null so the worker contract stays `string | null`.
-          resolveVaultSecret(db, projectId, msg.name)
-            .then((value) => {
+          // helper public.vault_get_for_runner (migration 000049,
+          // key_version added in 000061) and decrypt locally with the
+          // key for the version the secret was sealed with (#201).
+          // Missing secret → null; platform-side failures (no key,
+          // lookup/decrypt failure) → error, which the worker's RPC
+          // layer surfaces to user code as a thrown Error so "secret
+          // missing" and "vault broken" are distinguishable.
+          resolveVaultSecret(db, projectId, schemaName, msg.name)
+            .then((result) => {
               if (settled) return;
-              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value };
+              if ("error" in result) {
+                logCapture.warn(`vault.get(${JSON.stringify(msg.name)}) failed: ${result.error}`);
+                const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: null, error: result.error };
+                worker.postMessage(reply);
+                return;
+              }
+              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: result.value };
               worker.postMessage(reply);
             })
             .catch((err) => {
               if (settled) return;
               console.error(`[fn:${projectId}] vault.get failed`, err);
-              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: null };
+              const reply: ParentToWorker = { type: "vault.get.result", id: msg.id, value: null, error: "vault unavailable: internal error" };
               worker.postMessage(reply);
             });
           break;

--- a/functions-runner/vault.ts
+++ b/functions-runner/vault.ts
@@ -1,10 +1,22 @@
-// Vault read path for edge functions. Closes #79.
+// Vault read path for edge functions. Closes #79; key_version support
+// closes #201.
 //
 // Worker calls ctx.vault.get(name) → bridge.ts emits a vault.get.call →
 // server.ts (parent) calls resolveVaultSecret() here → we query
 // public.vault_get_for_runner(projectId, name) (SECURITY DEFINER, granted
-// only to eurobase_function_runner, added by migration 000049), get back
-// the encrypted blob and nonce, and decrypt locally with VAULT_ENCRYPTION_KEY.
+// only to eurobase_function_runner; migration 000049, key_version added in
+// 000061), get back the encrypted blob + nonce + key_version, and decrypt
+// locally.
+//
+// Key derivation mirrors internal/vault/keyprovider.go exactly:
+//   key_version 0  → the raw 32-byte master (VAULT_ENCRYPTION_KEY decoded);
+//                    rows that predate per-tenant keys (migration 000057).
+//   key_version ≥1 → HKDF-SHA256(master, salt = tenant schema name,
+//                    info = "eurobase-vault-v<version>") — the per-tenant
+//                    derived key the gateway seals new writes with.
+// The schema name passed in MUST be the same value the gateway used as the
+// HKDF salt (projects.schema_name); server.ts takes it from the
+// HMAC-verified X-Schema-Name header.
 //
 // Layout compatibility with the Go gateway:
 //   gcm.Seal(nil, nonce, plaintext, nil)  → ciphertext || tag (16 bytes)
@@ -12,19 +24,30 @@
 // Web Crypto's AES-GCM expects the auth tag appended to the ciphertext —
 // same layout as Go's GCM, so we pass the bytea blob through directly.
 
+// VaultResult distinguishes "the secret does not exist" (value: null) from
+// "the platform could not read it" (error) — closes the silent-null half
+// of #201. The error string surfaces to user code as a thrown Error via
+// the RPC bridge, so a developer can tell a missing secret apart from a
+// misconfigured runtime without pod access.
+export type VaultResult = { value: string | null } | { error: string };
+
 // Lazy: read VAULT_ENCRYPTION_KEY on first use rather than at module
 // load. Lets tests set the env var after import without resorting to
 // cache-busting URL params, and matches how the gateway boots vault.
-let _key: CryptoKey | null = null;
-let _keyEnv: string | null = null;
+let _masterEnv: string | null = null;
+let _masterRaw: Uint8Array | null = null;
+// Imported CryptoKeys per (version, schema) — derivation is cheap but
+// not free, and the same few tenants invoke repeatedly.
+const _keyCache = new Map<string, CryptoKey>();
 
-async function getCryptoKey(): Promise<CryptoKey | null> {
+function getMasterRaw(): Uint8Array | null {
   const env = Deno.env.get("VAULT_ENCRYPTION_KEY") ?? "";
-  if (_key && env === _keyEnv) return _key;
+  if (env === _masterEnv) return _masterRaw;
   // Reset if env changed (only meaningful in tests; in production the
   // pod env is fixed for its lifetime).
-  _key = null;
-  _keyEnv = env;
+  _masterEnv = env;
+  _masterRaw = null;
+  _keyCache.clear();
   if (!env) return null;
   let raw: Uint8Array;
   try {
@@ -37,41 +60,89 @@ async function getCryptoKey(): Promise<CryptoKey | null> {
     console.error(`[vault] VAULT_ENCRYPTION_KEY must decode to 32 bytes (got ${raw.byteLength})`);
     return null;
   }
-  _key = await crypto.subtle.importKey("raw", raw, "AES-GCM", false, ["decrypt"]);
-  return _key;
+  _masterRaw = raw;
+  return raw;
 }
 
-// resolveVaultSecret returns the decrypted secret value for (projectId, name)
-// or null when the secret doesn't exist, the encryption key isn't configured,
-// or decryption fails. All failure modes return null deliberately — the
-// worker contract is `string | null`, and surfacing exceptions through the
-// RPC bridge would just leak internals to user code.
+// getAesKey returns the AES-GCM decrypt key for (schemaName, version),
+// mirroring keyprovider.go DeriveKey. Throws when version ≥1 but no
+// schema name is available to derive with.
+async function getAesKey(
+  master: Uint8Array,
+  schemaName: string,
+  version: number,
+): Promise<CryptoKey> {
+  const cacheKey = version === 0 ? "v0" : `v${version}:${schemaName}`;
+  const hit = _keyCache.get(cacheKey);
+  if (hit) return hit;
+
+  let rawKey: Uint8Array = master;
+  if (version !== 0) {
+    if (!schemaName) {
+      throw new Error("missing tenant schema name for per-tenant key derivation");
+    }
+    const te = new TextEncoder();
+    const hkdfKey = await crypto.subtle.importKey("raw", master, "HKDF", false, ["deriveBits"]);
+    const bits = await crypto.subtle.deriveBits(
+      {
+        name: "HKDF",
+        hash: "SHA-256",
+        salt: te.encode(schemaName),
+        info: te.encode("eurobase-vault-v" + version),
+      },
+      hkdfKey,
+      256,
+    );
+    rawKey = new Uint8Array(bits);
+  }
+  const key = await crypto.subtle.importKey("raw", rawKey, "AES-GCM", false, ["decrypt"]);
+  _keyCache.set(cacheKey, key);
+  return key;
+}
+
+// resolveVaultSecret returns { value } for found/not-found secrets and
+// { error } for platform-side failures (no key configured, lookup failed,
+// wrong key / decryption failed). Not-found stays a plain null value —
+// that one is the developer's to handle.
 export async function resolveVaultSecret(
   // deno-lint-ignore no-explicit-any
   db: any,
   projectId: string,
+  schemaName: string,
   name: string,
-): Promise<string | null> {
-  if (!projectId || !name) return null;
-  const key = await getCryptoKey();
-  if (!key) {
-    console.warn("[vault] VAULT_ENCRYPTION_KEY not configured; ctx.vault.get returns null");
-    return null;
+): Promise<VaultResult> {
+  if (!projectId || !name) return { value: null };
+
+  const master = getMasterRaw();
+  if (!master) {
+    console.warn("[vault] VAULT_ENCRYPTION_KEY not configured/invalid; ctx.vault.get unavailable");
+    return {
+      error: "vault unavailable: encryption key is not configured in the functions runtime — contact the platform operator",
+    };
   }
 
-  // postgres.js returns bytea columns as Uint8Array. The SECURITY DEFINER
-  // function returns at most one row (vault_secrets.name has a unique
-  // constraint) — destructure with a length guard for safety.
-  let rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array }>;
+  // postgres.js returns bytea columns as Uint8Array and smallint as
+  // number. The SECURITY DEFINER function returns at most one row
+  // (vault_secrets.name has a unique constraint).
+  let rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array; key_version: number | null }>;
   try {
-    rows = await db`SELECT encrypted, nonce FROM public.vault_get_for_runner(${projectId}::uuid, ${name})`;
+    rows = await db`SELECT encrypted, nonce, key_version FROM public.vault_get_for_runner(${projectId}::uuid, ${name})`;
   } catch (err) {
     console.error("[vault] DB read failed", err instanceof Error ? err.message : err);
-    return null;
+    return { error: "vault unavailable: secret lookup failed" };
   }
-  if (!rows || rows.length === 0) return null;
+  if (!rows || rows.length === 0) return { value: null };
   const { encrypted, nonce } = rows[0];
-  if (!encrypted || !nonce) return null;
+  if (!encrypted || !nonce) return { value: null };
+  const version = Number(rows[0].key_version ?? 0);
+
+  let key: CryptoKey;
+  try {
+    key = await getAesKey(master, schemaName, version);
+  } catch (err) {
+    console.error("[vault] key derivation failed", err instanceof Error ? err.message : err);
+    return { error: `vault unavailable: key derivation failed (key_version ${version})` };
+  }
 
   try {
     const plain = await crypto.subtle.decrypt(
@@ -79,9 +150,14 @@ export async function resolveVaultSecret(
       key,
       encrypted,
     );
-    return new TextDecoder().decode(plain);
+    return { value: new TextDecoder().decode(plain) };
   } catch (err) {
-    console.error("[vault] decryption failed", err instanceof Error ? err.message : err);
-    return null;
+    console.error(
+      `[vault] decryption failed for ${name} (key_version ${version})`,
+      err instanceof Error ? err.message : err,
+    );
+    return {
+      error: `vault decryption failed for "${name}" (key_version ${version}) — the runtime's key does not match the key this secret was sealed with`,
+    };
   }
 }

--- a/functions-runner/vault_test.ts
+++ b/functions-runner/vault_test.ts
@@ -1,10 +1,12 @@
-// Tests for the vault read path. Closes #79.
+// Tests for the vault read path. Closes #79; key_version support #201.
 //
 // We focus on the decrypt half: given an AES-256-GCM ciphertext + nonce
 // produced exactly the way the Go gateway produces it
 // (gcm.Seal(nil, nonce, plaintext, nil) → ciphertext || tag), the runner
-// must recover the plaintext. The DB query is mocked via a stub `db`
-// tagged-template so the tests are hermetic.
+// must recover the plaintext — including secrets sealed with the
+// per-tenant HKDF-derived keys the gateway uses since migration 000057.
+// The DB query is mocked via a stub `db` tagged-template so the tests
+// are hermetic.
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { resolveVaultSecret } from "./vault.ts";
@@ -12,6 +14,9 @@ import { resolveVaultSecret } from "./vault.ts";
 const KEY_RAW = new Uint8Array(32);
 for (let i = 0; i < 32; i++) KEY_RAW[i] = i;
 const KEY_B64 = btoa(String.fromCharCode(...KEY_RAW));
+
+const PROJECT_ID = "11111111-2222-3333-4444-555555555555";
+const SCHEMA = "tenant_11111111_2222_3333_4444_555555555555";
 
 // Encrypt with the same layout the Go gateway uses so the test exercises
 // the actual on-disk byte format. iv is 12 bytes (GCM standard / what
@@ -32,7 +37,7 @@ async function encryptForGateway(
 
 // Tagged-template stub matching postgres.js's call shape.
 // deno-lint-ignore no-explicit-any
-function stubDB(rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array }>): any {
+function stubDB(rows: Array<{ encrypted: Uint8Array; nonce: Uint8Array; key_version?: number }>): any {
   return (_strings: TemplateStringsArray, ..._values: unknown[]) => Promise.resolve(rows);
 }
 
@@ -41,30 +46,73 @@ function stubDBThrowing(message: string): any {
   return (_strings: TemplateStringsArray, ..._values: unknown[]) => Promise.reject(new Error(message));
 }
 
-Deno.test("vault.get round-trips a Go-encrypted secret", async () => {
+function b64ToBytes(b64: string): Uint8Array {
+  return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+Deno.test("vault.get round-trips a Go-encrypted legacy (key_version 0) secret", async () => {
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
   const { encrypted, nonce } = await encryptForGateway("fal_ai_key_value", KEY_RAW);
-  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "11111111-2222-3333-4444-555555555555", "FAL_AI_KEY");
-  assertEquals(got, "fal_ai_key_value");
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce, key_version: 0 }]), PROJECT_ID, SCHEMA, "FAL_AI_KEY");
+  assertEquals(got, { value: "fal_ai_key_value" });
 });
 
-Deno.test("vault.get returns null when VAULT_ENCRYPTION_KEY is unset", async () => {
+Deno.test("vault.get decrypts a key_version 1 secret sealed by the Go gateway (issue #201)", async () => {
+  // Fixture generated with Go's crypto/hkdf + crypto/cipher, exactly as
+  // internal/vault/keyprovider.go derives and service.go seals:
+  //   master  = bytes 0x00..0x1f (KEY_RAW above)
+  //   tenant  = SCHEMA (HKDF salt)
+  //   info    = "eurobase-vault-v1"
+  //   derived = RF884Rlm9sIYlm8ig2EQzav21+5drtmIg+vEujfkG54=
+  //   nonce   = 0x01..0x0c
+  //   sealed  = gcm.Seal(nil, nonce, "mistral_api_key_value", nil)
+  // The same vector is pinned Go-side in
+  // internal/vault/keyprovider_test.go so a drift in either
+  // implementation fails one of the two CI jobs.
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const encrypted = b64ToBytes("OYT3J2/GBpxo9TmQF9/BYzfodt28C63W91q7+g19CVRVFcSXTA==");
+  const nonce = b64ToBytes("AQIDBAUGBwgJCgsM");
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce, key_version: 1 }]), PROJECT_ID, SCHEMA, "MISTRAL_API_KEY");
+  assertEquals(got, { value: "mistral_api_key_value" });
+});
+
+Deno.test("vault.get errors (not null) for a key_version 1 secret decrypted with the wrong tenant (issue #201)", async () => {
+  // Same v1 fixture but a different schema name → different derived key
+  // → GCM auth failure. Must surface as an error so the developer can
+  // tell it apart from a missing secret.
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const encrypted = b64ToBytes("OYT3J2/GBpxo9TmQF9/BYzfodt28C63W91q7+g19CVRVFcSXTA==");
+  const nonce = b64ToBytes("AQIDBAUGBwgJCgsM");
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce, key_version: 1 }]), PROJECT_ID, "tenant_other", "MISTRAL_API_KEY");
+  if (!("error" in got)) throw new Error(`expected error result, got ${JSON.stringify(got)}`);
+});
+
+Deno.test("vault.get missing key_version is treated as legacy version 0", async () => {
+  // Rollout edge: a DB row read through a stub that omits key_version
+  // (pre-000061 shape) must keep decrypting with the master key.
+  Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
+  const { encrypted, nonce } = await encryptForGateway("legacy_value", KEY_RAW);
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), PROJECT_ID, SCHEMA, "LEGACY");
+  assertEquals(got, { value: "legacy_value" });
+});
+
+Deno.test("vault.get errors when VAULT_ENCRYPTION_KEY is unset (issue #201: not a silent null)", async () => {
   Deno.env.delete("VAULT_ENCRYPTION_KEY");
   const { encrypted, nonce } = await encryptForGateway("x", KEY_RAW);
-  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "p", "K");
-  assertEquals(got, null);
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce, key_version: 0 }]), "p", "s", "K");
+  if (!("error" in got)) throw new Error(`expected error result, got ${JSON.stringify(got)}`);
 });
 
-Deno.test("vault.get returns null when the secret does not exist", async () => {
+Deno.test("vault.get returns null value when the secret does not exist", async () => {
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
-  const got = await resolveVaultSecret(stubDB([]), "11111111-2222-3333-4444-555555555555", "MISSING");
-  assertEquals(got, null);
+  const got = await resolveVaultSecret(stubDB([]), PROJECT_ID, SCHEMA, "MISSING");
+  assertEquals(got, { value: null });
 });
 
-Deno.test("vault.get returns null when the DB query throws (no exception leak)", async () => {
+Deno.test("vault.get errors when the DB query throws (no exception leak)", async () => {
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
-  const got = await resolveVaultSecret(stubDBThrowing("permission denied"), "11111111-2222-3333-4444-555555555555", "X");
-  assertEquals(got, null);
+  const got = await resolveVaultSecret(stubDBThrowing("permission denied"), PROJECT_ID, SCHEMA, "X");
+  if (!("error" in got)) throw new Error(`expected error result, got ${JSON.stringify(got)}`);
 });
 
 Deno.test("vault.get returns null with no projectId or name (no DB call)", async () => {
@@ -75,15 +123,15 @@ Deno.test("vault.get returns null with no projectId or name (no DB call)", async
     return Promise.resolve([]);
   };
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
-  assertEquals(await resolveVaultSecret(db, "", "X"), null);
-  assertEquals(await resolveVaultSecret(db, "p", ""), null);
+  assertEquals(await resolveVaultSecret(db, "", SCHEMA, "X"), { value: null });
+  assertEquals(await resolveVaultSecret(db, "p", SCHEMA, ""), { value: null });
   assertEquals(called, false);
 });
 
-Deno.test("vault.get returns null when ciphertext was tampered (auth tag mismatch)", async () => {
+Deno.test("vault.get errors when ciphertext was tampered (auth tag mismatch)", async () => {
   Deno.env.set("VAULT_ENCRYPTION_KEY", KEY_B64);
   const { encrypted, nonce } = await encryptForGateway("secret", KEY_RAW);
   encrypted[0] ^= 0xff; // flip a bit in the ciphertext
-  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce }]), "p", "K");
-  assertEquals(got, null);
+  const got = await resolveVaultSecret(stubDB([{ encrypted, nonce, key_version: 0 }]), PROJECT_ID, SCHEMA, "K");
+  if (!("error" in got)) throw new Error(`expected error result, got ${JSON.stringify(got)}`);
 });

--- a/internal/vault/keyprovider_test.go
+++ b/internal/vault/keyprovider_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"testing"
 )
 
@@ -114,5 +115,34 @@ func TestSealOpen_RoundTripAndIsolation(t *testing.T) {
 
 	if _, err := decryptWith(keyB, ct, nonce); err == nil {
 		t.Error("tenant B's key decrypted tenant A's ciphertext — separation broken")
+	}
+}
+
+// Cross-language vector pinned in BOTH this Go suite and the Deno runner
+// suite (functions-runner/vault_test.ts, issue #201). The runner
+// re-implements this derivation with WebCrypto HKDF; if either side
+// drifts, its CI job fails. Do not change the vector without changing
+// both files.
+func TestHKDFProvider_CrossLanguageVector(t *testing.T) {
+	p := newHKDFKeyProvider(testMaster())
+	key, err := p.DeriveKey(context.Background(), "tenant_11111111_2222_3333_4444_555555555555", 1)
+	if err != nil {
+		t.Fatalf("DeriveKey: %v", err)
+	}
+	want, _ := base64.StdEncoding.DecodeString("RF884Rlm9sIYlm8ig2EQzav21+5drtmIg+vEujfkG54=")
+	if !bytes.Equal(key, want) {
+		t.Errorf("derived key = %s, want %s — runner vault.ts pins this exact vector",
+			base64.StdEncoding.EncodeToString(key), base64.StdEncoding.EncodeToString(want))
+	}
+
+	// And the sealed fixture the Deno test decrypts: same key, fixed nonce.
+	nonce := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	sealed, _ := base64.StdEncoding.DecodeString("OYT3J2/GBpxo9TmQF9/BYzfodt28C63W91q7+g19CVRVFcSXTA==")
+	got, err := decryptWith(key, sealed, nonce)
+	if err != nil {
+		t.Fatalf("decryptWith fixture: %v", err)
+	}
+	if got != "mistral_api_key_value" {
+		t.Errorf("fixture plaintext = %q, want %q", got, "mistral_api_key_value")
 	}
 }

--- a/migrations/000061_vault_runner_key_version.down.sql
+++ b/migrations/000061_vault_runner_key_version.down.sql
@@ -1,0 +1,42 @@
+-- Restores the 000049 two-column signature. WARNING: an updated runner
+-- (selecting key_version) will fail against this version — only roll
+-- back together with the pre-#201 runner image. Reverting also re-breaks
+-- decryption of key_version >= 1 secrets from edge functions (the bug
+-- this migration fixes).
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.vault_get_for_runner(uuid, text);
+
+CREATE FUNCTION public.vault_get_for_runner(
+    p_project_id uuid,
+    p_name       text
+)
+RETURNS TABLE(encrypted bytea, nonce bytea)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_schema text;
+BEGIN
+    SELECT schema_name INTO v_schema
+    FROM public.projects
+    WHERE id = p_project_id;
+
+    IF v_schema IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY EXECUTE format(
+        'SELECT secret, nonce FROM %I.vault_secrets WHERE name = $1',
+        v_schema
+    ) USING p_name;
+END;
+$$;
+
+ALTER FUNCTION public.vault_get_for_runner(uuid, text) OWNER TO eurobase_migrator;
+REVOKE ALL ON FUNCTION public.vault_get_for_runner(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.vault_get_for_runner(uuid, text) TO eurobase_function_runner;
+
+COMMIT;

--- a/migrations/000061_vault_runner_key_version.up.sql
+++ b/migrations/000061_vault_runner_key_version.up.sql
@@ -1,0 +1,64 @@
+-- Issue #201: vault_get_for_runner must return key_version.
+--
+-- Migration 000057 moved the gateway to per-tenant HKDF-derived keys —
+-- every secret written since is sealed at key_version >= 1 — but the
+-- runner's read helper (000049) only returned (encrypted, nonce), so the
+-- runner kept decrypting with the raw master key (the version-0 key) and
+-- ctx.vault.get returned null for every post-000057 secret.
+--
+-- Adding a return column requires DROP + CREATE (CREATE OR REPLACE cannot
+-- change an OUT row type), so the owner/grants from 000049 are re-applied.
+--
+-- Rollout compatibility: a not-yet-updated runner selects explicit columns
+-- (encrypted, nonce) and is unaffected by the extra column. The updated
+-- runner selects key_version, so this migration must apply before the new
+-- runner image rolls out — guaranteed by the CI pipeline (migrate Job
+-- gates the Deployment roll).
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.vault_get_for_runner(uuid, text);
+
+CREATE FUNCTION public.vault_get_for_runner(
+    p_project_id uuid,
+    p_name       text
+)
+RETURNS TABLE(encrypted bytea, nonce bytea, key_version smallint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_schema text;
+BEGIN
+    -- Resolve the project's tenant schema. SECURITY DEFINER means we
+    -- read public.projects with the function owner's privileges
+    -- (eurobase_migrator), bypassing the runner role's lack of direct
+    -- access. Empty result for unknown project_id — never raises so the
+    -- runner just sees `not found` and replies null to the worker.
+    SELECT schema_name INTO v_schema
+    FROM public.projects
+    WHERE id = p_project_id;
+
+    IF v_schema IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Format-then-USING the parameter avoids any SQL injection through
+    -- p_name since it's bound as a parameter, not interpolated. The
+    -- schema name comes from public.projects (UUID-derived) so it's
+    -- safe to interpolate via %I. COALESCE covers any pre-000057 row
+    -- where key_version is somehow NULL — those were sealed with the
+    -- legacy (version 0) key.
+    RETURN QUERY EXECUTE format(
+        'SELECT secret, nonce, COALESCE(key_version, 0::smallint) FROM %I.vault_secrets WHERE name = $1',
+        v_schema
+    ) USING p_name;
+END;
+$$;
+
+ALTER FUNCTION public.vault_get_for_runner(uuid, text) OWNER TO eurobase_migrator;
+REVOKE ALL ON FUNCTION public.vault_get_for_runner(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.vault_get_for_runner(uuid, text) TO eurobase_function_runner;
+
+COMMIT;


### PR DESCRIPTION
## Root cause

Migration 000057 (#179) moved the gateway to per-tenant HKDF-derived vault keys — every secret written or updated since is sealed at `key_version 1` — but the runner was left behind: `vault.ts` decrypts everything with the raw master key (the version-0 key), and `vault_get_for_runner` (000049) doesn't even return `key_version`. So **every post-000057 secret fails GCM auth in the runner** and `ctx.vault.get` returns `null`, indistinguishable from a missing secret. That's why `listSecrets`/console reads work (the gateway's own path is version-aware) while every edge function gets `null` (#201).

## Fix

- **Migration 000061**: `vault_get_for_runner` now also returns `key_version` (DROP + CREATE — return-type change — with 000049's owner/REVOKE/GRANT re-applied, wrapped in a transaction). An old runner selecting explicit columns is unaffected by the extra column; the new runner needs the migration first, which CI's migrate-before-deploy ordering guarantees.
- **`vault.ts`**: version-aware decryption mirroring `internal/vault/keyprovider.go` — version 0 uses the raw master; version ≥ 1 derives via WebCrypto HKDF-SHA256 with salt = tenant schema name and info = `eurobase-vault-v<version>`, plus a per-(version, schema) derived-key cache. The schema name comes from the HMAC-verified `X-Schema-Name` header — the same `projects.schema_name` value the gateway used as the HKDF salt.
- **Distinguishable failures** (issue fix 2): `resolveVaultSecret` returns `{value}` or `{error}`. Platform-side failures (key unconfigured, lookup failed, wrong key/decrypt failure) now surface to user code as a **thrown Error** with an actionable message, via the worker bridge's existing error path; a warning also lands in the function's log capture. A genuinely missing secret stays a plain `null`.

## Cross-language compatibility pinning

The exact derived key + sealed fixture (generated with Go `crypto/hkdf` + `crypto/cipher`, mirroring `keyprovider.go`) is asserted in **both** `internal/vault/keyprovider_test.go` (test-go job) and `functions-runner/vault_test.ts` (test-functions-runner job) — a drift in either implementation fails its CI job. WebCrypto HKDF was verified byte-identical to Go's `hkdf.Key` for this vector before embedding.

## Remaining items from the issue (not in this PR)

- **Ops check**: `kubectl exec deploy/functions -n eurobase -- printenv | grep VAULT_ENCRYPTION_KEY` to rule out a stale pod env as a second contributing cause (the key_version bug is deterministic regardless).
- **env_vars stored in plaintext** despite docs claiming "encrypted at rest (vault key)" — separate discrepancy, should get its own issue.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)