### PR TITLE
Fix 000063 (take 3): GRANT WITH INHERIT TRUE, SET TRUE for owner-reassign

### DIFF
--- a/migrations/000063_tenant_ddl_role.up.sql
+++ b/migrations/000063_tenant_ddl_role.up.sql
@@ -107,14 +107,16 @@ BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION public.record_tenant_migration(bigint, text, text, text) TO %I', v_ddl_role);
 
     -- Migrator manages ddl-owned objects (console DDL) and sets the role's
-    -- login password per apply. The membership is granted WITH INHERIT TRUE
-    -- so the next statement works even though eurobase_migrator is NOINHERIT
-    -- in production: ALTER DEFAULT PRIVILEGES FOR ROLE <ddl> needs
-    -- has_privs_of_role (INHERIT-based) membership of <ddl>. Per-membership
-    -- INHERIT TRUE (PG16) overrides migrator's role-level NOINHERIT for just
-    -- this grant. (SET ROLE is not an option — it's forbidden inside a
-    -- SECURITY DEFINER function; plain membership fails the FOR ROLE check.)
-    EXECUTE format('GRANT %I TO eurobase_migrator WITH INHERIT TRUE', v_ddl_role);
+    -- login password per apply. Both membership options are granted
+    -- explicitly (PG16), because production's eurobase_migrator is NOINHERIT
+    -- and managed-PG defaults the unspecified option to FALSE:
+    --   INHERIT TRUE → ALTER DEFAULT PRIVILEGES FOR ROLE <ddl> below needs
+    --     has_privs_of_role (INHERIT-based) membership of <ddl>;
+    --   SET TRUE     → the ALTER TABLE … OWNER TO <ddl> reassign below needs
+    --     SET-ROLE-able membership of <ddl> (PG16 owner-reassign rule).
+    -- (SET ROLE itself is not an option — forbidden inside a SECURITY
+    -- DEFINER function. Plain membership without these fails both checks.)
+    EXECUTE format('GRANT %I TO eurobase_migrator WITH INHERIT TRUE, SET TRUE', v_ddl_role);
 
     -- Tables the ddl role creates become usable at runtime.
     EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO eurobase_gateway', v_ddl_role, p_schema);

--- a/scripts/verify-tenant-migration-isolation.sh
+++ b/scripts/verify-tenant-migration-isolation.sh
@@ -134,7 +134,7 @@ BEGIN
   CREATE ROLE tenant_e_ddl NOLOGIN;
   EXECUTE 'CREATE SCHEMA tenant_e AUTHORIZATION eurobase_migrator';
   GRANT USAGE,CREATE ON SCHEMA tenant_e TO tenant_e_ddl;
-  GRANT tenant_e_ddl TO eurobase_migrator WITH INHERIT TRUE;
+  GRANT tenant_e_ddl TO eurobase_migrator WITH INHERIT TRUE, SET TRUE;
   ALTER DEFAULT PRIVILEGES FOR ROLE tenant_e_ddl IN SCHEMA tenant_e GRANT SELECT ON TABLES TO eurobase_gateway;
 END$$;
 ALTER FUNCTION prov_inherit() OWNER TO eurobase_migrator;
@@ -143,7 +143,14 @@ out="$(psql -tAc "SET ROLE eurobase_migrator; SELECT prov_plain();" 2>&1 || true
 echo "$out" | grep -qi "permission denied to change default privileges" \
   || fail "expected plain GRANT (no INHERIT) to be denied in SECURITY DEFINER under NOINHERIT migrator (got: $out)"
 psql -tAc "SET ROLE eurobase_migrator; SELECT prov_inherit();" >/dev/null 2>&1 \
-  || fail "WITH INHERIT TRUE + FOR ROLE failed inside SECURITY DEFINER under NOINHERIT migrator"
+  || fail "WITH INHERIT TRUE/SET TRUE + FOR ROLE failed inside SECURITY DEFINER under NOINHERIT migrator"
+# Assert migrator effectively has BOTH INHERIT and SET on the ddl role.
+# Managed Postgres defaults the unspecified GRANT option to FALSE (alpine
+# defaults it TRUE, which would hide a missing SET/INHERIT and let the
+# reassign pass locally while failing prod). Aggregate across membership
+# rows (CREATE ROLE by a CREATEROLE migrator auto-adds a second row).
+opts="$(psql -tAc "SELECT bool_or(inherit_option)||','||bool_or(set_option) FROM pg_auth_members m JOIN pg_roles r ON r.oid=m.roleid JOIN pg_roles g ON g.oid=m.member WHERE r.rolname='tenant_e_ddl' AND g.rolname='eurobase_migrator';")"
+[ "$opts" = "true,true" ] || fail "migrator's membership in the ddl role must give INHERIT TRUE + SET TRUE (got: $opts) — ALTER DEFAULT PRIVILEGES needs INHERIT, owner-reassign needs SET"
 
 echo "10. promote/demote lifecycle (role NOLOGIN except during apply) ..."
 psql -tAc "SET ROLE eurobase_migrator; ALTER ROLE tenant_a_ddl WITH NOLOGIN;" >/dev/null


### PR DESCRIPTION
## Third fix for the 000063 deploy failure — explicit grant options

All three failures share one root cause: Scaleway's managed Postgres defaults the unspecified role-grant option to **FALSE** (and `eurobase_migrator` is `NOINHERIT`), while local Alpine Postgres defaults them **TRUE** — so each fix passed locally and failed in prod on the next statement that needed the option Alpine silently provided:

1. `ALTER DEFAULT PRIVILEGES FOR ROLE <ddl>` → needs **INHERIT** membership
2. (take-1 `SET ROLE`) → forbidden inside a SECURITY DEFINER function
3. `ALTER TABLE … OWNER TO <ddl>` (ownership reassign) → needs **SET** membership

## Fix

Grant both options explicitly so nothing relies on a default that differs across PG builds:

```sql
GRANT <ddl> TO eurobase_migrator WITH INHERIT TRUE, SET TRUE
```

INHERIT for `ALTER DEFAULT PRIVILEGES FOR ROLE`, SET for the owner reassign.

## Verified (Postgres 16, NOINHERIT migrator)

The combined option syntax parses, the membership ends up with both options, and the full SECURITY DEFINER path (`ALTER DEFAULT PRIVILEGES` + `ALTER TABLE OWNER`) succeeds. `verify-tenant-migration-isolation.sh` now asserts migrator's membership in the ddl role carries both INHERIT and SET (aggregated across the auto-creator + explicit grant rows). All 10 checks pass.

**Caveat (honest):** Alpine PG defaults these options TRUE, so I can't fully reproduce prod's FALSE-default locally. The protection is that both options are now **explicit** — the migration never relies on the default. I've audited the rest of `000063` and don't see another statement depending on a grant-option default.

## Recovery (the 3rd failed deploy re-dirtied at 63)

`./scripts/ops/migrate-force.sh` (forces 62), then this merge's deploy applies the fixed 063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)