### PR TITLE
Fix 000063 (take 2): GRANT WITH INHERIT TRUE — works inside SECURITY DEFINER

### DIFF
--- a/migrations/000063_tenant_ddl_role.up.sql
+++ b/migrations/000063_tenant_ddl_role.up.sql
@@ -106,25 +106,21 @@ BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION public.tenant_migration_checksum(bigint) TO %I', v_ddl_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION public.record_tenant_migration(bigint, text, text, text) TO %I', v_ddl_role);
 
-    -- Migrator manages ddl-owned objects (console DDL) AND sets the role's
-    -- login password per apply (creator + CREATEROLE; no ADMIN OPTION needed).
-    EXECUTE format('GRANT %I TO eurobase_migrator', v_ddl_role);
+    -- Migrator manages ddl-owned objects (console DDL) and sets the role's
+    -- login password per apply. The membership is granted WITH INHERIT TRUE
+    -- so the next statement works even though eurobase_migrator is NOINHERIT
+    -- in production: ALTER DEFAULT PRIVILEGES FOR ROLE <ddl> needs
+    -- has_privs_of_role (INHERIT-based) membership of <ddl>. Per-membership
+    -- INHERIT TRUE (PG16) overrides migrator's role-level NOINHERIT for just
+    -- this grant. (SET ROLE is not an option — it's forbidden inside a
+    -- SECURITY DEFINER function; plain membership fails the FOR ROLE check.)
+    EXECUTE format('GRANT %I TO eurobase_migrator WITH INHERIT TRUE', v_ddl_role);
 
-    -- Tables the ddl role creates become usable at runtime. Done while
-    -- SET ROLE'd to the ddl role (altering its OWN default privileges)
-    -- rather than `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>` as migrator:
-    -- the FOR ROLE form requires has_privs_of_role (INHERIT-based)
-    -- membership, and eurobase_migrator is NOINHERIT in production, so it
-    -- fails with "permission denied to change default privileges". A role
-    -- altering its own defaults is always permitted. SET ROLE works because
-    -- migrator is a member of the ddl role WITH SET (default), independent
-    -- of INHERIT.
-    EXECUTE format('SET ROLE %I', v_ddl_role);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO eurobase_gateway', p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', p_schema, v_func_role);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO %I', p_schema, v_func_role);
-    RESET ROLE;
+    -- Tables the ddl role creates become usable at runtime.
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_ddl_role, p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO eurobase_gateway', v_ddl_role, p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', v_ddl_role, p_schema, v_func_role);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO %I', v_ddl_role, p_schema, v_func_role);
 
     -- Reassign existing APPLICATION tables (everything except platform
     -- system tables) from migrator to the ddl role. Idempotent.

--- a/scripts/ops/migrate-force.sh
+++ b/scripts/ops/migrate-force.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Clear the dirty migration flag in production by forcing the schema version,
+# via a one-off Job inside the cluster. `migrate force <V>` only rewrites the
+# schema_migrations bookkeeping (version=V, dirty=false) — it runs NO SQL and
+# changes NO schema.
+#
+# Default forces version 62 (the last good migration before 000063 failed and
+# rolled back). After this, the next deploy's `migrate up` re-applies the
+# fixed 000063. Pass a different version as $1 if migrate-status showed
+# something other than 63-dirty.
+#
+# Usage: ./scripts/ops/migrate-force.sh [version]   (default 62)
+set -euo pipefail
+
+VERSION="${1:-62}"
+NS=eurobase
+JOB=migrate-force
+IMG=rg.fr-par.scw.cloud/eurobase-app/migrations:latest
+
+echo "==> forcing migration version to ${VERSION} (no schema change)"
+read -r -p "    proceed? [y/N] " ans
+[ "$ans" = "y" ] || [ "$ans" = "Y" ] || { echo "aborted"; exit 1; }
+
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+
+kubectl -n "$NS" apply -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ${IMG}
+          imagePullPolicy: Always
+          args: ["-database", "\$(DATABASE_URL_MIGRATOR)", "force", "${VERSION}"]
+          env:
+            - name: DATABASE_URL_MIGRATOR
+              valueFrom:
+                secretKeyRef:
+                  name: eurobase-secrets
+                  key: DATABASE_URL_MIGRATOR
+YAML
+
+echo "==> waiting for the force to run..."
+for _ in $(seq 1 30); do
+  phase=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+  [ "$phase" = "Succeeded" ] || [ "$phase" = "Failed" ] && break
+  sleep 2
+done
+
+echo "==> force output:"
+kubectl -n "$NS" logs job/${JOB} || true
+phase=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found >/dev/null 2>&1 || true
+echo
+if [ "$phase" = "Succeeded" ]; then
+  echo "✅ Dirty flag cleared at version ${VERSION}. The fixed 000063 will apply on the next deploy."
+else
+  echo "⚠️  Force job did not succeed (phase=${phase}). Check the output above before redeploying."
+  exit 1
+fi

--- a/scripts/ops/migrate-status.sh
+++ b/scripts/ops/migrate-status.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Show the current migration version + dirty flag in production, by running
+# `migrate version` as a one-off Job inside the cluster (DATABASE_URL_MIGRATOR
+# from the eurobase-secrets Secret; the prod DB is reachable only there).
+#
+# Usage: ./scripts/ops/migrate-status.sh
+set -euo pipefail
+
+NS=eurobase
+JOB=migrate-version
+IMG=rg.fr-par.scw.cloud/eurobase-app/migrations:latest
+
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+
+kubectl -n "$NS" apply -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB}
+  namespace: ${NS}
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ${IMG}
+          imagePullPolicy: Always
+          args: ["-database", "\$(DATABASE_URL_MIGRATOR)", "version"]
+          env:
+            - name: DATABASE_URL_MIGRATOR
+              valueFrom:
+                secretKeyRef:
+                  name: eurobase-secrets
+                  key: DATABASE_URL_MIGRATOR
+YAML
+
+echo "==> waiting for the version check to run..."
+# Wait for the pod to finish (complete or fail), then print its logs.
+for _ in $(seq 1 30); do
+  phase=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+  [ "$phase" = "Succeeded" ] || [ "$phase" = "Failed" ] && break
+  sleep 2
+done
+
+echo "==> migrate version output:"
+kubectl -n "$NS" logs job/${JOB}
+echo
+echo "(If it shows '63' with a dirty/error line, run ./scripts/ops/migrate-force.sh next.)"
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found >/dev/null 2>&1 || true

--- a/scripts/verify-tenant-migration-isolation.sh
+++ b/scripts/verify-tenant-migration-isolation.sh
@@ -107,18 +107,43 @@ psql -tAc "SET ROLE eurobase_migrator; GRANT CONNECT ON DATABASE eurobase TO ten
 [ "$(psql -tAc "SELECT has_database_privilege('tenant_c_ddl','eurobase','CONNECT');")" = "t" ] \
   || fail "db-owner migrator could not grant CONNECT"
 
-echo "9. ALTER DEFAULT PRIVILEGES via SET ROLE works under NOINHERIT migrator ..."
-# The FOR ROLE form fails under NOINHERIT; the SET ROLE form (what 000063
-# uses) succeeds. Run the failing form to document, then the fix.
-out="$(psql -tAc "SET ROLE eurobase_migrator; ALTER DEFAULT PRIVILEGES FOR ROLE tenant_a_ddl IN SCHEMA tenant_a GRANT SELECT ON TABLES TO eurobase_gateway;" 2>&1 || true)"
-echo "$out" | grep -qi "permission denied to change default privileges" \
-  || fail "expected FOR ROLE form to be denied under NOINHERIT migrator (got: $out)"
-psql -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL' || fail "SET ROLE alter-own-defaults failed under NOINHERIT migrator"
-SET ROLE eurobase_migrator;
-SET ROLE tenant_a_ddl;
-ALTER DEFAULT PRIVILEGES IN SCHEMA tenant_a GRANT SELECT ON TABLES TO eurobase_gateway;
-RESET ROLE;
+echo "9. ALTER DEFAULT PRIVILEGES inside a SECURITY DEFINER, NOINHERIT migrator (the prod path) ..."
+# Faithful to provision_tenant_ddl_role: a SECURITY DEFINER func owned by the
+# NOINHERIT migrator that grants the ddl role to migrator and runs
+# ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>. Two pitfalls this guards:
+#   - SET ROLE is forbidden inside SECURITY DEFINER (so the "SET ROLE then
+#     alter own defaults" approach fails here);
+#   - plain GRANT (no INHERIT) fails the FOR ROLE has_privs check under a
+#     NOINHERIT migrator.
+# Only GRANT ... WITH INHERIT TRUE + FOR ROLE works — assert exactly that.
+psql -v ON_ERROR_STOP=1 >/dev/null 2>&1 <<'SQL'
+CREATE SCHEMA tenant_d AUTHORIZATION eurobase_migrator;
+CREATE ROLE tenant_d_func NOLOGIN;
+-- negative control: plain GRANT (no INHERIT) must fail the FOR ROLE check
+CREATE FUNCTION prov_plain() RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  CREATE ROLE tenant_d_ddl NOLOGIN;
+  GRANT USAGE,CREATE ON SCHEMA tenant_d TO tenant_d_ddl;
+  GRANT tenant_d_ddl TO eurobase_migrator;          -- plain, no INHERIT
+  ALTER DEFAULT PRIVILEGES FOR ROLE tenant_d_ddl IN SCHEMA tenant_d GRANT SELECT ON TABLES TO eurobase_gateway;
+END$$;
+ALTER FUNCTION prov_plain() OWNER TO eurobase_migrator;
+-- the fix: WITH INHERIT TRUE
+CREATE FUNCTION prov_inherit() RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  CREATE ROLE tenant_e_ddl NOLOGIN;
+  EXECUTE 'CREATE SCHEMA tenant_e AUTHORIZATION eurobase_migrator';
+  GRANT USAGE,CREATE ON SCHEMA tenant_e TO tenant_e_ddl;
+  GRANT tenant_e_ddl TO eurobase_migrator WITH INHERIT TRUE;
+  ALTER DEFAULT PRIVILEGES FOR ROLE tenant_e_ddl IN SCHEMA tenant_e GRANT SELECT ON TABLES TO eurobase_gateway;
+END$$;
+ALTER FUNCTION prov_inherit() OWNER TO eurobase_migrator;
 SQL
+out="$(psql -tAc "SET ROLE eurobase_migrator; SELECT prov_plain();" 2>&1 || true)"
+echo "$out" | grep -qi "permission denied to change default privileges" \
+  || fail "expected plain GRANT (no INHERIT) to be denied in SECURITY DEFINER under NOINHERIT migrator (got: $out)"
+psql -tAc "SET ROLE eurobase_migrator; SELECT prov_inherit();" >/dev/null 2>&1 \
+  || fail "WITH INHERIT TRUE + FOR ROLE failed inside SECURITY DEFINER under NOINHERIT migrator"
 
 echo "10. promote/demote lifecycle (role NOLOGIN except during apply) ..."
 psql -tAc "SET ROLE eurobase_migrator; ALTER ROLE tenant_a_ddl WITH NOLOGIN;" >/dev/null


### PR DESCRIPTION
## Supersedes the broken first fix (#211)

The #211 fix (`SET ROLE` the ddl role, alter its own defaults) **failed the redeploy**: `cannot set parameter "role" within security-definer function`. `SET ROLE` is prohibited inside a `SECURITY DEFINER` function, which `provision_tenant_ddl_role` is. My verify script tested `SET ROLE` at session level (where it's allowed), so it didn't catch it — the same mock-vs-real testing gap that caused the first miss.

## Correct fix

Keep `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>` and grant the ddl role to migrator **`WITH INHERIT TRUE`**. The `FOR ROLE` form needs `has_privs_of_role` (INHERIT-based) membership of `<ddl>`; production's `eurobase_migrator` is `NOINHERIT`, but PG16 **per-membership `WITH INHERIT TRUE`** overrides the role-level NOINHERIT for just this grant. No `SET ROLE` needed.

## Verified two ways on Postgres 16 (NOINHERIT migrator)

1. **The actual `provision_tenant_ddl_role` from this migration file**, loaded and called exactly as the migrate job does (SECURITY DEFINER, as migrator) — runs clean, ownership converges to the ddl role, CONNECT granted. No more mocks.
2. `verify-tenant-migration-isolation.sh` step 9 rewritten to exercise the real prod path — a SECURITY DEFINER func owned by a NOINHERIT migrator — asserting plain `GRANT` fails the `FOR ROLE` check and `WITH INHERIT TRUE` succeeds. **All 10 checks pass.**

## Ops scripts included

`scripts/ops/migrate-status.sh` / `migrate-force.sh` — one-off Job runners to read the prod migration version and clear a dirty flag from inside the cluster (used to recover from the failed 000063 deploys).

## Recovery (the 2nd failed deploy re-dirtied at 63)

`./scripts/ops/migrate-force.sh` (forces 62), then this merge's deploy applies the fixed 063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)