### PR TITLE
fix #226: token refresh + verification per-IP gates

### DIFF
--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -138,7 +138,11 @@ func HandleSignIn(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 }
 
 // HandleRefresh returns an HTTP handler for POST /v1/auth/refresh.
-func HandleRefresh(svc *AuthService) http.HandlerFunc {
+func HandleRefresh(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.HandlerFunc {
+	var rl *ratelimit.RateLimiter
+	if len(limiter) > 0 {
+		rl = limiter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
 		if !ok {
@@ -147,6 +151,22 @@ func HandleRefresh(svc *AuthService) http.HandlerFunc {
 		}
 
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
+
+		// Per-project per-IP gate on the refresh endpoint (#226 —
+		// closes the burst-guard gap that #56's reuse-detection
+		// can't cover before a stolen token is family-revoked).
+		// Default 150 per 5 min — generous because legitimate SDK
+		// clients refresh proactively; tighten via the Rate Limits
+		// page.
+		//
+		// XFF caveat: ratelimit.ClientIP trusts the leftmost
+		// X-Forwarded-For unconditionally; the per-project
+		// trust_proxy knob enforcement lands in #228. Prod traffic
+		// relies on the nginx-ingress XFF rewrite in the meantime.
+		rlCfg := config.EffectiveRateLimits()
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_refresh", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenRefreshPer5MinPerIP, ratelimit.FiveMinutes) {
+			return
+		}
 
 		var req RefreshRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -300,11 +320,27 @@ func HandleResetPassword(svc *AuthService) http.HandlerFunc {
 }
 
 // HandleVerifyEmail returns an HTTP handler for POST /v1/auth/verify-email.
-func HandleVerifyEmail(svc *AuthService) http.HandlerFunc {
+func HandleVerifyEmail(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.HandlerFunc {
+	var rl *ratelimit.RateLimiter
+	if len(limiter) > 0 {
+		rl = limiter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
 		if !ok {
 			http.Error(w, `{"error":"missing project context"}`, http.StatusUnauthorized)
+			return
+		}
+
+		// Per-project per-IP gate on token-verification endpoints
+		// (#226 — closes the OTP/magic-link brute-force gap: a
+		// 6-digit OTP is otherwise enumerable within 5 minutes
+		// because the verify step is currently unrate-limited).
+		// Same knob shared with /signin-magic-link and /phone/verify.
+		// XFF caveat: trust_proxy enforcement lands in #228.
+		config := tenant.ParseAuthConfig(pc.AuthConfig)
+		rlCfg := config.EffectiveRateLimits()
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -370,7 +406,11 @@ func HandleRequestMagicLink(svc *AuthService, limiter ...*ratelimit.RateLimiter)
 }
 
 // HandleSignInWithMagicLink returns an HTTP handler for POST /v1/auth/signin-magic-link.
-func HandleSignInWithMagicLink(svc *AuthService) http.HandlerFunc {
+func HandleSignInWithMagicLink(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.HandlerFunc {
+	var rl *ratelimit.RateLimiter
+	if len(limiter) > 0 {
+		rl = limiter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
 		if !ok {
@@ -379,6 +419,14 @@ func HandleSignInWithMagicLink(svc *AuthService) http.HandlerFunc {
 		}
 
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
+
+		// Per-project per-IP gate — shares the token_verify knob with
+		// the email and phone OTP verify endpoints. See HandleVerifyEmail
+		// for the brute-force rationale; XFF caveat tracked in #228.
+		rlCfg := config.EffectiveRateLimits()
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+			return
+		}
 
 		var req struct {
 			Token string `json:"token"`
@@ -681,7 +729,11 @@ func HandleSendPhoneOTP(svc *AuthService, limiter ...*ratelimit.RateLimiter) htt
 }
 
 // HandleVerifyPhoneOTP returns an HTTP handler for POST /v1/auth/phone/verify.
-func HandleVerifyPhoneOTP(svc *AuthService) http.HandlerFunc {
+func HandleVerifyPhoneOTP(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.HandlerFunc {
+	var rl *ratelimit.RateLimiter
+	if len(limiter) > 0 {
+		rl = limiter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
 		if !ok {
@@ -692,6 +744,16 @@ func HandleVerifyPhoneOTP(svc *AuthService) http.HandlerFunc {
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
 		if !config.IsPhoneAuthEnabled() {
 			writeJSON(w, map[string]string{"error": "phone authentication is not enabled"}, http.StatusBadRequest)
+			return
+		}
+
+		// Per-project per-IP gate — shares the token_verify knob with
+		// the email and magic-link verify endpoints. A 6-digit OTP is
+		// enumerable in 5 min without this; the per-phone OTP-issue
+		// limit (PhoneOTPLimit) gates the SEND side, not the verify.
+		// XFF caveat tracked in #228.
+		rlCfg := config.EffectiveRateLimits()
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 

--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -290,7 +290,11 @@ func HandleForgotPassword(svc *AuthService, limiter ...*ratelimit.RateLimiter) h
 }
 
 // HandleResetPassword returns an HTTP handler for POST /v1/auth/reset-password.
-func HandleResetPassword(svc *AuthService) http.HandlerFunc {
+func HandleResetPassword(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.HandlerFunc {
+	var rl *ratelimit.RateLimiter
+	if len(limiter) > 0 {
+		rl = limiter[0]
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		pc, ok := auth.ProjectFromContext(r.Context())
 		if !ok {
@@ -299,6 +303,17 @@ func HandleResetPassword(svc *AuthService) http.HandlerFunc {
 		}
 
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
+
+		// Per-project per-IP gate — shares the token_verify knob with
+		// the other verify endpoints. Low risk here (the reset token is
+		// high-entropy hex from rand.Read, not enumerable) — added for
+		// consistency so a project that tightens token_verify also
+		// tightens reset, and one IP can't burn through the bucket via
+		// /reset-password while the other verify endpoints stay open.
+		rlCfg := config.EffectiveRateLimits()
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+			return
+		}
 
 		var req struct {
 			Token    string `json:"token"`
@@ -333,10 +348,18 @@ func HandleVerifyEmail(svc *AuthService, limiter ...*ratelimit.RateLimiter) http
 		}
 
 		// Per-project per-IP gate on token-verification endpoints
-		// (#226 — closes the OTP/magic-link brute-force gap: a
-		// 6-digit OTP is otherwise enumerable within 5 minutes
-		// because the verify step is currently unrate-limited).
-		// Same knob shared with /signin-magic-link and /phone/verify.
+		// (#226 — defense in depth on top of the per-token controls
+		// each underlying flow has). Same knob shared with
+		// /signin-magic-link, /phone/verify, and /reset-password.
+		//
+		// For email-verify, magic-link, and reset-password the token
+		// is high-entropy hex from rand.Read — practically
+		// unguessable, so the per-IP gate is purely volume control.
+		// For phone OTP (6-digit code) the picture is different and
+		// the residual risk is not closed by an IP-keyed limit alone:
+		// see the security issue tracking the VerifyOTP code-only
+		// match + missing per-token attempt counter.
+		//
 		// XFF caveat: trust_proxy enforcement lands in #228.
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
 		rlCfg := config.EffectiveRateLimits()
@@ -748,9 +771,16 @@ func HandleVerifyPhoneOTP(svc *AuthService, limiter ...*ratelimit.RateLimiter) h
 		}
 
 		// Per-project per-IP gate — shares the token_verify knob with
-		// the email and magic-link verify endpoints. A 6-digit OTP is
-		// enumerable in 5 min without this; the per-phone OTP-issue
-		// limit (PhoneOTPLimit) gates the SEND side, not the verify.
+		// the email and magic-link verify endpoints. This NARROWS but
+		// does not CLOSE phone-OTP brute force: the underlying
+		// VerifyOTP SQL matches the 6-digit code tenant-wide
+		// (`WHERE token_hash = sha256(code)`) with no per-token
+		// attempt counter, so a forged XFF or a modest botnet can
+		// still chip away at the 10^6 code space. The proper fix is
+		// tracked as a separate P1 security issue: bind verify to the
+		// phone (`WHERE phone = $1 AND token_hash = $2`) + a
+		// per-token attempt counter. The per-phone OTP-issue limit
+		// (PhoneOTPLimit) gates the SEND side, not the verify.
 		// XFF caveat tracked in #228.
 		rlCfg := config.EffectiveRateLimits()
 		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -531,17 +531,17 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, migrationExec *q
 			r.Use(apiKeyMw.Handler)
 			r.Post("/signup", enduser.HandleSignUp(endUserAuthSvc, limiter))
 			r.Post("/signin", enduser.HandleSignIn(endUserAuthSvc, limiter))
-			r.Post("/refresh", enduser.HandleRefresh(endUserAuthSvc))
+			r.Post("/refresh", enduser.HandleRefresh(endUserAuthSvc, limiter))
 			r.Post("/signout", enduser.HandleSignOut(endUserAuthSvc))
 			r.Post("/forgot-password", enduser.HandleForgotPassword(endUserAuthSvc, limiter))
 			r.Post("/reset-password", enduser.HandleResetPassword(endUserAuthSvc))
-			r.Post("/verify-email", enduser.HandleVerifyEmail(endUserAuthSvc))
+			r.Post("/verify-email", enduser.HandleVerifyEmail(endUserAuthSvc, limiter))
 			r.Post("/resend-verification", enduser.HandleResendVerification(endUserAuthSvc, limiter))
 			r.Post("/request-magic-link", enduser.HandleRequestMagicLink(endUserAuthSvc, limiter))
-			r.Post("/signin-magic-link", enduser.HandleSignInWithMagicLink(endUserAuthSvc))
+			r.Post("/signin-magic-link", enduser.HandleSignInWithMagicLink(endUserAuthSvc, limiter))
 			r.Get("/oauth/{provider}", enduser.HandleOAuthRedirect(endUserAuthSvc))
 			r.Post("/phone/send-otp", enduser.HandleSendPhoneOTP(endUserAuthSvc, limiter))
-			r.Post("/phone/verify", enduser.HandleVerifyPhoneOTP(endUserAuthSvc))
+			r.Post("/phone/verify", enduser.HandleVerifyPhoneOTP(endUserAuthSvc, limiter))
 
 			// GET /v1/auth/user requires end-user JWT.
 			r.Group(func(r chi.Router) {

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -534,7 +534,7 @@ func NewRouter(pool *pgxpool.Pool, developerPool *pgxpool.Pool, migrationExec *q
 			r.Post("/refresh", enduser.HandleRefresh(endUserAuthSvc, limiter))
 			r.Post("/signout", enduser.HandleSignOut(endUserAuthSvc))
 			r.Post("/forgot-password", enduser.HandleForgotPassword(endUserAuthSvc, limiter))
-			r.Post("/reset-password", enduser.HandleResetPassword(endUserAuthSvc))
+			r.Post("/reset-password", enduser.HandleResetPassword(endUserAuthSvc, limiter))
 			r.Post("/verify-email", enduser.HandleVerifyEmail(endUserAuthSvc, limiter))
 			r.Post("/resend-verification", enduser.HandleResendVerification(endUserAuthSvc, limiter))
 			r.Post("/request-magic-link", enduser.HandleRequestMagicLink(endUserAuthSvc, limiter))


### PR DESCRIPTION
Closes #226 (umbrella #224). Wires the TokenRefresh and TokenVerification knobs landed in #225 into HandleRefresh, HandleVerifyEmail, HandleSignInWithMagicLink, HandleVerifyPhoneOTP. Same per-project keying + XFF caveat (tracked in #228). See commit body for design.