### PR TITLE
ops: tenant-migration enablement + recovery tooling and runbook

### DIFF
--- a/docs/runbooks/enable-tenant-migrations.md
+++ b/docs/runbooks/enable-tenant-migrations.md
@@ -1,0 +1,85 @@
+# Enabling tenant migrations (#190) in production
+
+Tenant migrations (`POST /platform/projects/{id}/migrations`, `eurobase migrations up`)
+ship dormant and **fail closed (503)** until two one-time ops steps are done.
+Both are safe to do independently; the feature only works once both are complete.
+
+## Step 1 — `DDL_PASSWORD_SECRET` (done via script)
+
+The gateway derives each per-tenant ddl role's login password from this secret.
+
+```
+./scripts/ops/set-ddl-password-secret.sh
+```
+
+Generates a 32-byte secret, patches `eurobase-secrets`, and restarts the gateway.
+Confirm with the gateway log line `"tenant migrations enabled"`.
+
+## Step 2 — let `eurobase_migrator` grant CONNECT (needs `_rdb_superadmin`)
+
+The per-tenant `tenant_<id>_ddl` roles are LOGIN roles the gateway connects as.
+They are created by the SQL migration `provision_tenant_ddl_role`, so — unlike the
+runtime roles created through the Scaleway console — they do **not** get Scaleway's
+automatic CONNECT grant. `eurobase_migrator` cannot grant it onward (it has CONNECT
+but no grant option), and the `eurobase` database is owned by `_rdb_superadmin`,
+which customers cannot log in as or `SET ROLE` to.
+
+So one statement must be run **as `_rdb_superadmin`** — which on Scaleway managed
+Postgres means a support request.
+
+### Scaleway support ticket (copy-paste)
+
+> Subject: Run a one-time GRANT as the database superadmin on our PostgreSQL instance
+>
+> Instance: **eurobase-db** (`62deb4e1-4dba-44ea-8fbc-2d519637425a`), region **fr-par**, PostgreSQL 16.
+> Database: **eurobase**.
+>
+> Please run the following as the database owner / `_rdb_superadmin`:
+>
+> ```sql
+> GRANT CONNECT ON DATABASE eurobase TO eurobase_migrator WITH GRANT OPTION;
+> ```
+>
+> (Equivalent alternative if you prefer transferring ownership:
+> `ALTER DATABASE eurobase OWNER TO eurobase_migrator;`)
+>
+> Context: `eurobase_migrator` is our deploy/migration role (already a Scaleway
+> "admin" user). It needs to forward CONNECT to per-tenant roles our migrations
+> create dynamically. It currently has CONNECT but no grant option, and the
+> database is owned by `_rdb_superadmin`, so we can't run this ourselves.
+
+### After Scaleway completes it
+
+Verify the grant took (read-only, from inside the cluster):
+
+```
+./scripts/ops/db-checks.sh   # prints migrator_canconnectgrant=true when done
+```
+
+No redeploy needed — the gateway re-grants and verifies each tenant's CONNECT on
+its first `eurobase migrations up`.
+
+## Verify the feature end to end
+
+From a project with a PAT:
+
+```
+eurobase login --token "$EUROBASE_PAT"
+eurobase switch <project>
+eurobase migrations new create_example
+$EDITOR migrations/0001_create_example.sql
+eurobase migrations up
+```
+
+## Recovery: a failed/dirty migrate deploy
+
+The migrate Job gates the rollout, so a failed migration leaves production on the
+previous version and `schema_migrations` dirty. Clear it before redeploying:
+
+```
+./scripts/ops/migrate-status.sh   # shows the version + dirty flag
+./scripts/ops/migrate-force.sh    # forces the last-good version (default 62)
+```
+
+See also: the isolation proof `scripts/verify-tenant-migration-isolation.sh`, and
+the prod-vs-local Postgres role-default notes in the team memory.

--- a/scripts/ops/db-checks.sh
+++ b/scripts/ops/db-checks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Read-only production DB checks for tenant migrations (#190). Runs a one-off
+# Job in-cluster (the prod DB is only reachable there) as eurobase_migrator.
+# Use to confirm step 2 is done (migrator_canconnectgrant=true) after Scaleway
+# runs the CONNECT grant, and to sanity-check the role/db state.
+#
+# Usage: ./scripts/ops/db-checks.sh
+set -euo pipefail
+
+NS=eurobase
+JOB=db-checks
+IMG=rg.fr-par.scw.cloud/eurobase-app/migrations:latest
+
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata: { name: ${JOB}, namespace: ${NS} }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 200
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: c
+          image: ${IMG}
+          imagePullPolicy: Always
+          command: ["sh","-c","psql \"\$DATABASE_URL_MIGRATOR\" -tAc \"SELECT 'db_owner=' || pg_get_userbyid(datdba) FROM pg_database WHERE datname=current_database(); SELECT 'migrator_canconnectgrant=' || has_database_privilege('eurobase_migrator','eurobase','CONNECT WITH GRANT OPTION'); SELECT 'ddl_roles=' || count(*) FROM pg_roles WHERE rolname LIKE 'tenant_%\\_ddl';\""]
+          env:
+            - name: DATABASE_URL_MIGRATOR
+              valueFrom: { secretKeyRef: { name: eurobase-secrets, key: DATABASE_URL_MIGRATOR } }
+YAML
+
+for _ in $(seq 1 30); do
+  p=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+  [ "$p" = "Succeeded" ] || [ "$p" = "Failed" ] && break; sleep 2
+done
+kubectl -n "$NS" logs job/${JOB} 2>&1 | grep -E "db_owner|canconnectgrant|ddl_roles" || kubectl -n "$NS" logs job/${JOB} 2>&1
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found >/dev/null 2>&1 || true
+echo
+echo "migrator_canconnectgrant=true  → step 2 done, tenant migrations can grant per-tenant CONNECT."

--- a/scripts/ops/grant-migrator-connect.sh
+++ b/scripts/ops/grant-migrator-connect.sh
@@ -11,6 +11,17 @@
 # read hidden and passed via a short-lived Secret, never put on the command
 # line or into shell history.
 #
+# Assumes the operator has Secret-create/delete rights in the `eurobase`
+# namespace (used for the short-lived PG* envFrom Secret and for the Job
+# itself). Both are deleted by the EXIT trap below.
+#
+# The verification at the end is **gating**: a non-owner running `GRANT … WITH
+# GRANT OPTION` against a Scaleway-owned DB returns a Postgres WARNING (not an
+# error), so `ON_ERROR_STOP=1` would still exit 0 and a phase-only success
+# check would print ✅ on a silent no-op (the same pattern that bit #217). The
+# Job's second `-c` is a `DO $$ … RAISE EXCEPTION $$;` block that flips the
+# Job to phase=Failed if the privilege didn't actually take.
+#
 # Usage: ./scripts/ops/grant-migrator-connect.sh [admin-user]   (default: eurobase)
 set -euo pipefail
 
@@ -68,7 +79,14 @@ spec:
         - name: grant
           image: ${IMG}
           imagePullPolicy: Always
-          command: ["sh","-c","psql -v ON_ERROR_STOP=1 -c 'GRANT CONNECT ON DATABASE eurobase TO eurobase_migrator WITH GRANT OPTION;' && psql -tAc \"SELECT 'migrator_canconnectgrant=' || has_database_privilege('eurobase_migrator','eurobase','CONNECT WITH GRANT OPTION');\""]
+          command:
+            - sh
+            - -c
+            - |
+              psql -v ON_ERROR_STOP=1 \
+                -c "GRANT CONNECT ON DATABASE eurobase TO eurobase_migrator WITH GRANT OPTION;" \
+                -c "SELECT 'migrator_canconnectgrant=' || has_database_privilege('eurobase_migrator','eurobase','CONNECT WITH GRANT OPTION');" \
+                -c "DO \$\$ BEGIN IF NOT has_database_privilege('eurobase_migrator','eurobase','CONNECT WITH GRANT OPTION') THEN RAISE EXCEPTION 'grant did not take — the DB is owned by _rdb_superadmin, ask Scaleway support or run as _rdb_superadmin'; END IF; END \$\$;"
           envFrom:
             - secretRef: { name: ${TMP_SECRET} }
 YAML
@@ -83,12 +101,18 @@ kubectl -n "$NS" logs job/${JOB} 2>&1 || true
 phase=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
 echo
 if [ "$phase" = "Succeeded" ]; then
+  # Job phase=Succeeded is meaningful: the DO-block assertion above makes the
+  # Job fail if the privilege didn't actually take, even though Postgres would
+  # only WARN on a silent-no-op grant by a non-owner.
   echo "✅ Granted. eurobase_migrator can now forward CONNECT to per-tenant ddl roles."
   echo "   Tenant migrations are fully enabled — the gateway grants each tenant's"
   echo "   CONNECT on first 'eurobase migrations up'. No redeploy needed."
 else
-  echo "⚠️  The grant did not succeed (phase=${phase}). If it says 'permission denied',"
-  echo "   the '${ADMIN_USER}' user isn't the DB owner / lacks rights — you may need to"
-  echo "   run it as _rdb_superadmin via the Scaleway console, or transfer DB ownership."
+  echo "⚠️  The grant did not succeed (phase=${phase}). See the Job output above."
+  echo "   - 'permission denied' → the '${ADMIN_USER}' user isn't the DB owner."
+  echo "   - 'grant did not take' → the GRANT ran without error but the privilege"
+  echo "     didn't land (the DB is owned by _rdb_superadmin and silently ignores"
+  echo "     non-owner grants). Open a Scaleway support ticket asking them to run"
+  echo "     the GRANT as _rdb_superadmin (see docs/runbooks/tenant-migrations.md)."
   exit 1
 fi

--- a/scripts/ops/grant-migrator-connect.sh
+++ b/scripts/ops/grant-migrator-connect.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Step 2 of enabling tenant migrations (#190): let eurobase_migrator forward
+# CONNECT to the per-tenant ddl roles. The migrate job's role can't grant
+# this to itself (it has CONNECT but no grant option), and the database is
+# owned by _rdb_superadmin — so this must run as your Scaleway DB admin user.
+#
+# Runs:  GRANT CONNECT ON DATABASE eurobase TO eurobase_migrator WITH GRANT OPTION;
+#
+# It connects as the admin user over a one-off in-cluster Job (the DB is
+# reachable there; your laptop may be firewalled off). The admin password is
+# read hidden and passed via a short-lived Secret, never put on the command
+# line or into shell history.
+#
+# Usage: ./scripts/ops/grant-migrator-connect.sh [admin-user]   (default: eurobase)
+set -euo pipefail
+
+NS=eurobase
+IMG=rg.fr-par.scw.cloud/eurobase-app/migrations:latest
+ADMIN_USER="${1:-eurobase}"
+TMP_SECRET=eb-admin-grant
+JOB=eb-admin-grant
+
+# Host/port/dbname from the existing migrator URL (no creds reused). Parse
+# into separate fields so we can use PG* env vars instead of a URL — avoids
+# URL-encoding pitfalls when the username is an email (@) or the password
+# has special characters.
+MIG_URL="$(kubectl -n "$NS" get secret eurobase-secrets -o jsonpath='{.data.DATABASE_URL_MIGRATOR}' | base64 -d)"
+HOSTPART="$(printf '%s' "$MIG_URL" | sed -E 's#^[a-z]+://[^@]*@##')"   # host:port/db?params
+HOSTPORT="${HOSTPART%%/*}"                                            # host:port
+PGHOST="${HOSTPORT%%:*}"
+PGPORT="${HOSTPORT##*:}"
+DBQ="${HOSTPART#*/}"                                                  # db?params
+PGDATABASE="${DBQ%%\?*}"
+case "$MIG_URL" in *sslmode=*) PGSSLMODE="${MIG_URL##*sslmode=}"; PGSSLMODE="${PGSSLMODE%%&*}";; *) PGSSLMODE=require;; esac
+echo "Target: host=${PGHOST} port=${PGPORT} db=${PGDATABASE} sslmode=${PGSSLMODE} user=${ADMIN_USER}"
+
+read -r -s -p "Password for DB admin user '${ADMIN_USER}': " ADMIN_PW; echo
+[ -n "$ADMIN_PW" ] || { echo "no password entered, aborting"; exit 1; }
+
+cleanup() {
+  kubectl -n "$NS" delete secret "$TMP_SECRET" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete job "$JOB" --ignore-not-found >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+kubectl -n "$NS" delete secret "$TMP_SECRET" --ignore-not-found >/dev/null 2>&1 || true
+kubectl -n "$NS" create secret generic "$TMP_SECRET" \
+  --from-literal=PGHOST="$PGHOST" \
+  --from-literal=PGPORT="$PGPORT" \
+  --from-literal=PGDATABASE="$PGDATABASE" \
+  --from-literal=PGSSLMODE="$PGSSLMODE" \
+  --from-literal=PGUSER="$ADMIN_USER" \
+  --from-literal=PGPASSWORD="$ADMIN_PW" >/dev/null
+unset ADMIN_PW
+
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+kubectl -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata: { name: ${JOB}, namespace: ${NS} }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: grant
+          image: ${IMG}
+          imagePullPolicy: Always
+          command: ["sh","-c","psql -v ON_ERROR_STOP=1 -c 'GRANT CONNECT ON DATABASE eurobase TO eurobase_migrator WITH GRANT OPTION;' && psql -tAc \"SELECT 'migrator_canconnectgrant=' || has_database_privilege('eurobase_migrator','eurobase','CONNECT WITH GRANT OPTION');\""]
+          envFrom:
+            - secretRef: { name: ${TMP_SECRET} }
+YAML
+
+echo "==> running the grant as ${ADMIN_USER}..."
+for _ in $(seq 1 30); do
+  p=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+  [ "$p" = "Succeeded" ] || [ "$p" = "Failed" ] && break; sleep 2
+done
+echo "==> output:"
+kubectl -n "$NS" logs job/${JOB} 2>&1 || true
+phase=$(kubectl -n "$NS" get pods -l job-name=${JOB} -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+echo
+if [ "$phase" = "Succeeded" ]; then
+  echo "✅ Granted. eurobase_migrator can now forward CONNECT to per-tenant ddl roles."
+  echo "   Tenant migrations are fully enabled — the gateway grants each tenant's"
+  echo "   CONNECT on first 'eurobase migrations up'. No redeploy needed."
+else
+  echo "⚠️  The grant did not succeed (phase=${phase}). If it says 'permission denied',"
+  echo "   the '${ADMIN_USER}' user isn't the DB owner / lacks rights — you may need to"
+  echo "   run it as _rdb_superadmin via the Scaleway console, or transfer DB ownership."
+  exit 1
+fi

--- a/scripts/ops/set-ddl-password-secret.sh
+++ b/scripts/ops/set-ddl-password-secret.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Enable tenant migrations (#190) by adding DDL_PASSWORD_SECRET to the
+# eurobase-secrets Secret and restarting the gateway to pick it up.
+#
+# DDL_PASSWORD_SECRET is the master secret the gateway uses to derive each
+# per-tenant ddl role's login password (HMAC-SHA256). It only needs to be
+# set once and kept stable — rotating it changes every derived password
+# (the gateway re-sets them on the next apply, so rotation is safe, just
+# means a brief re-derive).
+#
+# NOTE: tenant migrations ALSO require eurobase_migrator to own the
+# `eurobase` database (or hold CONNECT … WITH GRANT OPTION) — without it
+# the apply path fails loud at first use. That's a separate DB-owner step.
+#
+# Usage: ./scripts/ops/set-ddl-password-secret.sh
+set -euo pipefail
+
+NS=eurobase
+SECRET=eurobase-secrets
+KEY=DDL_PASSWORD_SECRET
+
+if kubectl -n "$NS" get secret "$SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null | grep -q .; then
+  echo "⚠️  $KEY already exists in $SECRET. Overwriting it would invalidate"
+  echo "    every per-tenant ddl password until the next apply re-derives them."
+  read -r -p "    overwrite? [y/N] " ans
+  [ "$ans" = "y" ] || [ "$ans" = "Y" ] || { echo "aborted (left existing value untouched)"; exit 1; }
+fi
+
+VALUE="$(openssl rand -hex 32)"   # 32 bytes, hex-encoded
+echo "==> setting $KEY (64 hex chars) in $SECRET"
+kubectl -n "$NS" patch secret "$SECRET" --type merge \
+  -p "{\"stringData\":{\"$KEY\":\"$VALUE\"}}"
+
+echo "==> restarting the gateway to load the new env (envFrom injects only at pod start)"
+kubectl -n "$NS" rollout restart deployment/gateway
+kubectl -n "$NS" rollout status deployment/gateway --timeout=120s
+
+echo
+echo "✅ $KEY set and gateway rolled."
+echo "   Tenant migrations are enabled IF eurobase_migrator also owns the"
+echo "   eurobase database. Confirm with:"
+echo "     ./scripts/ops/migrate-status.sh   # (the gateway log will say 'tenant migrations enabled')"
+echo "   and test from a project:  eurobase migrations up"


### PR DESCRIPTION
## Operational tooling for tenant migrations (#190)

In-cluster one-off Job runners (the prod DB is reachable only from the cluster) plus a runbook, built while deploying and operating the tenant-migrations feature. These were used to recover the three `000063` deploy failures and to drive enablement.

### Scripts (`scripts/ops/`)
- **`migrate-status.sh`** — print the prod migration version + dirty flag.
- **`migrate-force.sh`** — clear a dirty `schema_migrations` flag by forcing the last-good version (default 62). Runs no SQL / changes no schema; prompts to confirm.
- **`set-ddl-password-secret.sh`** — step 1 of enablement: generate `DDL_PASSWORD_SECRET`, patch `eurobase-secrets`, roll the gateway. (Already run in prod — gateway logs "tenant migrations enabled".)
- **`grant-migrator-connect.sh`** — attempt step 2 (the CONNECT grant) as a DB admin; passes `PG*` env vars so an email-style username / special-char password don't break a connection URL. (In prod this needs `_rdb_superadmin`, so it ended up being a Scaleway support request — see runbook.)
- **`db-checks.sh`** — read-only state (db owner, migrator CONNECT grant option, ddl-role count) to confirm step 2 landed.

All pass the admin password via a hidden prompt + short-lived Secret, never on the command line; Jobs and temp secrets are cleaned up.

### Runbook (`docs/runbooks/enable-tenant-migrations.md`)
The two enablement steps, the copy-paste Scaleway support ticket for the `_rdb_superadmin` CONNECT grant, end-to-end verification, and the dirty-migration recovery flow.

### Why step 2 needs Scaleway
The per-tenant `tenant_<id>_ddl` roles are SQL-created by `provision_tenant_ddl_role`, so they don't get Scaleway's automatic CONNECT grant (only console/API-created users do). `eurobase_migrator` can't forward CONNECT (has it, no grant option) and the `eurobase` DB is owned by `_rdb_superadmin`, which customers can't log in as — so one grant must be run by Scaleway. Documented in the runbook; tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)