### PR TITLE
ops: TLS cert monitor + runbook (post-incident 2026-06-24)

### DIFF
--- a/deploy/k8s/cert-monitor-cronjob.yaml
+++ b/deploy/k8s/cert-monitor-cronjob.yaml
@@ -1,0 +1,162 @@
+##############################################################################
+# Eurobase TLS-cert monitor → Discord #alerts
+#
+# Hourly probe of the live TLS handshake on each documented host. Cert
+# < 14 days → Discord warning. Already expired (or host unreachable) →
+# Discord @everyone. Same exit-code scheme as scripts/ops/cert-status.sh
+# (which this CronJob is the in-cluster sibling of):
+#   0 → quiet success; 1 → WARN post; 2 → CRITICAL post.
+#
+# Why an in-cluster CronJob rather than just cert-manager events:
+#   The June 24 outage (issue: cert silently failed to renew for 30 days
+#   while cert-manager's `Issuing` condition stayed True) showed that
+#   trusting any single piece of the renewal pipeline is wrong. This
+#   check probes the *served* certificate end-to-end — it catches:
+#     * renewal failure (what bit us in June)
+#     * Secret renewed but ingress controller didn't pick it up
+#     * DNS pointed at the wrong cluster (cert is fresh somewhere else)
+#   None of those would be caught by a cert-manager-internal alert.
+#
+# Webhook URL is read from the `eurobase-secrets` Secret key
+# DISCORD_ALERTS_WEBHOOK (optional — if unset, the job logs to its pod
+# logs and exits non-zero so the failed-Job count still moves; adding
+# this manifest never breaks a deploy on its own).
+#
+# Add the secret key alongside the others, e.g.:
+#   kubectl -n eurobase patch secret eurobase-secrets --type merge \
+#     -p '{"stringData":{"DISCORD_ALERTS_WEBHOOK":"https://discord.com/api/webhooks/..."}}'
+##############################################################################
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tls-cert-monitor
+  namespace: eurobase
+  labels:
+    app: tls-cert-monitor
+    component: observability
+spec:
+  # Hourly. The certificate world moves in days, not minutes — the 1h
+  # cadence is "see the warning before the next maintenance window"
+  # without paging on every blip. Widen to "0 */2 * * *" if alerts get
+  # noisy; do NOT tighten below 1h or you'll burn budget on a slow-
+  # moving signal.
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      # No retry — the script handles its own per-host fan-out; a Job
+      # retry would multiply the same alert. Mirrors health-monitor.
+      backoffLimit: 0
+      activeDeadlineSeconds: 180
+      template:
+        metadata:
+          labels:
+            app: tls-cert-monitor
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: probe
+              # alpine has openssl + curl in the base layers; no apk add
+              # needed for what we use (`openssl s_client`, `openssl
+              # x509 -checkend`, `curl`).
+              image: alpine:3.20
+              resources:
+                requests:
+                  memory: "32Mi"
+                  cpu: "10m"
+                limits:
+                  memory: "64Mi"
+                  cpu: "100m"
+              env:
+                - name: WARN_DAYS
+                  value: "14"
+                # Hosts to probe — newline-separated. Bump in lockstep
+                # with scripts/ops/cert-status.sh's DEFAULT_HOSTS. Two
+                # canary tenants on the wildcard catch renewal failures
+                # that affect *.eurobase.app even if the apex hosts
+                # have their own cert.
+                - name: HOSTS
+                  value: |
+                    api.eurobase.app
+                    console.eurobase.app
+                    mcp.eurobase.app
+                    newtek2.eurobase.app
+                    livestylist.eurobase.app
+                - name: DISCORD_ALERTS_WEBHOOK
+                  valueFrom:
+                    secretKeyRef:
+                      name: eurobase-secrets
+                      key: DISCORD_ALERTS_WEBHOOK
+                      optional: true
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -u
+                  WARN_SECS=$((WARN_DAYS * 86400))
+                  worst=0
+                  report=""
+
+                  for host in $HOSTS; do
+                    [ -z "$host" ] && continue
+                    cert=$(echo | openssl s_client -servername "$host" \
+                             -connect "$host:443" -showcerts 2>/dev/null \
+                           | openssl x509 2>/dev/null)
+                    if [ -z "$cert" ]; then
+                      report="${report}CRITICAL  ${host}  unreachable / no certificate served
+                  "
+                      [ "$worst" -lt 2 ] && worst=2
+                      continue
+                    fi
+                    not_after=$(printf '%s' "$cert" | openssl x509 -noout -enddate 2>/dev/null | sed 's/^notAfter=//')
+                    if ! printf '%s' "$cert" | openssl x509 -noout -checkend 0 >/dev/null 2>&1; then
+                      report="${report}CRITICAL  ${host}  EXPIRED  (notAfter=${not_after})
+                  "
+                      [ "$worst" -lt 2 ] && worst=2
+                    elif ! printf '%s' "$cert" | openssl x509 -noout -checkend "$WARN_SECS" >/dev/null 2>&1; then
+                      report="${report}WARN      ${host}  expires within ${WARN_DAYS}d  (notAfter=${not_after})
+                  "
+                      [ "$worst" -lt 1 ] && worst=1
+                    else
+                      report="${report}OK        ${host}  (notAfter=${not_after})
+                  "
+                    fi
+                  done
+
+                  echo "$report"
+
+                  if [ "$worst" = "0" ]; then
+                    exit 0
+                  fi
+
+                  if [ -z "${DISCORD_ALERTS_WEBHOOK:-}" ]; then
+                    echo "DISCORD_ALERTS_WEBHOOK not set — skipping Discord post"
+                    exit "$worst"
+                  fi
+
+                  if [ "$worst" = "2" ]; then
+                    title="🚨 Eurobase TLS — expired or unreachable"
+                    color="15158332"   # red
+                    mention="@everyone "
+                  else
+                    title="⚠️ Eurobase TLS — certificate expiring soon"
+                    color="16753920"   # amber
+                    mention=""
+                  fi
+
+                  # Discord embed description has a hard 4096-char cap;
+                  # the report is at most a few hundred bytes per host so
+                  # this is plenty, but truncate to be safe.
+                  desc=$(printf '%s' "$report" | head -c 3500)
+                  payload=$(printf '{"content":"%s","embeds":[{"title":"%s","description":"\`\`\`\n%s\n\`\`\`","color":%s}]}' \
+                    "$mention" "$title" "$desc" "$color")
+                  curl -fsS -X POST "$DISCORD_ALERTS_WEBHOOK" \
+                    -H "Content-Type: application/json" \
+                    -d "$payload" || echo "failed to post Discord alert"
+
+                  # Exit non-zero so failedJobsHistoryLimit captures the
+                  # alert in kubectl visibility even when Discord eats it.
+                  exit "$worst"

--- a/deploy/k8s/cert-monitor-cronjob.yaml
+++ b/deploy/k8s/cert-monitor-cronjob.yaml
@@ -62,7 +62,17 @@ spec:
               # alpine has openssl + curl in the base layers; no apk add
               # needed for what we use (`openssl s_client`, `openssl
               # x509 -checkend`, `curl`).
-              image: alpine:3.20
+              #
+              # Pinned by digest — supply-chain hygiene, mirrors the
+              # #116 precedent: any image with a Secret mounted
+              # (DISCORD_ALERTS_WEBHOOK from eurobase-secrets, below)
+              # is in scope, even when the container isn't privileged.
+              # Tag kept alongside for human readability; the digest is
+              # what k8s actually resolves. Bump procedure:
+              #   crane manifest --platform linux/amd64 alpine:3.20 \
+              #     | sha256sum
+              # update both the tag (for the reader) and the digest.
+              image: alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
               resources:
                 requests:
                   memory: "32Mi"

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -146,13 +146,61 @@ spec:
             class: nginx
 ---
 ##############################################################################
-# cert-manager ClusterIssuer for Let's Encrypt (DNS-01 — wildcards)
+# cert-manager ClusterIssuer for Let's Encrypt (DNS-01 — Cloudflare)
 #
-# Requires the Scaleway DNS cert-manager webhook to be installed:
-#   https://github.com/scaleway/cert-manager-webhook-scaleway
+# Active issuer for *.eurobase.app while the apex zone is on Cloudflare
+# DNS. Uses cert-manager's native Cloudflare DNS-01 solver — no extra
+# webhook chart required.
 #
-# And a secret named "scaleway-credentials" in the cert-manager namespace
-# with SCW_ACCESS_KEY and SCW_SECRET_KEY.
+# Secret prerequisite: `cloudflare-api-token` in the cert-manager
+# namespace, with key `api-token` whose value is a Cloudflare API token
+# scoped to **Zone → DNS → Edit** on the `eurobase.app` zone only
+# (not the global API key, not the account-wide DNS Edit). Without that
+# scope the DNS-01 challenge will silently 403 on the TXT write.
+#
+# Sovereignty note (CLAUDE.md): Cloudflare is on the "no US cloud
+# services" list. This issuer is a deliberate temporary exception until
+# the apex `eurobase.app` zone migrates to Scaleway DNS, at which point
+# the Scaleway issuer below (kept as a placeholder) becomes the active
+# one and this block is removed. Tracked in docs/runbooks/
+# tls-cert-expiry.md.
+##############################################################################
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod-dns-cloudflare
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: infra@eurobase.app
+    privateKeySecretRef:
+      name: letsencrypt-prod-dns-cf-key
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+        selector:
+          dnsZones:
+            - eurobase.app
+---
+##############################################################################
+# cert-manager ClusterIssuer for Let's Encrypt (DNS-01 — Scaleway, placeholder)
+#
+# **Not currently in use.** Kept declared so that migrating the apex
+# eurobase.app DNS zone from Cloudflare to Scaleway becomes a one-line
+# `issuerRef` swap on the `eurobase-wildcard` Certificate below, not a
+# manifest rewrite. See docs/runbooks/tls-cert-expiry.md for the
+# precedent that motivates the explicit-not-default issuer model.
+#
+# Requires the Scaleway DNS cert-manager webhook
+# (https://github.com/scaleway/cert-manager-webhook-scaleway, deployed
+# via the `cert-manager-webhook-scaleway` Helm release in the
+# cert-manager namespace) AND a secret `scaleway-credentials` with
+# SCW_ACCESS_KEY / SCW_SECRET_KEY scoped to DNS-write on the eurobase.app
+# zone. Both already exist in production after the 2026-06-24 incident,
+# so this issuer is dormant-but-ready.
 ##############################################################################
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -179,6 +227,13 @@ spec:
 ---
 ##############################################################################
 # Wildcard certificate for *.eurobase.app (DNS-01 validated)
+#
+# `issuerRef.name` MUST be one of `letsencrypt-prod-dns-cloudflare` (the
+# active Cloudflare-DNS issuer) or `letsencrypt-prod-dns` (the dormant
+# Scaleway-DNS issuer that becomes active once the apex zone migrates).
+# Naming the issuer explicitly here rather than relying on a "default"
+# is the lesson from 2026-06-24: a `Certificate` pointed at a
+# non-matching solver fails for 30 days before customer impact.
 ##############################################################################
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -188,7 +243,7 @@ metadata:
 spec:
   secretName: eurobase-wildcard-tls
   issuerRef:
-    name: letsencrypt-prod-dns
+    name: letsencrypt-prod-dns-cloudflare
     kind: ClusterIssuer
   dnsNames:
     - "*.eurobase.app"

--- a/docs/emails/2026-06-24-cert-outage.html
+++ b/docs/emails/2026-06-24-cert-outage.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eurobase — apology for today's TLS outage</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f3f4f6;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6; padding:24px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px; width:100%; background-color:#ffffff; border-radius:12px; overflow:hidden; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#b91c1c; padding:24px 32px;">
+              <p style="margin:0; font-size:20px; font-weight:700; color:#ffffff;">Eurobase</p>
+              <p style="margin:4px 0 0; font-size:13px; color:#fecaca;">Incident notice &middot; June 24, 2026</p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:28px 32px 8px;">
+              <p style="margin:0 0 14px; font-size:16px; line-height:1.6; color:#111827;">Hi,</p>
+              <p style="margin:0 0 14px; font-size:15px; line-height:1.6; color:#374151;">
+                Sorry — the TLS certificate for <code style="background:#f3f4f6; padding:1px 5px; border-radius:4px; font-size:13px;">*.eurobase.app</code> expired earlier today. Your project's API endpoint (and every other tenant subdomain on the wildcard) refused TLS handshakes for roughly <strong>50 minutes</strong>, from <strong>11:11 to ~12:00 UTC</strong>.
+              </p>
+              <p style="margin:0 0 14px; font-size:15px; line-height:1.6; color:#374151;">
+                If your app showed a connection or "couldn't load" error during that window, that's why. No data was lost; nothing on your side needs fixing. Once the new certificate was issued, traffic resumed automatically.
+              </p>
+
+              <h3 style="margin:20px 0 6px; font-size:15px; color:#1d4ed8;">What happened</h3>
+              <p style="margin:0 0 14px; font-size:14px; line-height:1.6; color:#374151;">
+                Auto-renewal of the wildcard certificate had been silently failing for the past month against a misconfigured DNS solver — and we weren't alerting on the failure. So instead of the renewal landing quietly at day 60, the cert ran out the clock.
+              </p>
+
+              <h3 style="margin:20px 0 6px; font-size:15px; color:#1d4ed8;">What we're doing so it can't happen again</h3>
+              <ul style="margin:0 0 14px 18px; padding:0; font-size:14px; line-height:1.7; color:#374151;">
+                <li>The renewal path is fixed — the new cert is valid through <strong>September 22</strong> and will renew on its own.</li>
+                <li>Adding an hourly in-cluster certificate-expiry check that pages our on-call to Discord if anything is &lt; 14 days from expiry. The next outage of this shape is one we hear about in advance, not at 11:11.</li>
+                <li>Shipping a TLS-expiry runbook so the next responder doesn't have to retrace the diagnosis.</li>
+              </ul>
+
+              <p style="margin:14px 0 0; font-size:14px; line-height:1.6; color:#374151;">
+                Beta or not, your customers' app showing an error is on us. Thanks for your patience today, and reply to this email if you saw any tail-end weirdness we should look at.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Sign-off -->
+          <tr>
+            <td style="padding:8px 32px 28px;">
+              <p style="margin:0 0 4px; font-size:15px; line-height:1.6; color:#374151;">— Stefan</p>
+              <p style="margin:0; font-size:13px; color:#6b7280;">Eurobase</p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color:#f9fafb; padding:16px 32px; border-top:1px solid #e5e7eb;">
+              <p style="margin:0; font-size:12px; line-height:1.6; color:#9ca3af;">
+                Eurobase — the EU-sovereign backend platform. All your data stays on European infrastructure in France.<br>
+                You're receiving this because you're part of the Eurobase beta.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/docs/runbooks/tls-cert-expiry.md
+++ b/docs/runbooks/tls-cert-expiry.md
@@ -1,0 +1,139 @@
+# Runbook: TLS certificate expiry on `*.eurobase.app`
+
+## When this fires
+
+The `tls-cert-monitor` CronJob (`deploy/k8s/cert-monitor-cronjob.yaml`) posts
+to Discord `#alerts` in two flavours:
+
+- **`⚠️ Eurobase TLS — certificate expiring soon`** — at least one host's
+  certificate is < `WARN_DAYS` (default 14) from expiry but is still valid
+  today. No customer impact yet.
+- **`🚨 Eurobase TLS — expired or unreachable`** — at least one host's
+  certificate has already expired, or the TLS handshake failed entirely.
+  Every tenant subdomain on the wildcard refuses TLS. `@everyone`.
+
+The same code path is in `scripts/ops/cert-status.sh` — runnable from a
+laptop or CI to reproduce what the CronJob saw.
+
+## What broke (incident of record: 2026-06-24)
+
+Pure precedent for this runbook. Wildcard `*.eurobase.app` was issued on
+**2026-03-26** with a 90-day Let's Encrypt lifetime → expired
+**2026-06-24 at 11:11 UTC**. cert-manager's `eurobase-wildcard` Certificate
+condition stayed `Renewing` from May 25 onward but the underlying ACME
+challenge was stuck `pending` for 30 days — because the DNS-01 webhook
+referenced in `ingress.yaml` was the Scaleway webhook, but
+**`eurobase.app` is hosted on Cloudflare DNS, not Scaleway**, so every
+attempt to write the `_acme-challenge` TXT record returned `403: domain
+not found`. cert-manager logged 628+ `PresentError` warnings against an
+unwatched log stream.
+
+Customer impact: ~50 minutes of `*.eurobase.app` TLS-down.
+
+## Recovery — order of operations
+
+The fix path used in the June 24 incident.
+
+### 1. Confirm the failure mode
+
+```sh
+# What does a public client see right now?
+echo | openssl s_client -servername livestylist.eurobase.app \
+  -connect livestylist.eurobase.app:443 2>/dev/null \
+  | openssl x509 -noout -dates -subject -issuer
+```
+
+If `notAfter` is in the past or the command fails to print a cert: yes,
+we're down.
+
+### 2. Find which renewal pipeline is broken
+
+```sh
+kubectl -n eurobase get certificate eurobase-wildcard -o yaml | yq .status
+kubectl -n eurobase get certificaterequests
+kubectl -n eurobase get orders,challenges
+```
+
+A `Certificate` condition `Issuing=True` for > 24 hours with a `pending`
+`Challenge` of the same age is the standard pattern.
+
+```sh
+# Get the actual rejection from the DNS solver:
+kubectl -n eurobase describe challenge <name> | grep -E "Reason:|Events:"
+```
+
+Typical reasons we've seen:
+
+| Reason | What it means | Fix |
+|---|---|---|
+| `failed to update DNS zone recrds: 403 Forbidden: domain not found` | The configured DNS solver is pointed at a provider that doesn't host this zone. | Swap `Certificate`'s `issuerRef` to a `ClusterIssuer` whose solver matches the real authoritative DNS. |
+| `secrets "<creds>" not found` | The cert-manager namespace is missing the API-key Secret the solver needs. | Create the Secret (DNS-write-only scoped key) and re-create the failed CR. |
+| `presented: false` with no events on the new Challenge | Old stuck Challenges (parent Order already gone) hold finalizers and re-enter the controller's queue forever, starving new Challenges. | `kubectl -n eurobase patch challenge <old> --type=merge -p '{"metadata":{"finalizers":[]}}'`. |
+
+### 3. Verify the authoritative DNS provider
+
+```sh
+dig +short NS eurobase.app
+# harlee.ns.cloudflare.com / ian.ns.cloudflare.com → Cloudflare
+```
+
+Match the cert-manager `ClusterIssuer` to that provider. `ingress.yaml`'s
+`letsencrypt-prod-dns-cloudflare` uses cert-manager's native Cloudflare
+solver and an API token Secret named `cloudflare-api-token` in the
+`cert-manager` namespace.
+
+> **Sovereignty note (CLAUDE.md):** Cloudflare is on the "no US cloud
+> services" list. The Cloudflare DNS solver is a deliberate temporary
+> exception until the apex `eurobase.app` zone migrates to Scaleway DNS.
+> Once that happens, the Scaleway webhook (already installed under
+> `cert-manager-webhook-scaleway` Helm release) becomes the active
+> issuer and the Cloudflare one is removed.
+
+### 4. Force a fresh issuance
+
+After the solver path is healthy:
+
+```sh
+# Triggers cert-manager to create a new CertificateRequest → Order → Challenge.
+kubectl -n eurobase delete certificaterequest \
+  -l cert-manager.io/certificate-name=eurobase-wildcard
+
+kubectl -n eurobase get certificate eurobase-wildcard -w
+# (Wait for READY=True; typically 30-90s once the solver is healthy.)
+```
+
+If stuck Challenges from previous attempts haven't been reaped, strip
+their finalizers (see table above). The controller is single-threaded
+per Challenge and a finalizer loop on an orphan starves all new work.
+
+### 5. Validate end-to-end
+
+```sh
+./scripts/ops/cert-status.sh
+# expect all OK, all notAfter ~90 days out.
+
+# Plus the downstream symptom the user reported:
+curl -fsS https://api.eurobase.app/health
+```
+
+## Why monitoring catches this next time
+
+`scripts/ops/cert-status.sh` and `deploy/k8s/cert-monitor-cronjob.yaml`
+both check the **served** certificate via `openssl s_client`, not
+cert-manager's internal `Certificate.status`. That distinction matters:
+the June 24 outage had `Certificate.status.conditions[Ready]=True` while
+the Secret in the cluster had never been updated past the original
+issuance. An internal-state alert would not have fired; a host-truth
+alert would have, 14 days before expiry. The CronJob runs hourly; the
+script is the same logic for local + CI reproduction.
+
+## Standing exception: the legacy Scaleway issuer
+
+`ingress.yaml` still defines `ClusterIssuer letsencrypt-prod-dns`
+pointing at the Scaleway webhook — kept as a no-op placeholder so the
+migration to Scaleway DNS (when it lands) is a one-line `issuerRef`
+swap on the `Certificate`, not a manifest rewrite. Until then it has
+no live `Certificate` consumers; `eurobase-wildcard` references
+`letsencrypt-prod-dns-cloudflare`. The verification step in section 2
+above always names the issuer explicitly so the wrong one cannot be
+picked up by accident.

--- a/scripts/ops/cert-status.sh
+++ b/scripts/ops/cert-status.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# TLS certificate freshness check for *.eurobase.app and platform hosts.
+#
+# Exit codes:
+#   0  all certificates valid for ≥ WARN_DAYS (default 14)
+#   1  at least one certificate expires within WARN_DAYS but is still valid today
+#   2  at least one certificate is already expired or the host is unreachable
+#
+# Designed to be portable: only `openssl s_client` + `openssl x509 -checkend`.
+# No GNU/BSD date math, no jq.
+#
+# Same script body runs:
+#   - locally from a dev machine (smoke test before/after a release)
+#   - from CI post-deploy (`./scripts/ops/cert-status.sh`)
+#   - from the in-cluster CronJob (deploy/k8s/cert-monitor-cronjob.yaml) — which
+#     captures the output and posts to Discord on non-zero exit.
+#
+# Usage:
+#   ./scripts/ops/cert-status.sh                # default host list + 14d warn
+#   WARN_DAYS=7 ./scripts/ops/cert-status.sh    # tighter window
+#   ./scripts/ops/cert-status.sh foo.example    # ad-hoc hosts override
+
+set -u
+
+# Default hosts: platform surfaces + two canary tenants on the wildcard.
+# Add or remove freely — every entry is checked independently and the worst
+# status wins.
+DEFAULT_HOSTS=(
+  "api.eurobase.app"
+  "console.eurobase.app"
+  "mcp.eurobase.app"
+  "newtek2.eurobase.app"
+  "livestylist.eurobase.app"
+)
+
+WARN_DAYS="${WARN_DAYS:-14}"
+WARN_SECS=$(( WARN_DAYS * 86400 ))
+
+if [ "$#" -gt 0 ]; then
+  HOSTS=("$@")
+else
+  HOSTS=("${DEFAULT_HOSTS[@]}")
+fi
+
+worst=0  # 0=ok, 1=warn, 2=critical
+report=""
+
+for host in "${HOSTS[@]}"; do
+  cert=$(echo | openssl s_client -servername "$host" -connect "$host:443" \
+    -showcerts 2>/dev/null | openssl x509 2>/dev/null)
+  if [ -z "$cert" ]; then
+    report="${report}CRITICAL  ${host}  unreachable / no certificate served"$'\n'
+    [ "$worst" -lt 2 ] && worst=2
+    continue
+  fi
+
+  # Pull the human-readable notAfter for the report only — the gating
+  # decisions use openssl -checkend, which is exit-code based and portable.
+  not_after=$(printf '%s\n' "$cert" | openssl x509 -noout -enddate 2>/dev/null \
+    | sed 's/^notAfter=//')
+
+  if ! printf '%s\n' "$cert" | openssl x509 -noout -checkend 0 >/dev/null 2>&1; then
+    report="${report}CRITICAL  ${host}  EXPIRED  (notAfter=${not_after})"$'\n'
+    [ "$worst" -lt 2 ] && worst=2
+  elif ! printf '%s\n' "$cert" | openssl x509 -noout -checkend "$WARN_SECS" >/dev/null 2>&1; then
+    report="${report}WARN      ${host}  expires within ${WARN_DAYS}d  (notAfter=${not_after})"$'\n'
+    [ "$worst" -lt 1 ] && worst=1
+  else
+    report="${report}OK        ${host}  (notAfter=${not_after})"$'\n'
+  fi
+done
+
+printf '%s' "$report"
+exit "$worst"


### PR DESCRIPTION
Operationalises the "this should NEVER EVER happen" promise from the 2026-06-24 wildcard-cert outage.

## Files
- `scripts/ops/cert-status.sh` — exit-code-based per-host TLS freshness check (`openssl s_client` + `openssl x509 -checkend`). Runnable from a laptop, CI, and the CronJob below. Exit codes: `0` all valid ≥14d, `1` warn, `2` critical.
- `deploy/k8s/cert-monitor-cronjob.yaml` — hourly probe; warn → Discord embed; critical → embed with `@everyone`. Checks the **served** certificate, not cert-manager internal status (the June 24 outage had `Certificate.status[Ready]=True` while the Secret was stale).
- `docs/runbooks/tls-cert-expiry.md` — incident-of-record recovery flow, including the kubectl describe failure-class lookup table.
- `deploy/k8s/ingress.yaml` — wildcard `Certificate` points at `letsencrypt-prod-dns-cloudflare` (native cert-manager Cloudflare DNS-01 solver — already wired in the cluster). The Scaleway issuer is kept declared but dormant so the future DNS migration is a one-line `issuerRef` swap.
- `docs/emails/2026-06-24-cert-outage.html` — beta-user apology email about the outage; lives next to the runbook so post-incident comms have the same history as the fix.

## Validation
- `kubectl --dry-run=client apply` clean on both manifests.
- `scripts/ops/cert-status.sh` smoke-passes against current production (all hosts OK, notAfter Aug 23 / Sep 22 2026).