### PR TITLE
Fix 000063 deploy failure: ALTER DEFAULT PRIVILEGES under NOINHERIT migrator

### DIFF
--- a/migrations/000063_tenant_ddl_role.up.sql
+++ b/migrations/000063_tenant_ddl_role.up.sql
@@ -110,11 +110,21 @@ BEGIN
     -- login password per apply (creator + CREATEROLE; no ADMIN OPTION needed).
     EXECUTE format('GRANT %I TO eurobase_migrator', v_ddl_role);
 
-    -- Tables the ddl role creates become usable at runtime.
-    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_ddl_role, p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO eurobase_gateway', v_ddl_role, p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', v_ddl_role, p_schema, v_func_role);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO %I', v_ddl_role, p_schema, v_func_role);
+    -- Tables the ddl role creates become usable at runtime. Done while
+    -- SET ROLE'd to the ddl role (altering its OWN default privileges)
+    -- rather than `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>` as migrator:
+    -- the FOR ROLE form requires has_privs_of_role (INHERIT-based)
+    -- membership, and eurobase_migrator is NOINHERIT in production, so it
+    -- fails with "permission denied to change default privileges". A role
+    -- altering its own defaults is always permitted. SET ROLE works because
+    -- migrator is a member of the ddl role WITH SET (default), independent
+    -- of INHERIT.
+    EXECUTE format('SET ROLE %I', v_ddl_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO eurobase_gateway', p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', p_schema, v_func_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO %I', p_schema, v_func_role);
+    RESET ROLE;
 
     -- Reassign existing APPLICATION tables (everything except platform
     -- system tables) from migrator to the ddl role. Idempotent.

--- a/scripts/verify-tenant-migration-isolation.sh
+++ b/scripts/verify-tenant-migration-isolation.sh
@@ -22,7 +22,10 @@ psql -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 -- prod-like: PUBLIC has no default CONNECT, so login roles need it granted.
 REVOKE CONNECT ON DATABASE eurobase FROM PUBLIC;
-CREATE ROLE eurobase_migrator CREATEROLE;
+-- NOINHERIT mirrors production migrator: ALTER DEFAULT PRIVILEGES FOR ROLE
+-- <ddl> would fail under it (has_privs_of_role check) — provision must use
+-- SET ROLE <ddl> + alter-own-defaults instead.
+CREATE ROLE eurobase_migrator CREATEROLE NOINHERIT;
 CREATE ROLE eurobase_gateway LOGIN PASSWORD 'pw';
 GRANT CONNECT ON DATABASE eurobase TO eurobase_gateway;
 CREATE TABLE public.projects (id uuid primary key, schema_name text, plan text default 'free');
@@ -104,7 +107,20 @@ psql -tAc "SET ROLE eurobase_migrator; GRANT CONNECT ON DATABASE eurobase TO ten
 [ "$(psql -tAc "SELECT has_database_privilege('tenant_c_ddl','eurobase','CONNECT');")" = "t" ] \
   || fail "db-owner migrator could not grant CONNECT"
 
-echo "9. promote/demote lifecycle (role NOLOGIN except during apply) ..."
+echo "9. ALTER DEFAULT PRIVILEGES via SET ROLE works under NOINHERIT migrator ..."
+# The FOR ROLE form fails under NOINHERIT; the SET ROLE form (what 000063
+# uses) succeeds. Run the failing form to document, then the fix.
+out="$(psql -tAc "SET ROLE eurobase_migrator; ALTER DEFAULT PRIVILEGES FOR ROLE tenant_a_ddl IN SCHEMA tenant_a GRANT SELECT ON TABLES TO eurobase_gateway;" 2>&1 || true)"
+echo "$out" | grep -qi "permission denied to change default privileges" \
+  || fail "expected FOR ROLE form to be denied under NOINHERIT migrator (got: $out)"
+psql -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL' || fail "SET ROLE alter-own-defaults failed under NOINHERIT migrator"
+SET ROLE eurobase_migrator;
+SET ROLE tenant_a_ddl;
+ALTER DEFAULT PRIVILEGES IN SCHEMA tenant_a GRANT SELECT ON TABLES TO eurobase_gateway;
+RESET ROLE;
+SQL
+
+echo "10. promote/demote lifecycle (role NOLOGIN except during apply) ..."
 psql -tAc "SET ROLE eurobase_migrator; ALTER ROLE tenant_a_ddl WITH NOLOGIN;" >/dev/null
 out="$(as_role tenant_a_ddl pw_a -tAc 'SELECT 1;' 2>&1 || true)"
 echo "$out" | grep -qi "not permitted to log in\|role .* is not permitted" || fail "demoted role still able to log in: $out"


### PR DESCRIPTION
## Production deploy is currently broken — this fixes it

The #209 deploy's migrate job failed:

```
provision_tenant_ddl_role … permission denied to change default privileges
```

The migrate job **gates the rollout**, so it failed before any Deployment rolled — **production is safely on the previous version**. `000062` (the bookkeeping table) committed; `000063` ran in one transaction and rolled back fully (no partial state), leaving `schema_migrations` **dirty at version 63**.

## Root cause (reproduced + fixed on Postgres 16)

Production's `eurobase_migrator` is **`NOINHERIT`**. `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl_role>` requires `has_privs_of_role` — **INHERIT-based** membership of the target role — which a NOINHERIT member never gets, so the grant is denied. My local migrator inherits by default, which masked it locally and let the isolation script pass (it hand-built roles without exercising this path).

## Fix

Provision the per-tenant default privileges by `SET ROLE`-ing into the ddl role and altering its **own** defaults (always permitted for a role on itself), instead of `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>` as migrator. `SET ROLE` works because migrator's membership in the ddl role is `WITH SET` (the PG16 default), independent of `INHERIT`. The reassign / `ALTER ROLE` / `GRANT CONNECT` paths are unaffected (they need membership or creator rights, not INHERIT).

`scripts/verify-tenant-migration-isolation.sh` now creates a **NOINHERIT** migrator and asserts the `FOR ROLE` form is denied while the `SET ROLE` form succeeds — guarding this regression. **All 10 checks pass.**

## Recovery (operator step, needs `DATABASE_URL_MIGRATOR`)

The dirty flag must be cleared once before the next deploy can apply migrations:

```
migrate -path migrations -database "$DATABASE_URL_MIGRATOR" force 62
```

This marks 62 (the last good migration) clean — it does **not** re-run anything. The next deploy's `up` then applies the fixed 063. (Force **62**, not 63 — 063 rolled back and must actually re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)