### PR TITLE
Tier-1 #4 (closes #172): breach register + 24h/72h SLA workflow

### DIFF
--- a/docs/compliance/breach-register.md
+++ b/docs/compliance/breach-register.md
@@ -1,0 +1,124 @@
+# Breach Register — GDPR Art. 33 Workflow
+
+> GDPR Art. 33 (notification to supervisory authority), Art. 33(5) (internal
+> register), Art. 34 (notification to data subjects). Tier-1 launch blocker
+> #4 (issue #172). The operational runbook lives at
+> [`docs/runbooks/breach-notification.md`](../runbooks/breach-notification.md);
+> this file documents the data model and the HTTP surface.
+
+## What it is
+
+`public.breach_register` (migration `000065`) is the append-only ledger the
+DPO maintains under Art. 33(5) — including breaches we judged **not** to be
+notifiable. It is what we hand to the supervisory authority if they audit
+our process. It is also what the SLA dashboard reads to flag the
+24-hour (DPA §10) and 72-hour (Art. 33) commitments.
+
+## Data model
+
+Every change to an incident writes a NEW row keyed by `incident_id`. The
+most recent row by `seq` is the authoritative snapshot. UPDATE and DELETE
+are revoked from `eurobase_gateway` and `eurobase_developer` (same pattern
+as `audit_log` in 000058). A compromised gateway forging *new* appends is
+caught by cross-referencing the WORM object archive shipping in #171; the
+in-DB append-only constraint catches modification, deletion, and reordering
+of existing rows.
+
+| Column | Purpose |
+| ------ | ------- |
+| `incident_id` | Stable identifier across all rows of one incident. |
+| `seq` | Monotonic per-row sequence. Latest = authoritative. |
+| `project_id` | Tenant this incident concerns. NULL for platform-only. |
+| `affects_platform` | True if Eurobase platform data is involved. |
+| `title`, `description` | DPO summary. |
+| `likely_consequences`, `measures_taken` | Art. 33(3) bullets. |
+| `data_categories`, `subject_categories` | `TEXT[]` — DPO writes them in plain language. |
+| `records_affected`, `subjects_affected` | Approximate counts; NULL = under investigation. |
+| `occurred_at`, `occurred_until` | Best-known window of the breach itself. |
+| `awareness_at` | The moment Eurobase staff first had reasonable certainty. **All SLAs anchor here.** |
+| `contained_at`, `resolved_at` | Containment and full resolution timestamps. |
+| `notified_authority`, `notified_authority_at` | SA filing fact. |
+| `notified_customers`, `notified_customers_at` | DPA §10 customer notice fact. |
+| `notified_subjects`, `notified_subjects_at` | Art. 34 direct end-user notice (only where applicable). |
+| `lead_sa` | Supervisory-authority code (default `fr-cnil`). |
+| `mttd_seconds` | `awareness_at − occurred_at`. |
+| `mttr_seconds` | `resolved_at − awareness_at`. |
+| `status` | `open` / `contained` / `notified_customers` / `notified_authority` / `closed` / `no_action`. |
+| `actor_id`, `actor_email`, `note` | Who wrote the row and why. |
+| `metadata` | Reserved JSONB for forward-compat. |
+
+`no_action` covers the "logged but not notified" case the runbook calls out
+— Art. 33(5) requires keeping the record either way.
+
+## HTTP surface
+
+All routes are platform-authenticated and admin-gated. Mounted under
+`/platform/projects/{id}/compliance/breaches`.
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| GET | `/breaches` | List the latest snapshot per incident for the project. |
+| POST | `/breaches` | Open a new incident (writes row 1). |
+| GET | `/breaches/{incidentId}` | Latest snapshot + full append-only history. |
+| PATCH | `/breaches/{incidentId}` | Write a new snapshot with partial changes applied. |
+| POST | `/breaches/{incidentId}/close` | Terminal `closed` or `no_action`; computes MTTR. |
+| POST | `/breaches/{incidentId}/subjects` | Identify the end-users in scope (count + capped sample IDs). |
+| POST | `/breaches/{incidentId}/notify-customers` | Render + BCC the customer email; records the dispatch. |
+| POST | `/breaches/{incidentId}/authority-form` | Render the SA paste-in. `{"filed": true}` records the SA filing. |
+| GET | `/breaches/{incidentId}/sla` | Current state of the 24h / 72h clocks. |
+
+Every write also emits an `audit_log` entry (`breach.opened` /
+`breach.updated` / `breach.notified_customers` / `breach.notified_authority` /
+`breach.notified_subjects` / `breach.closed` / `breach.subjects_identified`)
+so a tampered register can be cross-checked against the chained audit log.
+
+## Subject identification
+
+`internal/breach/subjects.go` reuses the DSAR table-discovery logic from
+`internal/compliance/export.go` (`DiscoverUserTables`, `ListTenantTables`)
+so the breach-scope subject query stays in sync with what DSAR exports
+already consider "user data". The query runs under
+`edb.RunAsService` (sets `app.end_user_role='service'`) so tenant `users`
+RLS does not silently zero out the count when there is no end-user actor.
+
+Scope filters available in the request body (`SubjectQuery`):
+
+- `created_from` / `created_until` — bounds the `users.created_at` window;
+  use when the breach exposed a sign-up form or a batch import.
+- `updated_from` / `updated_until` — bounds the `users.updated_at` window;
+  use when the breach was a leak of "active sessions" or recently edited
+  profiles.
+- `user_ids` — restricts to a known list (intersected with the tenant).
+- `limit` — caps the size of the `affected_ids` sample (default 100;
+  `0` = no IDs returned, count only; `-1` = unbounded).
+
+The count is always exact; `affected_ids` is for spot-checking.
+
+## MTTD / MTTR metrics
+
+Exposed on the private metrics endpoint:
+
+| Metric | Help |
+| ------ | ---- |
+| `eurobase_breach_opened_total` | Counter — incidents opened. |
+| `eurobase_breach_closed_total{status}` | Counter — labelled by terminal status. |
+| `eurobase_breach_mttd_seconds` | Histogram — `awareness_at − occurred_at`. |
+| `eurobase_breach_mttr_seconds` | Histogram — `resolved_at − awareness_at`. |
+
+Buckets are chosen to make the DPA SLAs legible (5m, 30m, 1h, 4h, 12h,
+**24h** [DPA §10], 48h, **72h** [Art. 33], 7d, 30d).
+
+## Retention
+
+Indefinite. Art. 33(5) does not set a ceiling, and the WORM archive (#171)
+ensures we keep the original off-box copy beyond any operational
+incident-data purge.
+
+## Acceptance test
+
+`scripts/breach-synthetic-drill.sh` (TODO if the runbook drill becomes
+recurrent) opens a synthetic incident, identifies subjects on a seeded
+tenant, renders+sends the customer template to a test mailbox, and asserts
+the MTTD/MTTR metrics moved. The same flow is documented inline in
+`docs/runbooks/breach-notification.md` and tracked via the pre-flight
+checklist.

--- a/docs/compliance/breach-register.md
+++ b/docs/compliance/breach-register.md
@@ -63,7 +63,7 @@ All routes are platform-authenticated and admin-gated. Mounted under
 | PATCH | `/breaches/{incidentId}` | Write a new snapshot with partial changes applied. |
 | POST | `/breaches/{incidentId}/close` | Terminal `closed` or `no_action`; computes MTTR. |
 | POST | `/breaches/{incidentId}/subjects` | Identify the end-users in scope (count + capped sample IDs). |
-| POST | `/breaches/{incidentId}/notify-customers` | Render + BCC the customer email; records the dispatch. |
+| POST | `/breaches/{incidentId}/notify-customers` | Render + BCC the customer email to the project's owner + admin team members; records the dispatch. Optional `extra_recipients` adds DPO-supplied controller contacts. |
 | POST | `/breaches/{incidentId}/authority-form` | Render the SA paste-in. `{"filed": true}` records the SA filing. |
 | GET | `/breaches/{incidentId}/sla` | Current state of the 24h / 72h clocks. |
 

--- a/docs/runbooks/breach-notification.md
+++ b/docs/runbooks/breach-notification.md
@@ -1,0 +1,102 @@
+<!--
+INTERNAL RUNBOOK — not customer-facing.
+
+This runbook is referenced from the DPA (Section 10) and the Privacy
+Policy (Section 7). It commits Eurobase to:
+  - 24h target to notify Customers (controllers).
+  - 72h target to notify the lead supervisory authority.
+  - Notify affected end-users without undue delay where Art. 34 applies.
+
+Keep this runbook short and operational. Detail goes in linked
+templates and dashboards, not here.
+-->
+
+# Personal-Data Breach Notification Runbook
+
+**Owner:** DPO (dpo@eurobase.app)
+**Audience:** on-call engineers, founders, anyone who first sees an incident.
+
+A personal-data breach is **any** breach of security leading to accidental or unlawful destruction, loss, alteration, unauthorised disclosure of, or access to, personal data (GDPR Art. 4(12)). It does not require malicious intent — a misconfigured S3 bucket counts.
+
+When in doubt, treat it as a breach. The cost of a false positive is one extra runbook execution; the cost of a false negative is regulatory liability and customer trust.
+
+---
+
+## T+0 — first hour: contain and triage
+
+1. **Page the DPO** at dpo@eurobase.app and the on-call engineer.
+2. **Open an incident channel** (`#incident-YYYYMMDD-<short-name>`) and start a written timeline. Every action gets a timestamped entry. Do not investigate verbally; we will need the record later.
+3. **Scope the blast radius**. What data, whose data, how many records, what time window, what attacker capability is implied?
+4. **Stop the bleeding** — revoke compromised tokens, rotate credentials, block the offending IP, take the misconfigured surface offline. Do this *before* root-causing.
+5. **Preserve evidence** — snapshot logs, DB state, S3 keys, audit trail. Do not delete anything until the DPO clears it.
+
+If the incident is clearly bounded (e.g. a single user's session token leaked to themselves through a UI bug, no data exposed) the DPO may de-escalate after triage.
+
+## T+0 to T+24h — Customer notification (DPA §10)
+
+We commit to notifying affected **Customers** within 24 hours of becoming aware. "Becoming aware" = the moment any Eurobase staff member has reasonable certainty that a breach has occurred — *not* the moment the investigation is complete.
+
+The notification email contains, to the best of current knowledge:
+
+- Nature of the breach.
+- Categories of data affected and approximate number of records.
+- Categories of data subjects and approximate number.
+- Likely consequences.
+- Measures taken or proposed to address the breach and to mitigate its effects.
+- A point of contact (DPO email) for follow-up.
+
+Use the template at `docs/runbooks/templates/breach-customer-email.md`. Dispatch it via the breach register endpoint (`POST /platform/projects/{id}/compliance/breaches/{incidentId}/notify-customers`) so the send is recorded on the append-only register and a corresponding `audit_log` entry is written for hash-chain verification. Customers may have their own end-user notification obligations under Art. 34; we do not notify their end-users on their behalf.
+
+## T+0 to T+72h — Supervisory authority notification (Art. 33)
+
+If the breach has any non-trivial impact on Customer Data, the DPO files the Art. 33 notification with the **CNIL** (Commission nationale de l'informatique et des libertés — France, our establishment) within 72 hours of becoming aware. Filing portal: **https://notifications.cnil.fr/notifications/index** (login with the DPO's CNIL account; if locked out, the DPO's recovery contact is the founder).
+
+Render the structured paste-in for the filing via `POST /platform/projects/{id}/compliance/breaches/{incidentId}/authority-form` and copy section-by-section into the portal. Use the authority's standard form; partial information is acceptable if a follow-up is filed promptly.
+
+For incidents affecting end-users in another Member State, the CNIL acts as the lead SA under the one-stop-shop mechanism (Art. 56) and forwards as needed. Do not file with multiple SAs unless explicitly instructed.
+
+If a notification cannot be made within 72 hours, document the reason for the delay in writing.
+
+For breaches that are *not likely to result in a risk* to data subjects, we still log internally but do not notify the supervisory authority. The DPO makes that judgement call and writes it down.
+
+## When the breach is high-risk to data subjects (Art. 34)
+
+If the breach is **likely to result in a high risk to the rights and freedoms** of data subjects (e.g. plaintext passwords, financial data, location data, health data), we also notify affected end-users directly. For data where Eurobase is processor (tenant end-users), we coordinate with the Customer; the Customer is the controller and decides on end-user comms — but we provide them with everything they need within the 24-hour window above.
+
+Where Eurobase is controller (platform users — see Privacy Policy for scope), we send a direct notice from **dpo@eurobase.app** without the Customer in the loop.
+
+## After the immediate window — root cause, fix, learn
+
+- **Root cause analysis** within 5 working days. Written, blameless, focused on systemic causes (process, defaults, monitoring) not individuals.
+- **Permanent fix** scoped and tracked. Quick fixes from T+0 stay in place until the permanent fix lands.
+- **Public post-mortem** for material incidents, on /security or in a customer email. Default to transparency; redact only what is genuinely sensitive (active attacker indicators of compromise, ongoing investigation detail).
+- **Update this runbook** with anything that surprised us during the response.
+
+## Records
+
+The DPO maintains a register of all personal-data breaches under Art. 33(5) — including those not notified to the authority. The register lives in **`public.breach_register`** (migration 000065) and is exposed read/write via `/platform/projects/{id}/compliance/breaches`. The table is **append-only**: every state change writes a NEW row keyed by `incident_id`; the most recent row by `seq` is the authoritative snapshot. UPDATE/DELETE are revoked from the runtime roles (same pattern as `audit_log` in 000058), and the WORM object archive (issue #171, shipping alongside) provides off-box defence against a compromised gateway forging fresh appends.
+
+Each entry records:
+
+- Date of awareness, date and time of breach (or window).
+- Description of the breach.
+- Categories and approximate numbers (data subjects, records).
+- Likely consequences.
+- Measures taken.
+- Whether notified to the supervisory authority and Customers; if not, why.
+
+We keep the register indefinitely.
+
+## Pre-flight checklist before publication of /legal/dpa and /legal/privacy
+
+- [ ] dpo@eurobase.app receives mail (test from outside the org).
+- [ ] abuse@eurobase.app receives mail.
+- [ ] security@eurobase.app receives mail.
+- [ ] On-call rotation set up; everyone in the rotation has read this runbook. Primary on-call: founder. Backup: DPO. Rotation lives in the team password manager (1Password vault "On-Call").
+- [ ] Customer-email and authority-form templates written and saved alongside this file (`docs/runbooks/templates/breach-customer-email.md`, `docs/runbooks/templates/breach-authority-form.md`).
+- [ ] CNIL portal URL confirmed and DPO account verified (login test once per quarter).
+- [ ] `breach_register` table provisioned (migration 000065 applied in production); `eurobase_gateway` retains only SELECT + INSERT.
+- [ ] `DPO_EMAIL` env var set on the gateway Deployment (defaults to `dpo@eurobase.app`).
+- [ ] Synthetic breach drill executed end-to-end against a seeded tenant; MTTD/MTTR metrics observed on the Grafana board.
+
+When all of the above are checked, the 24-hour DPA SLA and the 72-hour Art. 33 SLA are ones we can actually meet.

--- a/docs/runbooks/templates/breach-authority-form.md
+++ b/docs/runbooks/templates/breach-authority-form.md
@@ -1,0 +1,59 @@
+<!--
+Supervisory authority paste-in — rendered programmatically by
+internal/breach/notify.go (RenderAuthorityForm). The DPO files this
+through the SA's portal within 72 hours of awareness.
+
+Each EU SA accepts its own form. This document is the structured
+content; the DPO copies the relevant sections into the SA portal's
+text fields. Section numbering matches Art. 33(3).
+-->
+
+# Personal-Data Breach Notification — GDPR Art. 33
+
+**Filer:** Eurobase SAS (controller for platform data; processor for tenant data)
+**Lead supervisory authority:** {{LEAD_SA}}
+**Incident reference:** `{{INCIDENT_ID}}`
+**DPO:** dpo@eurobase.app
+
+## 1. Nature of the breach
+
+{{INCIDENT_NATURE}}
+
+- **Title:** {{INCIDENT_TITLE}}
+- **Window of occurrence:** {{INCIDENT_WINDOW}} (UTC)
+- **Awareness:** {{INCIDENT_AWARENESS_AT}} (UTC)
+- **Time elapsed to this notification:** {{ELAPSED_HOURS}} hours
+
+## 2. Data and subjects
+
+- **Categories of personal data:** {{DATA_CATEGORIES}}
+- **Categories of data subjects:** {{SUBJECT_CATEGORIES}}
+- **Approximate number of records:** {{RECORDS_AFFECTED}}
+- **Approximate number of subjects:** {{SUBJECTS_AFFECTED}}
+
+## 3. Likely consequences of the breach
+
+{{LIKELY_CONSEQUENCES}}
+
+## 4. Measures taken or proposed
+
+{{MEASURES_TAKEN}}
+
+## 5. Contact point
+
+DPO: dpo@eurobase.app
+Eurobase incident reference: `{{INCIDENT_ID}}`
+
+---
+
+**Filing notes**
+
+- If notification is more than 72 hours after awareness, attach the
+  written reason for delay (Art. 33(1) sentence 2).
+- File even partial information if some fields are still "(pending)".
+  Follow up via the SA's "supplementary information" path as
+  investigation completes.
+- After filing, update the breach register by calling
+  `POST /compliance/breaches/{incidentId}/authority-form` with
+  `{"filed": true, "lead_sa": "<code>"}` so the register reflects the
+  notification timestamp and the SLA dashboard turns green.

--- a/docs/runbooks/templates/breach-customer-email.md
+++ b/docs/runbooks/templates/breach-customer-email.md
@@ -1,0 +1,74 @@
+<!--
+Customer notification template — referenced from
+docs/runbooks/breach-notification.md and rendered programmatically by
+internal/breach/notify.go (RenderCustomerEmail).
+
+DPA §10 commits us to sending this within 24 hours of becoming aware of
+a personal-data breach affecting Customer Data. Send via the
+/platform/projects/{id}/compliance/breaches/{incidentId}/notify-customers
+endpoint so the dispatch is recorded on the append-only register.
+
+Hand-edit only the placeholders below. Keep the structure unchanged —
+the Art. 33(3) bullets are what makes the notice complete.
+-->
+
+# Customer notification email — Eurobase breach
+
+**Subject:** [Eurobase] Personal-data breach notice ({{INCIDENT_SHORT_ID}})
+
+**To:** {{CUSTOMER_BILLING_EMAIL}}, {{CUSTOMER_DPO_EMAIL}}
+(send via BCC; recipients do not see each other's address)
+
+---
+
+Hello,
+
+Under our Data Processing Agreement (§10) and GDPR Art. 33, we are
+writing to notify you of a personal-data breach that affects your data
+processed on Eurobase. This notice is sent within 24 hours of our
+becoming aware of the incident.
+
+## What happened
+
+{{INCIDENT_NATURE}}
+
+- **Incident reference:** `{{INCIDENT_ID}}`
+- **Window:** {{INCIDENT_WINDOW}} (UTC)
+- **We became aware:** {{INCIDENT_AWARENESS_AT}} (UTC)
+
+## What data is affected
+
+- **Categories of data:** {{DATA_CATEGORIES}}
+- **Categories of data subjects:** {{SUBJECT_CATEGORIES}}
+- **Approximate records affected:** {{RECORDS_AFFECTED}}
+- **Approximate subjects affected:** {{SUBJECTS_AFFECTED}}
+
+## Likely consequences
+
+{{LIKELY_CONSEQUENCES}}
+
+## What we have done
+
+{{MEASURES_TAKEN}}
+
+## What we need from you
+
+You are the controller for end-user data on Eurobase. You may have
+your own notification obligations under GDPR Art. 34 toward your end
+users. We will provide any additional information you need.
+
+## Point of contact
+
+DPO: dpo@eurobase.app
+
+— The Eurobase team
+
+---
+
+**Internal post-send checklist**
+
+- [ ] Confirm send recorded on `breach_register` (status =
+      `notified_customers`).
+- [ ] Confirm `audit_log` entry `breach.notified_customers` is
+      present and the hash chain still verifies.
+- [ ] Slack #incident-{{INCIDENT_SHORT_ID}} with the BulkResult.

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -42,6 +42,17 @@ const (
 	ActionExportCompleted     = "compliance.export.completed"
 	ActionExportFailed        = "compliance.export.failed"
 
+	// Breach register lifecycle — Closes #172. Every write to
+	// public.breach_register also emits an audit_log entry so a tampered
+	// register can be cross-checked against the chained audit log.
+	ActionBreachOpened             = "breach.opened"
+	ActionBreachUpdated            = "breach.updated"
+	ActionBreachNotifiedCustomers  = "breach.notified_customers"
+	ActionBreachNotifiedAuthority  = "breach.notified_authority"
+	ActionBreachNotifiedSubjects   = "breach.notified_subjects"
+	ActionBreachClosed             = "breach.closed"
+	ActionBreachSubjectsIdentified = "breach.subjects_identified"
+
 	// MCP server lifecycle — Closes #165. The platform SQL handler
 	// can be called either from the console (full access) or via
 	// the MCP server's runSQL tool (read-only by default). The

--- a/internal/breach/handler.go
+++ b/internal/breach/handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/eurobase/euroback/internal/audit"
@@ -71,14 +72,16 @@ func (h *Handler) HandleList() http.HandlerFunc {
 	}
 }
 
-// HandleOpen creates a new incident.
+// HandleOpen creates a new incident scoped to the URL project.
 // POST /platform/projects/{id}/compliance/breaches
 //
-// The project_id in the URL is the scope check (the auth middleware already
-// verified the caller has admin on it); if the breach truly affects the
-// platform side, the handler also accepts `affects_platform: true` and a
-// nil project_id payload — but we always anchor at least the URL project so
-// every call has a tenant context for RBAC.
+// PR #219 review: this route always anchors the incident at the URL
+// `{id}` regardless of what the body asks for. `affects_platform` is a
+// tag (true if the incident bleeds into platform infrastructure too),
+// not a scope override — a tenant admin can't open a `project_id=NULL`
+// incident that would then be reachable from any other project.
+// Platform-only incidents are opened by platform admins through a
+// future platform-admin endpoint, not here.
 func (h *Handler) HandleOpen() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projectID := chi.URLParam(r, "id")
@@ -93,10 +96,8 @@ func (h *Handler) HandleOpen() http.HandlerFunc {
 			writeError(w, "invalid json body", http.StatusBadRequest)
 			return
 		}
-		if in.ProjectID == nil && !in.AffectsPlatform {
-			pid := projectID
-			in.ProjectID = &pid
-		}
+		pid := projectID
+		in.ProjectID = &pid
 
 		entry, err := h.Svc.Open(r.Context(), in, claims.Subject, claims.Email)
 		if err != nil {
@@ -108,12 +109,14 @@ func (h *Handler) HandleOpen() http.HandlerFunc {
 	}
 }
 
-// HandleGet returns the full append-only history for one incident.
+// HandleGet returns the full append-only history for one incident, scoped
+// to the URL project — cross-tenant lookups return 404 (PR #219 review).
 // GET /platform/projects/{id}/compliance/breaches/{incidentId}
 func (h *Handler) HandleGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
-		hist, err := h.Svc.History(r.Context(), incidentID)
+		hist, err := h.Svc.History(r.Context(), projectID, incidentID)
 		if err != nil {
 			slog.Error("breach history failed", "incident_id", incidentID, "error", err)
 			writeError(w, "failed to load incident", http.StatusInternalServerError)
@@ -134,6 +137,7 @@ func (h *Handler) HandleGet() http.HandlerFunc {
 // PATCH /platform/projects/{id}/compliance/breaches/{incidentId}
 func (h *Handler) HandleUpdate() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
 		claims, _ := auth.ClaimsFromContext(r.Context())
 		if claims == nil {
@@ -146,7 +150,7 @@ func (h *Handler) HandleUpdate() http.HandlerFunc {
 			writeError(w, "invalid json body", http.StatusBadRequest)
 			return
 		}
-		entry, err := h.Svc.Update(r.Context(), incidentID, in, claims.Subject, claims.Email)
+		entry, err := h.Svc.Update(r.Context(), projectID, incidentID, in, claims.Subject, claims.Email)
 		if err != nil {
 			writeError(w, err.Error(), http.StatusBadRequest)
 			return
@@ -159,6 +163,7 @@ func (h *Handler) HandleUpdate() http.HandlerFunc {
 // POST /platform/projects/{id}/compliance/breaches/{incidentId}/close
 func (h *Handler) HandleClose() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
 		claims, _ := auth.ClaimsFromContext(r.Context())
 		if claims == nil {
@@ -177,7 +182,7 @@ func (h *Handler) HandleClose() http.HandlerFunc {
 		if body.Status == "" {
 			body.Status = StatusClosed
 		}
-		entry, err := h.Svc.Close(r.Context(), incidentID, body.Status, body.Note, claims.Subject, claims.Email)
+		entry, err := h.Svc.Close(r.Context(), projectID, incidentID, body.Status, body.Note, claims.Subject, claims.Email)
 		if err != nil {
 			writeError(w, err.Error(), http.StatusBadRequest)
 			return
@@ -229,11 +234,15 @@ func (h *Handler) HandleSubjects() http.HandlerFunc {
 }
 
 // HandleNotifyCustomers renders the customer-notification email and sends
-// it via BCC to the supplied recipients (typically: the project's billing
-// contact + the controller's data-protection contact, supplied by the DPO).
+// it via BCC to the project's known controller contacts. Recipients are
+// resolved server-side from the project's owner + admin team members
+// (PR #219 review — caller-supplied recipients are no longer accepted to
+// prevent an admin from BCC'ing an official-looking breach notice to
+// arbitrary addresses from platform email infra).
 // POST /platform/projects/{id}/compliance/breaches/{incidentId}/notify-customers
 func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
 		claims, _ := auth.ClaimsFromContext(r.Context())
 		if claims == nil {
@@ -242,15 +251,25 @@ func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
 		}
 
 		var body struct {
-			Recipients []string `json:"recipients"`
-			Note       string   `json:"note"`
-			Preview    bool     `json:"preview"`
+			ExtraRecipients []string `json:"extra_recipients"`
+			Note            string   `json:"note"`
+			Preview         bool     `json:"preview"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeError(w, "invalid json body", http.StatusBadRequest)
 			return
 		}
-		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		recipients, err := h.resolveCustomerRecipients(r.Context(), projectID, body.ExtraRecipients)
+		if err != nil {
+			slog.Error("breach customer recipient resolve failed", "project_id", projectID, "error", err)
+			writeError(w, "failed to resolve recipients", http.StatusInternalServerError)
+			return
+		}
+		if len(recipients) == 0 {
+			writeError(w, "project has no controller contacts on file", http.StatusBadRequest)
+			return
+		}
+		latest, err := h.Svc.Latest(r.Context(), projectID, incidentID)
 		if err != nil || latest == nil {
 			writeError(w, "incident not found", http.StatusNotFound)
 			return
@@ -262,9 +281,10 @@ func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
 		}
 		if body.Preview {
 			writeJSON(w, map[string]interface{}{
-				"subject":   subject,
-				"html":      html,
-				"recipient_count": len(body.Recipients),
+				"subject":         subject,
+				"html":            html,
+				"recipient_count": len(recipients),
+				"recipients":      recipients,
 			}, http.StatusOK)
 			return
 		}
@@ -272,12 +292,12 @@ func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
 			writeError(w, "email service not configured", http.StatusServiceUnavailable)
 			return
 		}
-		res, err := h.Mailer.SendBulkBCC(r.Context(), body.Recipients, subject, html)
+		res, err := h.Mailer.SendBulkBCC(r.Context(), recipients, subject, html)
 		if err != nil {
 			writeError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		entry, err := h.Svc.MarkNotification(r.Context(), incidentID, "customers", "", body.Note, claims.Subject, claims.Email)
+		entry, err := h.Svc.MarkNotification(r.Context(), projectID, incidentID, "customers", "", body.Note, claims.Subject, claims.Email)
 		if err != nil {
 			writeError(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -290,11 +310,77 @@ func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
 	}
 }
 
+// resolveCustomerRecipients returns the email addresses that should
+// receive the breach notice for a project: every owner + admin team
+// member. Optional `extra` addresses (DPO-supplied controller DPO
+// contacts that aren't already team members) are unioned in only if
+// they parse as a plausible email address. Duplicates are de-duped.
+// PR #219 review: replaces caller-supplied recipients so an admin
+// can't BCC arbitrary addresses from platform email infra.
+func (h *Handler) resolveCustomerRecipients(ctx context.Context, projectID string, extra []string) ([]string, error) {
+	rows, err := h.Pool.Query(ctx, `
+		SELECT DISTINCT lower(u.email)
+		  FROM public.project_members pm
+		  JOIN public.platform_users u ON u.id = pm.user_id
+		 WHERE pm.project_id = $1 AND pm.role IN ('owner','admin')`,
+		projectID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	seen := map[string]bool{}
+	var out []string
+	for rows.Next() {
+		var e string
+		if err := rows.Scan(&e); err != nil {
+			return nil, err
+		}
+		if e != "" && !seen[e] {
+			seen[e] = true
+			out = append(out, e)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for _, e := range extra {
+		e = strings.ToLower(strings.TrimSpace(e))
+		if isPlausibleEmail(e) && !seen[e] {
+			seen[e] = true
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// isPlausibleEmail is a deliberately-cheap sanity check; it is not RFC-5322
+// compliant. The downstream TEM client rejects malformed addresses with a
+// 4xx, this just keeps the BCC list short and predictable.
+func isPlausibleEmail(s string) bool {
+	if len(s) < 5 || len(s) > 254 {
+		return false
+	}
+	at := strings.IndexByte(s, '@')
+	if at <= 0 || at == len(s)-1 || strings.Count(s, "@") != 1 {
+		return false
+	}
+	if strings.ContainsAny(s, " \t\n\r,;<>\"'()") {
+		return false
+	}
+	if !strings.Contains(s[at+1:], ".") {
+		return false
+	}
+	return true
+}
+
 // HandleAuthorityForm returns the Markdown paste-in for the supervisory
 // authority and (optionally) records that the SA was notified.
 // POST /platform/projects/{id}/compliance/breaches/{incidentId}/authority-form
 func (h *Handler) HandleAuthorityForm() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
 		claims, _ := auth.ClaimsFromContext(r.Context())
 		if claims == nil {
@@ -303,14 +389,14 @@ func (h *Handler) HandleAuthorityForm() http.HandlerFunc {
 		}
 
 		var body struct {
-			Filed   bool   `json:"filed"`
-			LeadSA  string `json:"lead_sa"`
-			Note    string `json:"note"`
+			Filed  bool   `json:"filed"`
+			LeadSA string `json:"lead_sa"`
+			Note   string `json:"note"`
 		}
 		if r.Body != nil {
 			_ = json.NewDecoder(r.Body).Decode(&body)
 		}
-		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		latest, err := h.Svc.Latest(r.Context(), projectID, incidentID)
 		if err != nil || latest == nil {
 			writeError(w, "incident not found", http.StatusNotFound)
 			return
@@ -322,7 +408,7 @@ func (h *Handler) HandleAuthorityForm() http.HandlerFunc {
 		}
 		var entry *Entry
 		if body.Filed {
-			entry, err = h.Svc.MarkNotification(r.Context(), incidentID, "authority", body.LeadSA, body.Note, claims.Subject, claims.Email)
+			entry, err = h.Svc.MarkNotification(r.Context(), projectID, incidentID, "authority", body.LeadSA, body.Note, claims.Subject, claims.Email)
 			if err != nil {
 				writeError(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -340,8 +426,9 @@ func (h *Handler) HandleAuthorityForm() http.HandlerFunc {
 // GET /platform/projects/{id}/compliance/breaches/{incidentId}/sla
 func (h *Handler) HandleSLAStatus() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
 		incidentID := chi.URLParam(r, "incidentId")
-		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		latest, err := h.Svc.Latest(r.Context(), projectID, incidentID)
 		if err != nil || latest == nil {
 			writeError(w, "incident not found", http.StatusNotFound)
 			return

--- a/internal/breach/handler.go
+++ b/internal/breach/handler.go
@@ -1,0 +1,364 @@
+package breach
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/eurobase/euroback/internal/audit"
+	"github.com/eurobase/euroback/internal/auth"
+	"github.com/eurobase/euroback/internal/email"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MailerAdapter adapts internal/email.EmailService to the breach Mailer
+// interface so the breach package doesn't import internal/email (which
+// would create an audit/email/breach diamond).
+type MailerAdapter struct {
+	Svc *email.EmailService
+}
+
+func (m *MailerAdapter) SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) (BulkSendResult, error) {
+	if m == nil || m.Svc == nil {
+		return BulkSendResult{}, nil
+	}
+	r, err := m.Svc.SendBulkBCC(ctx, recipients, subject, htmlBody)
+	return BulkSendResult{Sent: r.Sent, Failed: r.Failed}, err
+}
+
+func (m *MailerAdapter) SendRaw(ctx context.Context, to, subject, htmlBody string) error {
+	if m == nil || m.Svc == nil {
+		return nil
+	}
+	return m.Svc.SendRaw(ctx, to, subject, htmlBody)
+}
+
+// Handler is the HTTP surface for the breach register.
+type Handler struct {
+	Svc      *Service
+	Pool     *pgxpool.Pool
+	Mailer   Mailer
+	DPOEmail string // populated from env (DPO_EMAIL) by the router wiring.
+}
+
+func writeJSON(w http.ResponseWriter, data interface{}, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func writeError(w http.ResponseWriter, msg string, status int) {
+	writeJSON(w, map[string]string{"error": msg}, status)
+}
+
+// HandleList lists the latest snapshot per incident for a project.
+// GET /platform/projects/{id}/compliance/breaches
+func (h *Handler) HandleList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		entries, err := h.Svc.ListLatest(r.Context(), projectID, limit)
+		if err != nil {
+			slog.Error("breach list failed", "project_id", projectID, "error", err)
+			writeError(w, "failed to list breaches", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]interface{}{"breaches": entries}, http.StatusOK)
+	}
+}
+
+// HandleOpen creates a new incident.
+// POST /platform/projects/{id}/compliance/breaches
+//
+// The project_id in the URL is the scope check (the auth middleware already
+// verified the caller has admin on it); if the breach truly affects the
+// platform side, the handler also accepts `affects_platform: true` and a
+// nil project_id payload — but we always anchor at least the URL project so
+// every call has a tenant context for RBAC.
+func (h *Handler) HandleOpen() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var in OpenInput
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		if in.ProjectID == nil && !in.AffectsPlatform {
+			pid := projectID
+			in.ProjectID = &pid
+		}
+
+		entry, err := h.Svc.Open(r.Context(), in, claims.Subject, claims.Email)
+		if err != nil {
+			slog.Error("breach open failed", "project_id", projectID, "error", err)
+			writeError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, entry, http.StatusCreated)
+	}
+}
+
+// HandleGet returns the full append-only history for one incident.
+// GET /platform/projects/{id}/compliance/breaches/{incidentId}
+func (h *Handler) HandleGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		hist, err := h.Svc.History(r.Context(), incidentID)
+		if err != nil {
+			slog.Error("breach history failed", "incident_id", incidentID, "error", err)
+			writeError(w, "failed to load incident", http.StatusInternalServerError)
+			return
+		}
+		if len(hist) == 0 {
+			writeError(w, "incident not found", http.StatusNotFound)
+			return
+		}
+		writeJSON(w, map[string]interface{}{
+			"latest":  hist[len(hist)-1],
+			"history": hist,
+		}, http.StatusOK)
+	}
+}
+
+// HandleUpdate applies a partial change as a new register row.
+// PATCH /platform/projects/{id}/compliance/breaches/{incidentId}
+func (h *Handler) HandleUpdate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var in UpdateInput
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		entry, err := h.Svc.Update(r.Context(), incidentID, in, claims.Subject, claims.Email)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, entry, http.StatusOK)
+	}
+}
+
+// HandleClose terminates an incident with a "closed" or "no_action" row.
+// POST /platform/projects/{id}/compliance/breaches/{incidentId}/close
+func (h *Handler) HandleClose() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var body struct {
+			Status string `json:"status"`
+			Note   string `json:"note"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		if body.Status == "" {
+			body.Status = StatusClosed
+		}
+		entry, err := h.Svc.Close(r.Context(), incidentID, body.Status, body.Note, claims.Subject, claims.Email)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, entry, http.StatusOK)
+	}
+}
+
+// HandleSubjects identifies the affected end-users for an incident's scope.
+// POST /platform/projects/{id}/compliance/breaches/{incidentId}/subjects
+//
+// The request body is a SubjectQuery JSON; the response is a count + a
+// capped sample of IDs the DPO can spot-check. The handler also audits the
+// identification call because pulling a list of affected subjects is itself
+// a privacy-sensitive operation.
+func (h *Handler) HandleSubjects() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := chi.URLParam(r, "id")
+		incidentID := chi.URLParam(r, "incidentId")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var q SubjectQuery
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&q)
+		}
+		result, err := IdentifySubjects(r.Context(), h.Pool, projectID, q)
+		if err != nil {
+			slog.Error("breach subject identification failed", "incident_id", incidentID, "error", err)
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if h.Svc.auditSvc != nil {
+			h.Svc.auditSvc.Log(r.Context(), projectID, claims.Subject, claims.Email,
+				audit.ActionBreachSubjectsIdentified,
+				audit.WithTarget("breach", incidentID),
+				audit.WithMetadata(map[string]any{
+					"count":         result.Count,
+					"tables_probed": result.TablesProbed,
+				}),
+				audit.WithIP(r.RemoteAddr))
+		}
+		writeJSON(w, result, http.StatusOK)
+	}
+}
+
+// HandleNotifyCustomers renders the customer-notification email and sends
+// it via BCC to the supplied recipients (typically: the project's billing
+// contact + the controller's data-protection contact, supplied by the DPO).
+// POST /platform/projects/{id}/compliance/breaches/{incidentId}/notify-customers
+func (h *Handler) HandleNotifyCustomers() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var body struct {
+			Recipients []string `json:"recipients"`
+			Note       string   `json:"note"`
+			Preview    bool     `json:"preview"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, "invalid json body", http.StatusBadRequest)
+			return
+		}
+		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		if err != nil || latest == nil {
+			writeError(w, "incident not found", http.StatusNotFound)
+			return
+		}
+		subject, html, err := RenderCustomerEmail(latest, h.DPOEmail)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if body.Preview {
+			writeJSON(w, map[string]interface{}{
+				"subject":   subject,
+				"html":      html,
+				"recipient_count": len(body.Recipients),
+			}, http.StatusOK)
+			return
+		}
+		if h.Mailer == nil {
+			writeError(w, "email service not configured", http.StatusServiceUnavailable)
+			return
+		}
+		res, err := h.Mailer.SendBulkBCC(r.Context(), body.Recipients, subject, html)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		entry, err := h.Svc.MarkNotification(r.Context(), incidentID, "customers", "", body.Note, claims.Subject, claims.Email)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]interface{}{
+			"sent":   res.Sent,
+			"failed": res.Failed,
+			"entry":  entry,
+		}, http.StatusOK)
+	}
+}
+
+// HandleAuthorityForm returns the Markdown paste-in for the supervisory
+// authority and (optionally) records that the SA was notified.
+// POST /platform/projects/{id}/compliance/breaches/{incidentId}/authority-form
+func (h *Handler) HandleAuthorityForm() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		claims, _ := auth.ClaimsFromContext(r.Context())
+		if claims == nil {
+			writeError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		var body struct {
+			Filed   bool   `json:"filed"`
+			LeadSA  string `json:"lead_sa"`
+			Note    string `json:"note"`
+		}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		if err != nil || latest == nil {
+			writeError(w, "incident not found", http.StatusNotFound)
+			return
+		}
+		form, err := RenderAuthorityForm(latest, h.DPOEmail)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var entry *Entry
+		if body.Filed {
+			entry, err = h.Svc.MarkNotification(r.Context(), incidentID, "authority", body.LeadSA, body.Note, claims.Subject, claims.Email)
+			if err != nil {
+				writeError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		writeJSON(w, map[string]interface{}{
+			"form":  form,
+			"entry": entry,
+		}, http.StatusOK)
+	}
+}
+
+// HandleSLAStatus reports per-incident SLA status (DPA §10 24h, Art. 33
+// 72h) so the console can render a banner when one is about to elapse.
+// GET /platform/projects/{id}/compliance/breaches/{incidentId}/sla
+func (h *Handler) HandleSLAStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		incidentID := chi.URLParam(r, "incidentId")
+		latest, err := h.Svc.Latest(r.Context(), incidentID)
+		if err != nil || latest == nil {
+			writeError(w, "incident not found", http.StatusNotFound)
+			return
+		}
+		now := time.Now().UTC()
+		customerSLA := latest.AwarenessAt.Add(24 * time.Hour)
+		authoritySLA := latest.AwarenessAt.Add(72 * time.Hour)
+		writeJSON(w, map[string]interface{}{
+			"incident_id":       incidentID,
+			"awareness_at":      latest.AwarenessAt,
+			"now":               now,
+			"customer_sla_at":   customerSLA,
+			"customer_notified": latest.NotifiedCustomers,
+			"customer_breach":   !latest.NotifiedCustomers && now.After(customerSLA),
+			"authority_sla_at":  authoritySLA,
+			"authority_notified": latest.NotifiedAuthority,
+			"authority_breach":  !latest.NotifiedAuthority && now.After(authoritySLA),
+		}, http.StatusOK)
+	}
+}

--- a/internal/breach/notify.go
+++ b/internal/breach/notify.go
@@ -1,0 +1,267 @@
+package breach
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"strings"
+	"time"
+)
+
+// Mailer is the minimal interface the breach service needs to deliver
+// notifications. internal/email.EmailService implements both methods.
+type Mailer interface {
+	SendBulkBCC(ctx context.Context, recipients []string, subject, htmlBody string) (BulkSendResult, error)
+	SendRaw(ctx context.Context, to, subject, htmlBody string) error
+}
+
+// BulkSendResult mirrors internal/email.BulkResult so the breach service
+// doesn't take an import cycle on internal/email. The handler adapts the
+// concrete type.
+type BulkSendResult struct {
+	Sent   int
+	Failed int
+}
+
+// CustomerEmailData is the variable surface available to the customer
+// notification template. The runbook's "to the best of current knowledge"
+// fields all live here.
+type CustomerEmailData struct {
+	IncidentID         string
+	Title              string
+	OccurredWindow     string
+	AwarenessAt        string
+	Nature             string
+	DataCategories     string
+	SubjectCategories  string
+	RecordsAffected    string
+	SubjectsAffected   string
+	LikelyConsequences string
+	MeasuresTaken      string
+	DPOEmail           string
+}
+
+// AuthorityFormData populates the supervisory-authority free-form summary.
+// The actual filing is done by the DPO in the SA's portal; we provide a
+// structured paste-in that already covers every Art. 33(3) bullet.
+type AuthorityFormData struct {
+	IncidentID         string
+	Title              string
+	OccurredWindow     string
+	AwarenessAt        string
+	Nature             string
+	DataCategories     string
+	SubjectCategories  string
+	RecordsAffected    string
+	SubjectsAffected   string
+	LikelyConsequences string
+	MeasuresTaken      string
+	LeadSA             string
+	DPOEmail           string
+}
+
+const customerEmailTpl = `<!DOCTYPE html>
+<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#18181b;max-width:640px;margin:0 auto;padding:24px">
+<h2 style="margin:0 0 16px">Notice of a personal-data breach affecting your Eurobase project</h2>
+<p>Hello,</p>
+<p>Under our Data Processing Agreement (§10) and GDPR Art. 33, we are
+writing to notify you of a personal-data breach that affects your data
+processed on Eurobase. This notice is sent within 24 hours of our
+becoming aware of the incident.</p>
+
+<h3>What happened</h3>
+<p>{{.Nature}}</p>
+<p><strong>Incident reference:</strong> {{.IncidentID}}<br>
+<strong>Window:</strong> {{.OccurredWindow}}<br>
+<strong>We became aware:</strong> {{.AwarenessAt}} UTC</p>
+
+<h3>What data is affected</h3>
+<ul>
+<li><strong>Categories of data:</strong> {{.DataCategories}}</li>
+<li><strong>Categories of data subjects:</strong> {{.SubjectCategories}}</li>
+<li><strong>Approximate records affected:</strong> {{.RecordsAffected}}</li>
+<li><strong>Approximate subjects affected:</strong> {{.SubjectsAffected}}</li>
+</ul>
+
+<h3>Likely consequences</h3>
+<p>{{.LikelyConsequences}}</p>
+
+<h3>What we have done</h3>
+<p>{{.MeasuresTaken}}</p>
+
+<h3>What we need from you</h3>
+<p>You are the controller for end-user data on Eurobase. You may have
+your own notification obligations under GDPR Art. 34 toward your end
+users. We are available to support that process and will provide any
+additional information you need.</p>
+
+<p>Point of contact: <a href="mailto:{{.DPOEmail}}">{{.DPOEmail}}</a> (Eurobase DPO).</p>
+
+<p>— The Eurobase team</p>
+</body></html>`
+
+const authorityFormTpl = `# Personal-Data Breach Notification under GDPR Art. 33
+
+**Filer:** Eurobase (controller for platform data; processor for tenant data)
+**Lead supervisory authority:** {{.LeadSA}}
+**Incident reference:** {{.IncidentID}}
+**DPO:** {{.DPOEmail}}
+
+## 1. Nature of the breach
+{{.Nature}}
+
+**Title:** {{.Title}}
+**Window:** {{.OccurredWindow}}
+**Awareness:** {{.AwarenessAt}} UTC
+
+## 2. Data and subjects
+- **Categories of personal data:** {{.DataCategories}}
+- **Categories of data subjects:** {{.SubjectCategories}}
+- **Approximate number of records:** {{.RecordsAffected}}
+- **Approximate number of subjects:** {{.SubjectsAffected}}
+
+## 3. Likely consequences of the breach
+{{.LikelyConsequences}}
+
+## 4. Measures taken or proposed
+{{.MeasuresTaken}}
+
+## 5. Contact point
+DPO: {{.DPOEmail}}
+`
+
+// RenderCustomerEmail produces the (subject, html) pair sent to controllers.
+func RenderCustomerEmail(e *Entry, dpoEmail string) (string, string, error) {
+	data := newCustomerData(e, dpoEmail)
+	subject := fmt.Sprintf("[Eurobase] Personal-data breach notice (%s)", shortID(e.IncidentID))
+	body, err := renderHTML(customerEmailTpl, data)
+	if err != nil {
+		return "", "", err
+	}
+	return subject, body, nil
+}
+
+// RenderAuthorityForm produces the Markdown paste-in for the supervisory
+// authority. Returns plain text — the DPO files it through the SA's portal.
+func RenderAuthorityForm(e *Entry, dpoEmail string) (string, error) {
+	data := AuthorityFormData{
+		IncidentID:         e.IncidentID,
+		Title:              e.Title,
+		OccurredWindow:     formatWindow(e.OccurredAt, e.OccurredUntil),
+		AwarenessAt:        e.AwarenessAt.UTC().Format(time.RFC3339),
+		Nature:             ifEmpty(e.Description, "(pending)"),
+		DataCategories:     ifEmptySlice(e.DataCategories, "(pending)"),
+		SubjectCategories:  ifEmptySlice(e.SubjectCategories, "(pending)"),
+		RecordsAffected:    formatInt64Ptr(e.RecordsAffected, "(pending)"),
+		SubjectsAffected:   formatInt64Ptr(e.SubjectsAffected, "(pending)"),
+		LikelyConsequences: ifEmpty(e.LikelyConsequences, "(pending)"),
+		MeasuresTaken:      ifEmpty(e.MeasuresTaken, "(pending)"),
+		LeadSA:             derefStr(e.LeadSA, "(unset)"),
+		DPOEmail:           dpoEmail,
+	}
+	t, err := template.New("auth").Parse(authorityFormTpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// SendCustomerNotice renders and BCCs the customer notice to the given
+// recipients. Returns (sent, failed) like the underlying SendBulkBCC.
+func SendCustomerNotice(ctx context.Context, mailer Mailer, e *Entry, recipients []string, dpoEmail string) (BulkSendResult, error) {
+	if mailer == nil {
+		return BulkSendResult{}, fmt.Errorf("mailer not configured")
+	}
+	if len(recipients) == 0 {
+		return BulkSendResult{}, fmt.Errorf("no recipients")
+	}
+	subject, html, err := RenderCustomerEmail(e, dpoEmail)
+	if err != nil {
+		return BulkSendResult{}, err
+	}
+	return mailer.SendBulkBCC(ctx, recipients, subject, html)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func newCustomerData(e *Entry, dpoEmail string) CustomerEmailData {
+	return CustomerEmailData{
+		IncidentID:         e.IncidentID,
+		Title:              e.Title,
+		OccurredWindow:     formatWindow(e.OccurredAt, e.OccurredUntil),
+		AwarenessAt:        e.AwarenessAt.UTC().Format(time.RFC3339),
+		Nature:             ifEmpty(e.Description, "Details are still being established. We will follow up as our investigation completes."),
+		DataCategories:     ifEmptySlice(e.DataCategories, "under investigation"),
+		SubjectCategories:  ifEmptySlice(e.SubjectCategories, "under investigation"),
+		RecordsAffected:    formatInt64Ptr(e.RecordsAffected, "under investigation"),
+		SubjectsAffected:   formatInt64Ptr(e.SubjectsAffected, "under investigation"),
+		LikelyConsequences: ifEmpty(e.LikelyConsequences, "under assessment"),
+		MeasuresTaken:      ifEmpty(e.MeasuresTaken, "Stop-the-bleeding measures are in place; root cause analysis is ongoing."),
+		DPOEmail:           dpoEmail,
+	}
+}
+
+func renderHTML(tpl string, data interface{}) (string, error) {
+	t, err := template.New("email").Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func formatWindow(from, until *time.Time) string {
+	if from == nil && until == nil {
+		return "under investigation"
+	}
+	if from != nil && until == nil {
+		return from.UTC().Format(time.RFC3339) + " — ongoing"
+	}
+	if from == nil && until != nil {
+		return "unknown — " + until.UTC().Format(time.RFC3339)
+	}
+	return from.UTC().Format(time.RFC3339) + " — " + until.UTC().Format(time.RFC3339)
+}
+
+func ifEmpty(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func ifEmptySlice(s []string, fallback string) string {
+	if len(s) == 0 {
+		return fallback
+	}
+	return strings.Join(s, ", ")
+}
+
+func formatInt64Ptr(v *int64, fallback string) string {
+	if v == nil {
+		return fallback
+	}
+	return fmt.Sprintf("%d", *v)
+}
+
+func derefStr(p *string, fallback string) string {
+	if p == nil || *p == "" {
+		return fallback
+	}
+	return *p
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/internal/breach/notify_test.go
+++ b/internal/breach/notify_test.go
@@ -1,0 +1,130 @@
+package breach
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func mkEntry() *Entry {
+	occ := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	aware := time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC)
+	recs := int64(1234)
+	subs := int64(98)
+	leadSA := "fr-cnil"
+	return &Entry{
+		IncidentID:         "11111111-2222-3333-4444-555555555555",
+		Title:              "Misconfigured S3 ACL exposed thumbnails bucket",
+		Description:        "A staging cron rotated bucket ACL to public-read for ~2h. Personal-data thumbnails were enumerable.",
+		LikelyConsequences: "Loss of confidentiality of profile photos for affected users.",
+		MeasuresTaken:      "ACL reverted, CDN purged, attacker IPs blocked, root-cause cron disabled.",
+		DataCategories:     []string{"profile photo", "user id"},
+		SubjectCategories:  []string{"end-users of project acme"},
+		RecordsAffected:    &recs,
+		SubjectsAffected:   &subs,
+		OccurredAt:         &occ,
+		OccurredUntil:      &until,
+		AwarenessAt:        aware,
+		LeadSA:             &leadSA,
+		Status:             StatusOpen,
+		ActorEmail:         "dpo@eurobase.app",
+	}
+}
+
+func TestRenderCustomerEmail_PopulatesAllSections(t *testing.T) {
+	subject, html, err := RenderCustomerEmail(mkEntry(), "dpo@eurobase.app")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(subject, "Personal-data breach notice") {
+		t.Errorf("subject missing prefix: %q", subject)
+	}
+	// Subject must include a recognisable short id, not the full UUID.
+	if !strings.Contains(subject, "11111111") {
+		t.Errorf("subject missing short id: %q", subject)
+	}
+	if strings.Contains(subject, "555555555555") {
+		t.Errorf("subject leaks full UUID: %q", subject)
+	}
+
+	for _, want := range []string{
+		"staging cron rotated bucket ACL",                // nature (description)
+		"profile photo, user id",                         // data categories joined
+		"end-users of project acme",                      // subjects
+		"1234",                                           // records
+		"98",                                             // subjects count
+		"Loss of confidentiality",                        // consequences
+		"ACL reverted, CDN purged",                       // measures
+		"<a href=\"mailto:dpo@eurobase.app\">",           // DPO link
+		"2026-06-01T08:00:00Z — 2026-06-01T10:00:00Z",   // window UTC
+		"2026-06-01T11:00:00Z",                           // awareness
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("html missing %q", want)
+		}
+	}
+}
+
+func TestRenderCustomerEmail_FallbacksWhenFieldsAreEmpty(t *testing.T) {
+	e := &Entry{
+		IncidentID:  "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Title:       "Unknown",
+		AwarenessAt: time.Now().UTC(),
+	}
+	_, html, err := RenderCustomerEmail(e, "dpo@eurobase.app")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		"Details are still being established",
+		"under investigation",
+		"under assessment",
+		"Stop-the-bleeding measures are in place",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("html missing fallback %q", want)
+		}
+	}
+}
+
+func TestRenderAuthorityForm_StructuredArticle33Bullets(t *testing.T) {
+	out, err := RenderAuthorityForm(mkEntry(), "dpo@eurobase.app")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		"## 1. Nature of the breach",
+		"## 2. Data and subjects",
+		"## 3. Likely consequences",
+		"## 4. Measures taken or proposed",
+		"## 5. Contact point",
+		"**Lead supervisory authority:** fr-cnil",
+		"**Incident reference:** 11111111-2222-3333-4444-555555555555",
+		"profile photo, user id",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("authority form missing %q", want)
+		}
+	}
+}
+
+func TestFormatWindow_Permutations(t *testing.T) {
+	a := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+	b := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	cases := []struct {
+		from, until *time.Time
+		want        string
+	}{
+		{nil, nil, "under investigation"},
+		{&a, nil, "2026-06-01T08:00:00Z — ongoing"},
+		{nil, &b, "unknown — 2026-06-01T10:00:00Z"},
+		{&a, &b, "2026-06-01T08:00:00Z — 2026-06-01T10:00:00Z"},
+	}
+	for _, c := range cases {
+		got := formatWindow(c.from, c.until)
+		if got != c.want {
+			t.Errorf("formatWindow(%v,%v) = %q, want %q", c.from, c.until, got, c.want)
+		}
+	}
+}

--- a/internal/breach/service.go
+++ b/internal/breach/service.go
@@ -1,0 +1,534 @@
+// Package breach implements the personal-data breach register required by
+// GDPR Art. 33(5) and operationalises the 72h supervisory-authority and 24h
+// customer notification SLAs the DPA commits to.
+//
+// Storage is public.breach_register (migration 000065). Append-only by the
+// same pattern as audit_log (000058): every state change writes a NEW row
+// keyed by the same incident_id. The most recent row by `seq` is the
+// authoritative snapshot.
+package breach
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/eurobase/euroback/internal/audit"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Status values mirror the runbook state machine.
+const (
+	StatusOpen              = "open"
+	StatusContained         = "contained"
+	StatusNotifiedCustomers = "notified_customers"
+	StatusNotifiedAuthority = "notified_authority"
+	StatusClosed            = "closed"
+	StatusNoAction          = "no_action"
+)
+
+// Entry is one row of the breach register. The latest seq per incident_id is
+// the current snapshot.
+type Entry struct {
+	ID                   string          `json:"id"`
+	IncidentID           string          `json:"incident_id"`
+	Seq                  int64           `json:"seq"`
+	ProjectID            *string         `json:"project_id,omitempty"`
+	AffectsPlatform      bool            `json:"affects_platform"`
+	Title                string          `json:"title"`
+	Description          string          `json:"description"`
+	LikelyConsequences   string          `json:"likely_consequences"`
+	MeasuresTaken        string          `json:"measures_taken"`
+	DataCategories       []string        `json:"data_categories"`
+	SubjectCategories    []string        `json:"subject_categories"`
+	RecordsAffected      *int64          `json:"records_affected,omitempty"`
+	SubjectsAffected     *int64          `json:"subjects_affected,omitempty"`
+	OccurredAt           *time.Time      `json:"occurred_at,omitempty"`
+	OccurredUntil        *time.Time      `json:"occurred_until,omitempty"`
+	AwarenessAt          time.Time       `json:"awareness_at"`
+	ContainedAt          *time.Time      `json:"contained_at,omitempty"`
+	ResolvedAt           *time.Time      `json:"resolved_at,omitempty"`
+	NotifiedAuthority    bool            `json:"notified_authority"`
+	NotifiedAuthorityAt  *time.Time      `json:"notified_authority_at,omitempty"`
+	NotifiedCustomers    bool            `json:"notified_customers"`
+	NotifiedCustomersAt  *time.Time      `json:"notified_customers_at,omitempty"`
+	NotifiedSubjects     bool            `json:"notified_subjects"`
+	NotifiedSubjectsAt   *time.Time      `json:"notified_subjects_at,omitempty"`
+	LeadSA               *string         `json:"lead_sa,omitempty"`
+	MTTDSeconds          *int64          `json:"mttd_seconds,omitempty"`
+	MTTRSeconds          *int64          `json:"mttr_seconds,omitempty"`
+	Status               string          `json:"status"`
+	ActorID              *string         `json:"actor_id,omitempty"`
+	ActorEmail           string          `json:"actor_email"`
+	Note                 string          `json:"note"`
+	Metadata             json.RawMessage `json:"metadata"`
+	CreatedAt            time.Time       `json:"created_at"`
+}
+
+// OpenInput is the create-incident payload.
+type OpenInput struct {
+	ProjectID          *string    `json:"project_id,omitempty"`
+	AffectsPlatform    bool       `json:"affects_platform"`
+	Title              string     `json:"title"`
+	Description        string     `json:"description"`
+	LikelyConsequences string     `json:"likely_consequences"`
+	MeasuresTaken      string     `json:"measures_taken"`
+	DataCategories     []string   `json:"data_categories"`
+	SubjectCategories  []string   `json:"subject_categories"`
+	RecordsAffected    *int64     `json:"records_affected"`
+	SubjectsAffected   *int64     `json:"subjects_affected"`
+	OccurredAt         *time.Time `json:"occurred_at"`
+	OccurredUntil      *time.Time `json:"occurred_until"`
+	AwarenessAt        *time.Time `json:"awareness_at"`
+	LeadSA             *string    `json:"lead_sa"`
+	Note               string     `json:"note"`
+}
+
+// UpdateInput is the patch payload. Nil pointer = leave unchanged; setting
+// an empty string explicitly is treated as "clear" (caller intent is clear
+// from JSON-present-vs-absent in the handler).
+type UpdateInput struct {
+	Title              *string    `json:"title,omitempty"`
+	Description        *string    `json:"description,omitempty"`
+	LikelyConsequences *string    `json:"likely_consequences,omitempty"`
+	MeasuresTaken      *string    `json:"measures_taken,omitempty"`
+	DataCategories     []string   `json:"data_categories,omitempty"`
+	SubjectCategories  []string   `json:"subject_categories,omitempty"`
+	RecordsAffected    *int64     `json:"records_affected,omitempty"`
+	SubjectsAffected   *int64     `json:"subjects_affected,omitempty"`
+	ContainedAt        *time.Time `json:"contained_at,omitempty"`
+	LeadSA             *string    `json:"lead_sa,omitempty"`
+	Status             *string    `json:"status,omitempty"`
+	Note               string     `json:"note"`
+}
+
+// Metrics is the interface the breach service uses to emit MTTD/MTTR
+// observations. The metrics package implements it.
+type Metrics interface {
+	ObserveBreachMTTD(seconds float64)
+	ObserveBreachMTTR(seconds float64)
+	IncBreachOpened()
+	IncBreachClosed(status string)
+}
+
+// Service is the breach-register service.
+type Service struct {
+	pool     *pgxpool.Pool
+	auditSvc *audit.Service
+	metrics  Metrics
+}
+
+// NewService creates a breach service. metrics may be nil in dev/test.
+func NewService(pool *pgxpool.Pool, auditSvc *audit.Service, m Metrics) *Service {
+	return &Service{pool: pool, auditSvc: auditSvc, metrics: m}
+}
+
+// Open inserts the first row for a new incident and returns the snapshot.
+// The caller (handler) supplies actor identity from auth context.
+func (s *Service) Open(ctx context.Context, in OpenInput, actorID, actorEmail string) (*Entry, error) {
+	if in.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	awareness := time.Now().UTC()
+	if in.AwarenessAt != nil {
+		awareness = in.AwarenessAt.UTC()
+	}
+
+	var incidentID string
+	if err := s.pool.QueryRow(ctx, `SELECT gen_random_uuid()::text`).Scan(&incidentID); err != nil {
+		return nil, fmt.Errorf("allocate incident id: %w", err)
+	}
+	e := Entry{
+		IncidentID:         incidentID,
+		ProjectID:          in.ProjectID,
+		AffectsPlatform:    in.AffectsPlatform,
+		Title:              in.Title,
+		Description:        in.Description,
+		LikelyConsequences: in.LikelyConsequences,
+		MeasuresTaken:      in.MeasuresTaken,
+		DataCategories:     nonNil(in.DataCategories),
+		SubjectCategories:  nonNil(in.SubjectCategories),
+		RecordsAffected:    in.RecordsAffected,
+		SubjectsAffected:   in.SubjectsAffected,
+		OccurredAt:         in.OccurredAt,
+		OccurredUntil:      in.OccurredUntil,
+		AwarenessAt:        awareness,
+		LeadSA:             in.LeadSA,
+		Status:             StatusOpen,
+		ActorID:            optStr(actorID),
+		ActorEmail:         actorEmail,
+		Note:               in.Note,
+		Metadata:           []byte("{}"),
+	}
+	if in.OccurredAt != nil {
+		// MTTD is "time from breach occurrence to awareness". The DPO
+		// confirms the breach window; we record what we know now.
+		secs := int64(awareness.Sub(in.OccurredAt.UTC()).Seconds())
+		if secs >= 0 {
+			e.MTTDSeconds = &secs
+		}
+	}
+	if err := s.insert(ctx, &e); err != nil {
+		return nil, err
+	}
+	if s.metrics != nil {
+		s.metrics.IncBreachOpened()
+		if e.MTTDSeconds != nil {
+			s.metrics.ObserveBreachMTTD(float64(*e.MTTDSeconds))
+		}
+	}
+	s.auditLog(ctx, &e, audit.ActionBreachOpened)
+	return &e, nil
+}
+
+// Update writes a new snapshot row for an incident with the requested
+// changes applied. Status may transition forward only via this call;
+// terminal transitions (closed / no_action) go through Close().
+func (s *Service) Update(ctx context.Context, incidentID string, in UpdateInput, actorID, actorEmail string) (*Entry, error) {
+	latest, err := s.Latest(ctx, incidentID)
+	if err != nil {
+		return nil, err
+	}
+	if latest == nil {
+		return nil, fmt.Errorf("incident not found")
+	}
+	if latest.Status == StatusClosed || latest.Status == StatusNoAction {
+		return nil, fmt.Errorf("incident is closed; reopen requires a new incident")
+	}
+
+	next := *latest
+	next.ID = ""
+	next.Seq = 0
+	next.ActorID = optStr(actorID)
+	next.ActorEmail = actorEmail
+	next.Note = in.Note
+
+	if in.Title != nil {
+		next.Title = *in.Title
+	}
+	if in.Description != nil {
+		next.Description = *in.Description
+	}
+	if in.LikelyConsequences != nil {
+		next.LikelyConsequences = *in.LikelyConsequences
+	}
+	if in.MeasuresTaken != nil {
+		next.MeasuresTaken = *in.MeasuresTaken
+	}
+	if in.DataCategories != nil {
+		next.DataCategories = in.DataCategories
+	}
+	if in.SubjectCategories != nil {
+		next.SubjectCategories = in.SubjectCategories
+	}
+	if in.RecordsAffected != nil {
+		next.RecordsAffected = in.RecordsAffected
+	}
+	if in.SubjectsAffected != nil {
+		next.SubjectsAffected = in.SubjectsAffected
+	}
+	if in.ContainedAt != nil {
+		next.ContainedAt = in.ContainedAt
+	}
+	if in.LeadSA != nil {
+		next.LeadSA = in.LeadSA
+	}
+	if in.Status != nil {
+		if *in.Status == StatusClosed || *in.Status == StatusNoAction {
+			return nil, fmt.Errorf("use /close to terminate an incident")
+		}
+		next.Status = *in.Status
+	}
+
+	if err := s.insert(ctx, &next); err != nil {
+		return nil, err
+	}
+	s.auditLog(ctx, &next, audit.ActionBreachUpdated)
+	return &next, nil
+}
+
+// MarkNotification stamps either the customer or authority notification on
+// a new register row. `kind` is "customers", "authority", or "subjects".
+func (s *Service) MarkNotification(ctx context.Context, incidentID, kind, leadSA, note, actorID, actorEmail string) (*Entry, error) {
+	latest, err := s.Latest(ctx, incidentID)
+	if err != nil {
+		return nil, err
+	}
+	if latest == nil {
+		return nil, fmt.Errorf("incident not found")
+	}
+
+	next := *latest
+	next.ID = ""
+	next.Seq = 0
+	next.ActorID = optStr(actorID)
+	next.ActorEmail = actorEmail
+	next.Note = note
+	now := time.Now().UTC()
+
+	switch kind {
+	case "customers":
+		next.NotifiedCustomers = true
+		next.NotifiedCustomersAt = &now
+		next.Status = StatusNotifiedCustomers
+	case "authority":
+		next.NotifiedAuthority = true
+		next.NotifiedAuthorityAt = &now
+		if leadSA != "" {
+			next.LeadSA = &leadSA
+		}
+		next.Status = StatusNotifiedAuthority
+	case "subjects":
+		next.NotifiedSubjects = true
+		next.NotifiedSubjectsAt = &now
+	default:
+		return nil, fmt.Errorf("unknown notification kind: %s", kind)
+	}
+
+	if err := s.insert(ctx, &next); err != nil {
+		return nil, err
+	}
+	action := audit.ActionBreachNotifiedCustomers
+	if kind == "authority" {
+		action = audit.ActionBreachNotifiedAuthority
+	} else if kind == "subjects" {
+		action = audit.ActionBreachNotifiedSubjects
+	}
+	s.auditLog(ctx, &next, action)
+	return &next, nil
+}
+
+// Close writes a terminal row. `terminalStatus` must be "closed" or
+// "no_action". MTTR is computed from awareness_at → resolved_at (now).
+func (s *Service) Close(ctx context.Context, incidentID, terminalStatus, note, actorID, actorEmail string) (*Entry, error) {
+	if terminalStatus != StatusClosed && terminalStatus != StatusNoAction {
+		return nil, fmt.Errorf("terminal status must be 'closed' or 'no_action'")
+	}
+	latest, err := s.Latest(ctx, incidentID)
+	if err != nil {
+		return nil, err
+	}
+	if latest == nil {
+		return nil, fmt.Errorf("incident not found")
+	}
+	if latest.Status == StatusClosed || latest.Status == StatusNoAction {
+		return latest, nil
+	}
+
+	now := time.Now().UTC()
+	next := *latest
+	next.ID = ""
+	next.Seq = 0
+	next.ActorID = optStr(actorID)
+	next.ActorEmail = actorEmail
+	next.Note = note
+	next.Status = terminalStatus
+	next.ResolvedAt = &now
+
+	mttr := int64(now.Sub(latest.AwarenessAt).Seconds())
+	if mttr < 0 {
+		mttr = 0
+	}
+	next.MTTRSeconds = &mttr
+
+	if err := s.insert(ctx, &next); err != nil {
+		return nil, err
+	}
+	if s.metrics != nil {
+		s.metrics.IncBreachClosed(terminalStatus)
+		s.metrics.ObserveBreachMTTR(float64(mttr))
+	}
+	s.auditLog(ctx, &next, audit.ActionBreachClosed)
+	return &next, nil
+}
+
+// Latest returns the most recent snapshot row for an incident, or nil if
+// the incident does not exist.
+func (s *Service) Latest(ctx context.Context, incidentID string) (*Entry, error) {
+	const q = `SELECT ` + entryCols + `
+	             FROM public.breach_register
+	            WHERE incident_id = $1
+	         ORDER BY seq DESC LIMIT 1`
+	row := s.pool.QueryRow(ctx, q, incidentID)
+	e, err := scanEntry(row)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	return e, err
+}
+
+// History returns every row written for an incident, oldest first.
+func (s *Service) History(ctx context.Context, incidentID string) ([]Entry, error) {
+	const q = `SELECT ` + entryCols + `
+	             FROM public.breach_register
+	            WHERE incident_id = $1
+	         ORDER BY seq ASC`
+	rows, err := s.pool.Query(ctx, q, incidentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanEntries(rows)
+}
+
+// ListLatest returns the latest snapshot per incident, optionally scoped to
+// a project. When projectID is empty, returns platform-wide incidents.
+func (s *Service) ListLatest(ctx context.Context, projectID string, limit int) ([]Entry, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	// DISTINCT ON (incident_id) ORDER BY incident_id, seq DESC picks the
+	// latest row per incident; the outer query reorders by awareness_at.
+	const tmpl = `SELECT * FROM (
+	                SELECT DISTINCT ON (incident_id) ` + entryCols + `
+	                  FROM public.breach_register
+	                 WHERE ($1::uuid IS NULL OR project_id = $1::uuid)
+	              ORDER BY incident_id, seq DESC
+	              ) latest
+	              ORDER BY awareness_at DESC
+	              LIMIT $2`
+	var arg interface{}
+	if projectID != "" {
+		arg = projectID
+	}
+	rows, err := s.pool.Query(ctx, tmpl, arg, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanEntries(rows)
+}
+
+// ── internal ──────────────────────────────────────────────────────────────
+
+const entryCols = `id, incident_id, seq, project_id, affects_platform,
+       title, description, likely_consequences, measures_taken,
+       data_categories, subject_categories, records_affected, subjects_affected,
+       occurred_at, occurred_until, awareness_at, contained_at, resolved_at,
+       notified_authority, notified_authority_at, notified_customers, notified_customers_at,
+       notified_subjects, notified_subjects_at, lead_sa,
+       mttd_seconds, mttr_seconds, status,
+       actor_id, actor_email, note, metadata, created_at`
+
+func (s *Service) insert(ctx context.Context, e *Entry) error {
+	meta := e.Metadata
+	if len(meta) == 0 {
+		meta = []byte("{}")
+	}
+	const q = `INSERT INTO public.breach_register
+		(incident_id, project_id, affects_platform,
+		 title, description, likely_consequences, measures_taken,
+		 data_categories, subject_categories, records_affected, subjects_affected,
+		 occurred_at, occurred_until, awareness_at, contained_at, resolved_at,
+		 notified_authority, notified_authority_at, notified_customers, notified_customers_at,
+		 notified_subjects, notified_subjects_at, lead_sa,
+		 mttd_seconds, mttr_seconds, status,
+		 actor_id, actor_email, note, metadata)
+		VALUES ($1, $2, $3,
+		        $4, $5, $6, $7,
+		        $8, $9, $10, $11,
+		        $12, $13, $14, $15, $16,
+		        $17, $18, $19, $20,
+		        $21, $22, $23,
+		        $24, $25, $26,
+		        $27, $28, $29, $30)
+		RETURNING id, seq, created_at`
+	return s.pool.QueryRow(ctx, q,
+		e.IncidentID, e.ProjectID, e.AffectsPlatform,
+		e.Title, e.Description, e.LikelyConsequences, e.MeasuresTaken,
+		e.DataCategories, e.SubjectCategories, e.RecordsAffected, e.SubjectsAffected,
+		e.OccurredAt, e.OccurredUntil, e.AwarenessAt, e.ContainedAt, e.ResolvedAt,
+		e.NotifiedAuthority, e.NotifiedAuthorityAt, e.NotifiedCustomers, e.NotifiedCustomersAt,
+		e.NotifiedSubjects, e.NotifiedSubjectsAt, e.LeadSA,
+		e.MTTDSeconds, e.MTTRSeconds, e.Status,
+		e.ActorID, e.ActorEmail, e.Note, meta,
+	).Scan(&e.ID, &e.Seq, &e.CreatedAt)
+}
+
+// rowScanner accepts both pgx.Row and pgx.Rows so scanEntry/scanEntries share
+// the same field list.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanEntry(r rowScanner) (*Entry, error) {
+	var e Entry
+	var meta []byte
+	if err := r.Scan(
+		&e.ID, &e.IncidentID, &e.Seq, &e.ProjectID, &e.AffectsPlatform,
+		&e.Title, &e.Description, &e.LikelyConsequences, &e.MeasuresTaken,
+		&e.DataCategories, &e.SubjectCategories, &e.RecordsAffected, &e.SubjectsAffected,
+		&e.OccurredAt, &e.OccurredUntil, &e.AwarenessAt, &e.ContainedAt, &e.ResolvedAt,
+		&e.NotifiedAuthority, &e.NotifiedAuthorityAt, &e.NotifiedCustomers, &e.NotifiedCustomersAt,
+		&e.NotifiedSubjects, &e.NotifiedSubjectsAt, &e.LeadSA,
+		&e.MTTDSeconds, &e.MTTRSeconds, &e.Status,
+		&e.ActorID, &e.ActorEmail, &e.Note, &meta, &e.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if len(meta) == 0 {
+		meta = []byte("{}")
+	}
+	e.Metadata = meta
+	return &e, nil
+}
+
+func scanEntries(rows pgx.Rows) ([]Entry, error) {
+	out := make([]Entry, 0)
+	for rows.Next() {
+		e, err := scanEntry(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *e)
+	}
+	return out, rows.Err()
+}
+
+// auditLog mirrors compliance/export's pattern: the breach service emits its
+// own audit-log entry on every register write so a tampered register can be
+// cross-checked against the chained audit_log.
+func (s *Service) auditLog(ctx context.Context, e *Entry, action string) {
+	if s.auditSvc == nil {
+		return
+	}
+	projectID := ""
+	if e.ProjectID != nil {
+		projectID = *e.ProjectID
+	}
+	actorID := ""
+	if e.ActorID != nil {
+		actorID = *e.ActorID
+	}
+	meta := map[string]any{
+		"incident_id": e.IncidentID,
+		"status":      e.Status,
+	}
+	if e.MTTDSeconds != nil {
+		meta["mttd_seconds"] = *e.MTTDSeconds
+	}
+	if e.MTTRSeconds != nil {
+		meta["mttr_seconds"] = *e.MTTRSeconds
+	}
+	s.auditSvc.Log(ctx, projectID, actorID, e.ActorEmail, action,
+		audit.WithTarget("breach", e.IncidentID),
+		audit.WithMetadata(meta))
+	slog.Info("breach register write", "incident_id", e.IncidentID, "action", action, "status", e.Status)
+}
+
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/breach/service.go
+++ b/internal/breach/service.go
@@ -187,8 +187,14 @@ func (s *Service) Open(ctx context.Context, in OpenInput, actorID, actorEmail st
 // Update writes a new snapshot row for an incident with the requested
 // changes applied. Status may transition forward only via this call;
 // terminal transitions (closed / no_action) go through Close().
-func (s *Service) Update(ctx context.Context, incidentID string, in UpdateInput, actorID, actorEmail string) (*Entry, error) {
-	latest, err := s.Latest(ctx, incidentID)
+//
+// projectID scopes the lookup at the SQL layer (PR #219 review). An empty
+// projectID is treated as "platform-only" and only matches incidents with
+// NULL project_id; this is a platform-admin code path and the per-project
+// route forbids it. A tenant admin of project A reaching for project B's
+// {incidentId} returns "incident not found".
+func (s *Service) Update(ctx context.Context, projectID, incidentID string, in UpdateInput, actorID, actorEmail string) (*Entry, error) {
+	latest, err := s.Latest(ctx, projectID, incidentID)
 	if err != nil {
 		return nil, err
 	}
@@ -252,8 +258,9 @@ func (s *Service) Update(ctx context.Context, incidentID string, in UpdateInput,
 
 // MarkNotification stamps either the customer or authority notification on
 // a new register row. `kind` is "customers", "authority", or "subjects".
-func (s *Service) MarkNotification(ctx context.Context, incidentID, kind, leadSA, note, actorID, actorEmail string) (*Entry, error) {
-	latest, err := s.Latest(ctx, incidentID)
+// projectID scopes the incident lookup — see Update for the rationale.
+func (s *Service) MarkNotification(ctx context.Context, projectID, incidentID, kind, leadSA, note, actorID, actorEmail string) (*Entry, error) {
+	latest, err := s.Latest(ctx, projectID, incidentID)
 	if err != nil {
 		return nil, err
 	}
@@ -303,11 +310,12 @@ func (s *Service) MarkNotification(ctx context.Context, incidentID, kind, leadSA
 
 // Close writes a terminal row. `terminalStatus` must be "closed" or
 // "no_action". MTTR is computed from awareness_at → resolved_at (now).
-func (s *Service) Close(ctx context.Context, incidentID, terminalStatus, note, actorID, actorEmail string) (*Entry, error) {
+// projectID scopes the incident lookup — see Update for the rationale.
+func (s *Service) Close(ctx context.Context, projectID, incidentID, terminalStatus, note, actorID, actorEmail string) (*Entry, error) {
 	if terminalStatus != StatusClosed && terminalStatus != StatusNoAction {
 		return nil, fmt.Errorf("terminal status must be 'closed' or 'no_action'")
 	}
-	latest, err := s.Latest(ctx, incidentID)
+	latest, err := s.Latest(ctx, projectID, incidentID)
 	if err != nil {
 		return nil, err
 	}
@@ -346,13 +354,16 @@ func (s *Service) Close(ctx context.Context, incidentID, terminalStatus, note, a
 }
 
 // Latest returns the most recent snapshot row for an incident, or nil if
-// the incident does not exist.
-func (s *Service) Latest(ctx context.Context, incidentID string) (*Entry, error) {
-	const q = `SELECT ` + entryCols + `
-	             FROM public.breach_register
-	            WHERE incident_id = $1
-	         ORDER BY seq DESC LIMIT 1`
-	row := s.pool.QueryRow(ctx, q, incidentID)
+// the incident does not exist or is not visible at the caller's scope.
+//
+// projectID == "" matches only platform-only incidents (project_id IS NULL).
+// projectID == "<uuid>" matches only incidents owned by that project. This
+// is the SQL-layer guard against the cross-tenant IDOR called out in the
+// PR #219 review — a handler that forgets to pass projectID still gets
+// `incident not found` for any incident that doesn't sit in the NULL bucket.
+func (s *Service) Latest(ctx context.Context, projectID, incidentID string) (*Entry, error) {
+	q, args := scopedSelect(entryCols, projectID, incidentID, "seq DESC LIMIT 1")
+	row := s.pool.QueryRow(ctx, q, args...)
 	e, err := scanEntry(row)
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -360,18 +371,31 @@ func (s *Service) Latest(ctx context.Context, incidentID string) (*Entry, error)
 	return e, err
 }
 
-// History returns every row written for an incident, oldest first.
-func (s *Service) History(ctx context.Context, incidentID string) ([]Entry, error) {
-	const q = `SELECT ` + entryCols + `
-	             FROM public.breach_register
-	            WHERE incident_id = $1
-	         ORDER BY seq ASC`
-	rows, err := s.pool.Query(ctx, q, incidentID)
+// History returns every row written for an incident, oldest first. Scope
+// rules match Latest — cross-tenant lookups return an empty slice.
+func (s *Service) History(ctx context.Context, projectID, incidentID string) ([]Entry, error) {
+	q, args := scopedSelect(entryCols, projectID, incidentID, "seq ASC")
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	return scanEntries(rows)
+}
+
+// scopedSelect builds the project-scoped lookup SQL shared by Latest and
+// History. Pulled out so the IDOR guard is one fragment, not three.
+func scopedSelect(cols, projectID, incidentID, orderBy string) (string, []interface{}) {
+	if projectID == "" {
+		return `SELECT ` + cols + `
+		          FROM public.breach_register
+		         WHERE incident_id = $1 AND project_id IS NULL
+		      ORDER BY ` + orderBy, []interface{}{incidentID}
+	}
+	return `SELECT ` + cols + `
+	          FROM public.breach_register
+	         WHERE incident_id = $1 AND project_id = $2
+	      ORDER BY ` + orderBy, []interface{}{incidentID, projectID}
 }
 
 // ListLatest returns the latest snapshot per incident, optionally scoped to

--- a/internal/breach/service_test.go
+++ b/internal/breach/service_test.go
@@ -1,0 +1,124 @@
+package breach
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// setupBreachTest provisions two projects so we can exercise the
+// cross-tenant scope check (PR #219 review). Skips when no test DB.
+func setupBreachTest(t *testing.T) (*Service, string, string, *pgxpool.Pool) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = "postgres://eurobase_api:localdev@localhost:5433/eurobase?sslmode=disable"
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Skipf("cannot connect to test database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("cannot ping test database: %v", err)
+	}
+
+	hankoID := fmt.Sprintf("test-breach-%d", os.Getpid())
+	var ownerID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO platform_users (hanko_user_id, email)
+		 VALUES ($1, $2)
+		 ON CONFLICT (hanko_user_id) DO UPDATE SET email = EXCLUDED.email
+		 RETURNING id`,
+		hankoID, "breachtest@eurobase.app",
+	).Scan(&ownerID); err != nil {
+		pool.Close()
+		t.Skipf("cannot create test platform user: %v", err)
+	}
+
+	mkProject := func(slug string) string {
+		var id string
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO projects (owner_id, name, slug, schema_name, s3_bucket, region, plan, status)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, 'provisioning')
+			 RETURNING id`,
+			ownerID, slug, slug, "tenant_"+slug, "bucket-"+slug, "fr-par", "free",
+		).Scan(&id); err != nil {
+			pool.Close()
+			t.Skipf("cannot create test project %s: %v", slug, err)
+		}
+		return id
+	}
+	projA := mkProject(fmt.Sprintf("breach-a-%d", os.Getpid()))
+	projB := mkProject(fmt.Sprintf("breach-b-%d", os.Getpid()))
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		_, _ = pool.Exec(ctx, `DELETE FROM public.breach_register WHERE project_id IN ($1, $2)`, projA, projB)
+		_, _ = pool.Exec(ctx, `DELETE FROM projects WHERE id IN ($1, $2)`, projA, projB)
+		_, _ = pool.Exec(ctx, `DELETE FROM platform_users WHERE hanko_user_id = $1`, hankoID)
+		pool.Close()
+	})
+
+	return NewService(pool, nil, nil), projA, projB, pool
+}
+
+// TestService_CrossTenantLookupReturnsNotFound is the regression for the
+// PR #219 IDOR: open an incident in project A, then assert that *every*
+// project-B-scoped read or mutation comes back empty / not-found.
+func TestService_CrossTenantLookupReturnsNotFound(t *testing.T) {
+	svc, projA, projB, _ := setupBreachTest(t)
+	ctx := context.Background()
+
+	// Open a project-A-scoped incident the way HandleOpen would: caller
+	// anchors ProjectID at the URL project.
+	entry, err := svc.Open(ctx, OpenInput{
+		Title:       "A's incident",
+		Description: "scoped to project A",
+		ProjectID:   &projA,
+	}, "", "actor@a")
+	if err != nil {
+		t.Fatalf("open A: %v", err)
+	}
+	incidentA := entry.IncidentID
+
+	// Same-project lookup is the happy path.
+	if got, err := svc.Latest(ctx, projA, incidentA); err != nil || got == nil {
+		t.Fatalf("Latest(A, A's incident) = (%v, %v); want non-nil", got, err)
+	}
+	if got, err := svc.History(ctx, projA, incidentA); err != nil || len(got) == 0 {
+		t.Fatalf("History(A, A's incident) = (%d, %v); want non-empty", len(got), err)
+	}
+
+	// Cross-tenant lookups (project B reaching for A's incident) must all
+	// come back empty / not-found.
+	if got, err := svc.Latest(ctx, projB, incidentA); err != nil || got != nil {
+		t.Errorf("Latest(B, A's incident) = (%+v, %v); want (nil, nil)", got, err)
+	}
+	if got, err := svc.History(ctx, projB, incidentA); err != nil || len(got) != 0 {
+		t.Errorf("History(B, A's incident) = (%d rows, %v); want (0, nil)", len(got), err)
+	}
+	if _, err := svc.Update(ctx, projB, incidentA, UpdateInput{Note: "tamper"}, "", "evil@b"); err == nil {
+		t.Errorf("Update(B, A's incident) succeeded; want incident-not-found error")
+	}
+	if _, err := svc.MarkNotification(ctx, projB, incidentA, "customers", "", "tamper", "", "evil@b"); err == nil {
+		t.Errorf("MarkNotification(B, A's incident) succeeded; want incident-not-found error")
+	}
+	if _, err := svc.Close(ctx, projB, incidentA, StatusClosed, "tamper", "", "evil@b"); err == nil {
+		t.Errorf("Close(B, A's incident) succeeded; want incident-not-found error")
+	}
+
+	// And the register itself must still only carry A's row — no smuggled-in
+	// B-owned writes from the failed attempts above.
+	if got, err := svc.History(ctx, projA, incidentA); err != nil || len(got) != 1 {
+		t.Errorf("History(A, A's incident) after attempted cross-tenant writes = (%d rows, %v); want (1, nil)", len(got), err)
+	}
+}

--- a/internal/breach/subjects.go
+++ b/internal/breach/subjects.go
@@ -1,0 +1,157 @@
+package breach
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eurobase/euroback/internal/compliance"
+	edb "github.com/eurobase/euroback/internal/db"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SubjectQuery scopes which end-users are considered "affected" by a breach.
+// All fields are optional and combined with AND. The default (all-nil) returns
+// every user in the tenant's users table — the worst case but sometimes the
+// only honest answer. Use Limit to cap the affected_ids list returned to
+// callers; the count itself is always exact.
+type SubjectQuery struct {
+	// CreatedFrom/CreatedUntil bound the users.created_at window. Useful
+	// when the breach exposed a sign-up form or a specific batch import.
+	CreatedFrom  *time.Time
+	CreatedUntil *time.Time
+	// UpdatedFrom/UpdatedUntil bound the users.updated_at window. Useful
+	// when the breach was a leak of "active sessions" or "last-edited
+	// profiles".
+	UpdatedFrom  *time.Time
+	UpdatedUntil *time.Time
+	// UserIDs restricts to a known list of subjects (e.g. from an audit
+	// log triage). Returns count = intersection-with-tenant.
+	UserIDs []string
+	// Limit caps the size of AffectedIDs in the result. 0 = no IDs
+	// returned; -1 = unbounded. Default 100 in the handler.
+	Limit int
+}
+
+// SubjectResult is what IdentifySubjects returns. Count is the size of the
+// affected set. AffectedIDs is a sample (up to Limit) — the DPO uses it to
+// spot-check the criteria before pulling the full list for notification.
+type SubjectResult struct {
+	Count        int64    `json:"count"`
+	TablesProbed int      `json:"tables_probed"`
+	AffectedIDs  []string `json:"affected_ids"`
+	SchemaName   string   `json:"schema_name"`
+}
+
+// IdentifySubjects counts (and optionally enumerates) the end-users whose
+// records fall under a breach's scope. Reuses DiscoverUserTables /
+// ListTenantTables from compliance/export.go so we don't drift from the
+// DSAR table inventory.
+//
+// Connects through edb.RunAsService so app.end_user_role='service' is set
+// for the transaction; tenant users RLS would otherwise filter every row
+// out — there's no end-user actor here, the caller is the DPO.
+func IdentifySubjects(ctx context.Context, pool *pgxpool.Pool, projectID string, q SubjectQuery) (*SubjectResult, error) {
+	var schemaName string
+	if err := pool.QueryRow(ctx,
+		`SELECT schema_name FROM projects WHERE id = $1`, projectID,
+	).Scan(&schemaName); err != nil {
+		return nil, fmt.Errorf("resolve project schema: %w", err)
+	}
+
+	whereSQL, args := buildUserWhere(q)
+	usersQ := fmt.Sprintf(`SELECT id::text FROM %s.users%s`, quoteIdent(schemaName), whereSQL)
+	countQ := fmt.Sprintf(`SELECT COUNT(*) FROM %s.users%s`, quoteIdent(schemaName), whereSQL)
+
+	limit := q.Limit
+	if limit == 0 {
+		limit = 100
+	}
+	if limit > 0 {
+		usersQ += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	result := &SubjectResult{SchemaName: schemaName, AffectedIDs: []string{}}
+
+	tables, err := compliance.ListTenantTables(ctx, pool, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant tables: %w", err)
+	}
+	refs, err := compliance.DiscoverUserTables(ctx, pool, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("discover user tables: %w", err)
+	}
+	result.TablesProbed = len(tables) + len(refs)
+
+	err = edb.RunAsService(ctx, pool, func(ctx context.Context, tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, countQ, args...).Scan(&result.Count); err != nil {
+			return fmt.Errorf("count affected subjects: %w", err)
+		}
+		if limit == 0 {
+			return nil
+		}
+		rows, err := tx.Query(ctx, usersQ, args...)
+		if err != nil {
+			return fmt.Errorf("query affected subjects: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			result.AffectedIDs = append(result.AffectedIDs, id)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// buildUserWhere assembles the WHERE clause for the users-table count and
+// sample queries from a SubjectQuery. Returns the SQL fragment (starting
+// with " WHERE", or empty) and positional args.
+func buildUserWhere(q SubjectQuery) (string, []interface{}) {
+	var conds []string
+	var args []interface{}
+	idx := 1
+
+	if q.CreatedFrom != nil {
+		conds = append(conds, fmt.Sprintf("created_at >= $%d", idx))
+		args = append(args, q.CreatedFrom.UTC())
+		idx++
+	}
+	if q.CreatedUntil != nil {
+		conds = append(conds, fmt.Sprintf("created_at <= $%d", idx))
+		args = append(args, q.CreatedUntil.UTC())
+		idx++
+	}
+	if q.UpdatedFrom != nil {
+		conds = append(conds, fmt.Sprintf("updated_at >= $%d", idx))
+		args = append(args, q.UpdatedFrom.UTC())
+		idx++
+	}
+	if q.UpdatedUntil != nil {
+		conds = append(conds, fmt.Sprintf("updated_at <= $%d", idx))
+		args = append(args, q.UpdatedUntil.UTC())
+		idx++
+	}
+	if len(q.UserIDs) > 0 {
+		conds = append(conds, fmt.Sprintf("id::text = ANY($%d)", idx))
+		args = append(args, q.UserIDs)
+		idx++
+	}
+
+	if len(conds) == 0 {
+		return "", args
+	}
+	return " WHERE " + strings.Join(conds, " AND "), args
+}
+
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/internal/breach/subjects_test.go
+++ b/internal/breach/subjects_test.go
@@ -1,0 +1,67 @@
+package breach
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildUserWhere_EmptyQuery(t *testing.T) {
+	w, args := buildUserWhere(SubjectQuery{})
+	if w != "" {
+		t.Errorf("expected empty WHERE, got %q", w)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %d", len(args))
+	}
+}
+
+func TestBuildUserWhere_AllFilters(t *testing.T) {
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	upFrom := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	upUntil := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	q := SubjectQuery{
+		CreatedFrom:  &from,
+		CreatedUntil: &until,
+		UpdatedFrom:  &upFrom,
+		UpdatedUntil: &upUntil,
+		UserIDs:      []string{"id-1", "id-2"},
+	}
+	w, args := buildUserWhere(q)
+
+	// All five predicates should be present, positional args numbered 1..5
+	// in declaration order.
+	for _, want := range []string{
+		"created_at >= $1",
+		"created_at <= $2",
+		"updated_at >= $3",
+		"updated_at <= $4",
+		"id::text = ANY($5)",
+	} {
+		if !strings.Contains(w, want) {
+			t.Errorf("WHERE missing %q\ngot: %s", want, w)
+		}
+	}
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d", len(args))
+	}
+	// Times are normalised to UTC by the builder so callers in other zones
+	// don't change the query plan.
+	if got := args[0].(time.Time); got.Location() != time.UTC {
+		t.Errorf("arg 0 not UTC: %v", got)
+	}
+	if got, ok := args[4].([]string); !ok || len(got) != 2 {
+		t.Errorf("arg 4 not []string of len 2: %T %v", args[4], args[4])
+	}
+}
+
+func TestBuildUserWhere_OnlyUserIDs(t *testing.T) {
+	w, args := buildUserWhere(SubjectQuery{UserIDs: []string{"a"}})
+	if w != " WHERE id::text = ANY($1)" {
+		t.Errorf("unexpected WHERE: %q", w)
+	}
+	if len(args) != 1 {
+		t.Errorf("expected 1 arg, got %d", len(args))
+	}
+}

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eurobase/euroback/internal/audit"
 	"github.com/eurobase/euroback/internal/auth"
+	"github.com/eurobase/euroback/internal/breach"
 	"github.com/eurobase/euroback/internal/compliance"
 	"github.com/eurobase/euroback/internal/cron"
 	"github.com/eurobase/euroback/internal/email"
@@ -338,6 +339,31 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, migrationExec *q
 			r.With(tenant.RequireMinRole("admin")).Post("/compliance/user-export", compliance.HandleRequestUserExport(exportSvc))
 			r.With(tenant.RequireMinRole("admin")).Get("/compliance/exports", compliance.HandleListExports(exportSvc))
 			r.With(tenant.RequireMinRole("admin")).Get("/compliance/exports/{exportId}", compliance.HandleGetExport(exportSvc))
+
+			// Breach register (Tier-1 #4, closes #172). Append-only by
+			// migration 000065. Admin-only because the register names
+			// affected subjects and triggers customer/authority comms.
+			// DPO_EMAIL drives the "point of contact" in templates;
+			// defaults to dpo@eurobase.app if unset.
+			dpoEmail := os.Getenv("DPO_EMAIL")
+			if dpoEmail == "" {
+				dpoEmail = "dpo@eurobase.app"
+			}
+			var breachMailer breach.Mailer
+			if emailService != nil {
+				breachMailer = &breach.MailerAdapter{Svc: emailService}
+			}
+			breachSvc := breach.NewService(pool, auditSvc, metricsReg)
+			breachH := &breach.Handler{Svc: breachSvc, Pool: pool, Mailer: breachMailer, DPOEmail: dpoEmail}
+			r.With(tenant.RequireMinRole("admin")).Get("/compliance/breaches", breachH.HandleList())
+			r.With(tenant.RequireMinRole("admin")).Post("/compliance/breaches", breachH.HandleOpen())
+			r.With(tenant.RequireMinRole("admin")).Get("/compliance/breaches/{incidentId}", breachH.HandleGet())
+			r.With(tenant.RequireMinRole("admin")).Patch("/compliance/breaches/{incidentId}", breachH.HandleUpdate())
+			r.With(tenant.RequireMinRole("admin")).Post("/compliance/breaches/{incidentId}/close", breachH.HandleClose())
+			r.With(tenant.RequireMinRole("admin")).Post("/compliance/breaches/{incidentId}/subjects", breachH.HandleSubjects())
+			r.With(tenant.RequireMinRole("admin")).Post("/compliance/breaches/{incidentId}/notify-customers", breachH.HandleNotifyCustomers())
+			r.With(tenant.RequireMinRole("admin")).Post("/compliance/breaches/{incidentId}/authority-form", breachH.HandleAuthorityForm())
+			r.With(tenant.RequireMinRole("admin")).Get("/compliance/breaches/{incidentId}/sla", breachH.HandleSLAStatus())
 
 			// Team members (invite, remove, change role).
 			var sendEmailFn func(ctx context.Context, to, subject, html string) error

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -34,6 +34,16 @@ type Registry struct {
 	panicsTotal      prometheus.Counter
 	buildInfo        *prometheus.GaugeVec
 	ExportsTotal     *prometheus.CounterVec
+
+	// Tier-1 #4 (issue #172) — breach register MTTD/MTTR. Histograms so
+	// dashboards can show distribution; counters labelled by terminal
+	// status so closed-vs-no_action splits are visible. Buckets are
+	// chosen for the DPA SLAs (24h customers, 72h authority): finer
+	// resolution under 24h, coarser above 72h.
+	breachOpenedTotal *prometheus.CounterVec
+	breachClosedTotal *prometheus.CounterVec
+	breachMTTD        prometheus.Histogram
+	breachMTTR        prometheus.Histogram
 }
 
 // New creates and registers all gateway metrics.
@@ -57,9 +67,41 @@ func New(buildVersion string) *Registry {
 	)
 	reg.MustRegister(exportsTotal)
 
+	breachOpenedTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eurobase_breach_opened_total",
+			Help: "Total personal-data breach incidents opened (GDPR Art. 33 register).",
+		},
+		[]string{},
+	)
+	breachClosedTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eurobase_breach_closed_total",
+			Help: "Total personal-data breach incidents closed, labelled by terminal status (closed vs no_action).",
+		},
+		[]string{"status"},
+	)
+	// Buckets: 5m, 30m, 1h, 4h, 12h, 24h (DPA §10), 48h, 72h (Art. 33), 7d, 30d.
+	breachBuckets := []float64{300, 1800, 3600, 14400, 43200, 86400, 172800, 259200, 604800, 2592000}
+	breachMTTD := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "eurobase_breach_mttd_seconds",
+		Help:    "Personal-data breach mean-time-to-detect: seconds from occurred_at to awareness_at.",
+		Buckets: breachBuckets,
+	})
+	breachMTTR := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "eurobase_breach_mttr_seconds",
+		Help:    "Personal-data breach mean-time-to-resolve: seconds from awareness_at to resolved_at.",
+		Buckets: breachBuckets,
+	})
+	reg.MustRegister(breachOpenedTotal, breachClosedTotal, breachMTTD, breachMTTR)
+
 	r := &Registry{
-		reg:          reg,
-		ExportsTotal: exportsTotal,
+		reg:               reg,
+		ExportsTotal:      exportsTotal,
+		breachOpenedTotal: breachOpenedTotal,
+		breachClosedTotal: breachClosedTotal,
+		breachMTTD:        breachMTTD,
+		breachMTTR:        breachMTTR,
 		requestsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "eurobase_http_requests_total",
@@ -124,6 +166,28 @@ func (r *Registry) Handler() http.Handler {
 // IncPanic increments the panic counter. Call this from your recover middleware.
 func (r *Registry) IncPanic() {
 	r.panicsTotal.Inc()
+}
+
+// IncBreachOpened increments the breach-opened counter. Called from
+// internal/breach.Service.Open. Implements the breach.Metrics interface.
+func (r *Registry) IncBreachOpened() {
+	r.breachOpenedTotal.WithLabelValues().Inc()
+}
+
+// IncBreachClosed increments the breach-closed counter for a terminal
+// status ("closed" or "no_action").
+func (r *Registry) IncBreachClosed(status string) {
+	r.breachClosedTotal.WithLabelValues(status).Inc()
+}
+
+// ObserveBreachMTTD records a mean-time-to-detect sample in seconds.
+func (r *Registry) ObserveBreachMTTD(seconds float64) {
+	r.breachMTTD.Observe(seconds)
+}
+
+// ObserveBreachMTTR records a mean-time-to-resolve sample in seconds.
+func (r *Registry) ObserveBreachMTTR(seconds float64) {
+	r.breachMTTR.Observe(seconds)
 }
 
 // Middleware records request count, latency, and in-flight count for every

--- a/migrations/000065_breach_register.down.sql
+++ b/migrations/000065_breach_register.down.sql
@@ -1,0 +1,2 @@
+-- 000065_breach_register.down.sql
+DROP TABLE IF EXISTS public.breach_register;

--- a/migrations/000065_breach_register.up.sql
+++ b/migrations/000065_breach_register.up.sql
@@ -1,0 +1,119 @@
+-- 000065_breach_register.up.sql
+--
+-- Tier-1 GDPR #4 (breach notification workflow — Art. 33/34). Creates the
+-- append-only register of personal-data breaches the DPO is required to
+-- maintain under Art. 33(5), including breaches that we judged NOT to be
+-- notifiable. Surfaced in the console at Compliance → Breaches and
+-- exposed on /platform/projects/{id}/compliance/breaches.
+--
+-- Append-only by the same pattern as audit_log (#171, migration 000058):
+-- the runtime roles get INSERT + SELECT only. UPDATE/DELETE are revoked
+-- from eurobase_gateway (the real DB user the breach service connects
+-- as). State transitions write a NEW row tying back to incident_id so
+-- "edits" remain auditable. The independent off-box WORM dump (#171)
+-- catches a compromised gateway forging fresh appends.
+--
+-- Schema choices:
+--   * incident_id groups every row that belongs to one incident
+--     (open → updated → notified → closed). This is what gives us
+--     append-only semantics for what would otherwise be UPDATE.
+--   * `status` mirrors the runbook state machine: open / contained /
+--     notified_customers / notified_authority / closed / no_action
+--     (the last for the "logged but did not notify" case the runbook
+--     calls out — Art. 33(5) requires keeping the record either way).
+--   * Categories of data and data subjects are TEXT[] so the report
+--     can group by both without forcing a controlled vocabulary up
+--     front. The DPO writes them in human-readable form.
+--   * mttd_seconds = (awareness_at - occurred_at).
+--     mttr_seconds = (resolved_at - awareness_at).
+--     Both are stored, not computed, because the closing row may set
+--     them while earlier rows leave them NULL. The DPO confirms.
+--   * notified_authority_at and notified_customers_at are the
+--     timestamps of the Art. 33 and DPA §10 notifications. SLA
+--     dashboards subtract these from awareness_at to detect breach of
+--     the 72h / 24h commitments.
+--   * lead_sa carries the supervisory authority code (e.g. "fr-cnil",
+--     "de-bayern"). Default for unbreached incidents stays NULL.
+--
+-- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its own tx.
+
+CREATE TABLE public.breach_register (
+    id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    incident_id              UUID NOT NULL,
+    seq                      BIGSERIAL NOT NULL,
+
+    -- Scope
+    project_id               UUID REFERENCES public.projects(id) ON DELETE SET NULL,
+    affects_platform         BOOLEAN NOT NULL DEFAULT false,
+
+    -- Art. 33(3)/(5) substantive fields
+    title                    TEXT NOT NULL,
+    description              TEXT NOT NULL DEFAULT '',
+    likely_consequences      TEXT NOT NULL DEFAULT '',
+    measures_taken           TEXT NOT NULL DEFAULT '',
+    data_categories          TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    subject_categories       TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    records_affected         BIGINT,
+    subjects_affected        BIGINT,
+
+    -- Timeline (Art. 33 SLAs are anchored to awareness_at, not occurred_at)
+    occurred_at              TIMESTAMPTZ,
+    occurred_until           TIMESTAMPTZ,
+    awareness_at             TIMESTAMPTZ NOT NULL,
+    contained_at             TIMESTAMPTZ,
+    resolved_at              TIMESTAMPTZ,
+
+    -- Notification state
+    notified_authority       BOOLEAN NOT NULL DEFAULT false,
+    notified_authority_at    TIMESTAMPTZ,
+    notified_customers       BOOLEAN NOT NULL DEFAULT false,
+    notified_customers_at    TIMESTAMPTZ,
+    notified_subjects        BOOLEAN NOT NULL DEFAULT false,
+    notified_subjects_at     TIMESTAMPTZ,
+    lead_sa                  TEXT,
+
+    -- MTTD/MTTR
+    mttd_seconds             BIGINT,
+    mttr_seconds             BIGINT,
+
+    -- State machine
+    status                   TEXT NOT NULL DEFAULT 'open'
+                                 CHECK (status IN ('open', 'contained', 'notified_customers',
+                                                   'notified_authority', 'closed', 'no_action')),
+
+    -- Actor + free-form context (JSON for forward compat)
+    actor_id                 UUID,
+    actor_email              TEXT NOT NULL DEFAULT '',
+    note                     TEXT NOT NULL DEFAULT '',
+    metadata                 JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One row per incident is the "head" (status differentiates open vs closed
+-- snapshots); list/UI queries always pull the latest seq per incident.
+CREATE INDEX idx_breach_register_incident ON public.breach_register(incident_id, seq DESC);
+CREATE INDEX idx_breach_register_project ON public.breach_register(project_id, created_at DESC);
+CREATE INDEX idx_breach_register_status ON public.breach_register(status)
+    WHERE status IN ('open', 'contained');
+CREATE INDEX idx_breach_register_awareness ON public.breach_register(awareness_at DESC);
+
+ALTER TABLE public.breach_register OWNER TO eurobase_migrator;
+
+-- Runtime: gateway INSERTs and SELECTs; UPDATE/DELETE revoked to keep the
+-- register tamper-resistant (same pattern as audit_log in 000058). The
+-- developer role inherits migrator privileges via SET LOCAL ROLE in the
+-- developer path, so platform writes go through migrator regardless;
+-- defense-in-depth REVOKE is below.
+GRANT SELECT, INSERT ON public.breach_register TO eurobase_gateway;
+GRANT USAGE, SELECT ON SEQUENCE public.breach_register_seq_seq TO eurobase_gateway;
+
+REVOKE UPDATE, DELETE ON public.breach_register FROM eurobase_gateway;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'eurobase_developer') THEN
+        EXECUTE 'GRANT SELECT, INSERT ON public.breach_register TO eurobase_developer';
+        EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE public.breach_register_seq_seq TO eurobase_developer';
+        EXECUTE 'REVOKE UPDATE, DELETE ON public.breach_register FROM eurobase_developer';
+    END IF;
+END$$;


### PR DESCRIPTION
Closes #172.

## Summary

Operationalises the Art. 33/34 + DPA §10 breach workflow that the runbook
described but nothing tracked, dispatched, or measured.

- **`migrations/000065_breach_register`** — `public.breach_register`,
  append-only on the `audit_log` pattern (REVOKE UPDATE/DELETE from
  runtime roles); every state change writes a NEW row keyed by
  `incident_id`. Columns cover every Art. 33(3)/(5) bullet plus
  `mttd_seconds` / `mttr_seconds`.
- **`internal/breach/`** — service (Open / Update / MarkNotification /
  Close / Latest / History / ListLatest), subject identification
  (reuses `compliance.DiscoverUserTables` + `ListTenantTables` via
  `edb.RunAsService` so tenant `users` RLS doesn't silently zero the
  count), customer-HTML + authority-Markdown templates, admin HTTP
  handler.
- **`internal/metrics`** — `eurobase_breach_opened_total`,
  `eurobase_breach_closed_total{status}`, and MTTD/MTTR histograms
  bucketed for the SLA boundaries (5m, 30m, 1h, 4h, 12h, **24h**, 48h,
  **72h**, 7d, 30d).
- **`internal/audit`** — 7 new `breach.*` action constants. Every
  register write also emits a chained `audit_log` entry so a tampered
  register can be cross-checked against the hash chain.
- **Runbook + docs** — `docs/runbooks/breach-notification.md`
  placeholders filled (CNIL, portal URL, register location, on-call),
  customer + authority templates written, `docs/compliance/breach-register.md`
  documents the data model + HTTP surface.

## Routes (admin-gated)

Mounted under `/platform/projects/{id}/compliance/breaches`:

| Method | Path | Purpose |
| ------ | ---- | ------- |
| GET | `/` | List latest snapshot per incident. |
| POST | `/` | Open a new incident. |
| GET | `/{incidentId}` | Latest + full append-only history. |
| PATCH | `/{incidentId}` | Apply a partial change as a new snapshot. |
| POST | `/{incidentId}/close` | Terminal `closed` or `no_action`; computes MTTR. |
| POST | `/{incidentId}/subjects` | Count + capped sample of affected end-users. |
| POST | `/{incidentId}/notify-customers` | Render + BCC the customer email; records the dispatch. |
| POST | `/{incidentId}/authority-form` | Render the SA paste-in; `{\"filed\": true}` records the SA filing. |
| GET | `/{incidentId}/sla` | Current state of the 24h / 72h clocks. |

## Go-live blockers (added to runbook pre-flight)

- Migration `000065` applied in prod; `eurobase_gateway` retains only
  SELECT + INSERT.
- `DPO_EMAIL` env var set on the gateway Deployment (defaults to
  `dpo@eurobase.app` if unset).
- CNIL portal URL confirmed + DPO account verified.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test -short ./internal/breach/... ./internal/metrics/... ./internal/audit/... ./internal/gateway/... ./internal/compliance/...` — all pass.
- [ ] In staging: apply `000065`, open synthetic incident, verify
      `eurobase_breach_opened_total` increments and `mttd_seconds` is
      populated when `occurred_at` is supplied.
- [ ] In staging: POST `/subjects` against a seeded tenant returns
      count + capped IDs and audits as `breach.subjects_identified`.
- [ ] In staging: POST `/notify-customers` BCCs the rendered template
      to a test inbox; new register row stamped with
      `notified_customers_at`, status = `notified_customers`.
- [ ] In staging: POST `/close` computes MTTR and emits the histogram
      observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)