### PR TITLE
fix #228: per-project trust_proxy enforcement (default true for Eurobase ingress)

### DIFF
--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -40,11 +40,12 @@ func HandleSignUp(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// platform defaults — a project loosening this knob does not
 		// loosen those.
 		//
-		// XFF caveat: see the signin handler below — until #228 lands
-		// the `trust_proxy` enforcement, this gate trusts the
-		// leftmost X-Forwarded-For unconditionally.
+		// The IP source honours auth_config.rate_limits.trust_proxy
+		// (#228): TCP peer by default, leftmost X-Forwarded-For when
+		// the project explicitly opts in. See ClientIPForProject for
+		// the trade-off.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -91,15 +92,10 @@ func HandleSignIn(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// at platform-wide defaults: brute-force per account stays
 		// gated even if a project loosens the per-IP knob.
 		//
-		// XFF caveat: ratelimit.ClientIP currently trusts the leftmost
-		// X-Forwarded-For unconditionally — an attacker rotating XFF
-		// gets a fresh counter per request unless the ingress
-		// overwrites (not appends) the header. The per-project
-		// `trust_proxy` knob is the intended fix and lands in #228;
-		// until then this gate relies on the nginx-ingress XFF
-		// rewrite for prod traffic.
+		// IP source honours auth_config.rate_limits.trust_proxy
+		// (#228) — false = TCP peer, true = leftmost X-Forwarded-For.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -157,14 +153,9 @@ func HandleRefresh(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Han
 		// can't cover before a stolen token is family-revoked).
 		// Default 150 per 5 min — generous because legitimate SDK
 		// clients refresh proactively; tighten via the Rate Limits
-		// page.
-		//
-		// XFF caveat: ratelimit.ClientIP trusts the leftmost
-		// X-Forwarded-For unconditionally; the per-project
-		// trust_proxy knob enforcement lands in #228. Prod traffic
-		// relies on the nginx-ingress XFF rewrite in the meantime.
+		// page. IP source honours trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_refresh", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenRefreshPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_refresh", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenRefreshPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -311,7 +302,7 @@ func HandleResetPassword(svc *AuthService, limiter ...*ratelimit.RateLimiter) ht
 		// tightens reset, and one IP can't burn through the bucket via
 		// /reset-password while the other verify endpoints stay open.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -360,10 +351,10 @@ func HandleVerifyEmail(svc *AuthService, limiter ...*ratelimit.RateLimiter) http
 		// see the security issue tracking the VerifyOTP code-only
 		// match + missing per-token attempt counter.
 		//
-		// XFF caveat: trust_proxy enforcement lands in #228.
+		// IP source honours trust_proxy (#228).
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -445,9 +436,10 @@ func HandleSignInWithMagicLink(svc *AuthService, limiter ...*ratelimit.RateLimit
 
 		// Per-project per-IP gate — shares the token_verify knob with
 		// the email and phone OTP verify endpoints. See HandleVerifyEmail
-		// for the brute-force rationale; XFF caveat tracked in #228.
+		// for the brute-force rationale. IP source honours
+		// trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -781,9 +773,9 @@ func HandleVerifyPhoneOTP(svc *AuthService, limiter ...*ratelimit.RateLimiter) h
 		// phone (`WHERE phone = $1 AND token_hash = $2`) + a
 		// per-token attempt counter. The per-phone OTP-issue limit
 		// (PhoneOTPLimit) gates the SEND side, not the verify.
-		// XFF caveat tracked in #228.
+		// IP source honours trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIP(r), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 

--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -41,9 +41,11 @@ func HandleSignUp(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// loosen those.
 		//
 		// The IP source honours auth_config.rate_limits.trust_proxy
-		// (#228). Eurobase default is true (the nginx-ingress rewrite
-		// makes XFF the real client IP); see ClientIPForProject for
-		// why we diverge from Supabase's false default here.
+		// (#228). Default false (Supabase parity, safe under any XFF
+		// config); project owners who know their ingress overwrites
+		// XFF can opt in to true for true per-end-user keying. See
+		// the field doc in internal/tenant/auth_config.go for the
+		// trade-off.
 		rlCfg := config.EffectiveRateLimits()
 		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
@@ -93,9 +95,10 @@ func HandleSignIn(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// gated even if a project loosens the per-IP knob.
 		//
 		// IP source honours auth_config.rate_limits.trust_proxy
-		// (#228) — default true: leftmost X-Forwarded-For (the value
-		// nginx-ingress writes, real client IP). false flips to TCP
-		// peer for projects on a non-standard path.
+		// (#228) — default false (TCP peer, safe under any XFF
+		// config). See ClientIPForProject for the trade-off; the
+		// follow-up issue tracks flipping the default once XFF
+		// behavior is verified empirically.
 		rlCfg := config.EffectiveRateLimits()
 		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return

--- a/internal/enduser/handler.go
+++ b/internal/enduser/handler.go
@@ -41,11 +41,11 @@ func HandleSignUp(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// loosen those.
 		//
 		// The IP source honours auth_config.rate_limits.trust_proxy
-		// (#228): TCP peer by default, leftmost X-Forwarded-For when
-		// the project explicitly opts in. See ClientIPForProject for
-		// the trade-off.
+		// (#228). Eurobase default is true (the nginx-ingress rewrite
+		// makes XFF the real client IP); see ClientIPForProject for
+		// why we diverge from Supabase's false default here.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -93,9 +93,11 @@ func HandleSignIn(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Hand
 		// gated even if a project loosens the per-IP knob.
 		//
 		// IP source honours auth_config.rate_limits.trust_proxy
-		// (#228) — false = TCP peer, true = leftmost X-Forwarded-For.
+		// (#228) — default true: leftmost X-Forwarded-For (the value
+		// nginx-ingress writes, real client IP). false flips to TCP
+		// peer for projects on a non-standard path.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "signup_signin", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.SignupSigninPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -155,7 +157,7 @@ func HandleRefresh(svc *AuthService, limiter ...*ratelimit.RateLimiter) http.Han
 		// clients refresh proactively; tighten via the Rate Limits
 		// page. IP source honours trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_refresh", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenRefreshPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_refresh", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.TokenRefreshPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -302,7 +304,7 @@ func HandleResetPassword(svc *AuthService, limiter ...*ratelimit.RateLimiter) ht
 		// tightens reset, and one IP can't burn through the bucket via
 		// /reset-password while the other verify endpoints stay open.
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -354,7 +356,7 @@ func HandleVerifyEmail(svc *AuthService, limiter ...*ratelimit.RateLimiter) http
 		// IP source honours trust_proxy (#228).
 		config := tenant.ParseAuthConfig(pc.AuthConfig)
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -439,7 +441,7 @@ func HandleSignInWithMagicLink(svc *AuthService, limiter ...*ratelimit.RateLimit
 		// for the brute-force rationale. IP source honours
 		// trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 
@@ -775,7 +777,7 @@ func HandleVerifyPhoneOTP(svc *AuthService, limiter ...*ratelimit.RateLimiter) h
 		// (PhoneOTPLimit) gates the SEND side, not the verify.
 		// IP source honours trust_proxy (#228).
 		rlCfg := config.EffectiveRateLimits()
-		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
+		if ratelimit.CheckAuthRateForProject(rl, w, r.Context(), "token_verify", pc.ProjectID, ratelimit.ClientIPForProject(r, *rlCfg.TrustProxy), rlCfg.TokenVerificationPer5MinPerIP, ratelimit.FiveMinutes) {
 			return
 		}
 

--- a/internal/ratelimit/auth.go
+++ b/internal/ratelimit/auth.go
@@ -130,13 +130,7 @@ const FiveMinutes = 5 * time.Minute
 // knob (#228).
 func ClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// First IP in the chain is the client.
-		for i := 0; i < len(xff); i++ {
-			if xff[i] == ',' {
-				return xff[:i]
-			}
-		}
-		return xff
+		return leftmostXFF(xff)
 	}
 	return remoteAddrNoPort(r)
 }
@@ -144,50 +138,67 @@ func ClientIP(r *http.Request) string {
 // ClientIPForProject is the per-project sibling that honours
 // auth_config.rate_limits.trust_proxy (#228).
 //
-// ── Mechanics ──
-//
 //   - trustProxy=true  → leftmost X-Forwarded-For (fall back to TCP
-//     peer if XFF is absent). Use when an upstream layer rewrites or
-//     authoritatively writes XFF on every request — nginx-ingress's
-//     default (no `use-forwarded-headers` override) does exactly
-//     that, so in this deployment XFF is the real client IP.
+//     peer if XFF is absent). Correct only when exactly one trusted
+//     hop authoritatively overwrites XFF with the real client IP
+//     (nginx-ingress with `use-forwarded-headers: false` is the
+//     canonical example). If anything in the chain APPENDS to XFF
+//     instead of overwriting, leftmost-XFF becomes client-controlled
+//     and the per-IP gate becomes header-rotation-bypassable.
 //
 //   - trustProxy=false → TCP peer only; XFF is ignored entirely.
-//     Use when the gateway is reached without a trusted hop in front
-//     of it and you can't trust caller-supplied headers.
+//     Safe under any XFF configuration. The cost is that when the
+//     gateway sits behind one shared hop (every request in Eurobase
+//     prod arrives through one nginx pod), `r.RemoteAddr` is the
+//     same value for every request — the per-IP gate effectively
+//     becomes per-project total.
 //
-// ── Why true is the Eurobase default (Supabase ships false) ──
-//
-// In our nginx-ingress deployment, RemoteAddr is the nginx pod IP for
-// every single request. Picking trustProxy=false would key every
-// project's per-IP counter on that one IP — every end user of the
-// project would share one counter, so the documented per-IP budget
-// becomes a total project budget. With the SignupSigninPer5MinPerIP
-// default of 8, a 9-person office team can't all sign up in the same
-// 5 minutes.
-//
-// With trustProxy=true, XFF is the real client IP (nginx wrote it,
-// nothing upstream can forge it through), and each end-user IP gets
-// its own counter — which is what the published "per-IP" knob is
-// meant to mean. So flipping the default to true is what matches the
-// numbers a project owner sees on the Rate Limits page.
-//
-// Projects whose traffic comes through a non-standard path (a
-// customer-side proxy that adds an extra hop the ingress then appends
-// to, a private route that bypasses ingress) can flip this knob to
-// false explicitly; the console will surface the trade-off.
+// The Eurobase default is `false` for safety until the Scaleway LB ↔
+// nginx-ingress XFF behavior is verified empirically (follow-up issue
+// tracks the verification + the trusted-hop-count hardening that's
+// robust to both modes). Project owners who know their deployment
+// trusts XFF can opt in today; the field comment in
+// internal/tenant/auth_config.go walks through the full decision.
 func ClientIPForProject(r *http.Request, trustProxy bool) string {
 	if trustProxy {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			for i := 0; i < len(xff); i++ {
-				if xff[i] == ',' {
-					return xff[:i]
-				}
-			}
-			return xff
+			return leftmostXFF(xff)
 		}
 	}
 	return remoteAddrNoPort(r)
+}
+
+// leftmostXFF returns the first entry of an X-Forwarded-For header,
+// trimming any whitespace a comma-and-space separator would have left
+// in. `"203.0.113.7, 10.0.0.5"` → `"203.0.113.7"`; a single-entry
+// header is returned verbatim (also trimmed). Stable across ClientIP
+// and ClientIPForProject so the extractor lives in one place.
+func leftmostXFF(xff string) string {
+	if i := indexByte(xff, ','); i >= 0 {
+		return trimSpace(xff[:i])
+	}
+	return trimSpace(xff)
+}
+
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func trimSpace(s string) string {
+	start := 0
+	for start < len(s) && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	end := len(s)
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
 }
 
 // remoteAddrNoPort returns r.RemoteAddr with any trailing ":port" stripped.

--- a/internal/ratelimit/auth.go
+++ b/internal/ratelimit/auth.go
@@ -142,28 +142,40 @@ func ClientIP(r *http.Request) string {
 }
 
 // ClientIPForProject is the per-project sibling that honours
-// auth_config.rate_limits.trust_proxy (#228):
+// auth_config.rate_limits.trust_proxy (#228).
 //
-//   - trustProxy=true  → behaves like ClientIP (read leftmost
-//     X-Forwarded-For; fall back to TCP peer if XFF is absent).
-//     Use this when the platform sits behind an edge or ingress that
-//     OVERWRITES XFF on every request (the prod nginx-ingress default
-//     in this deployment), or when the project is willing to trust the
-//     full XFF chain.
+// ── Mechanics ──
 //
-//   - trustProxy=false → use the TCP peer only, ignoring any
-//     X-Forwarded-For header. Defends against XFF rotation by a caller
-//     when the gateway is reached without a controlled intermediate
-//     hop. The trade-off is that in deployments where every request
-//     IS pre-aggregated through one hop (nginx-ingress, a CDN), the
-//     TCP peer is the hop's IP for every request — every caller shares
-//     one counter. The project owner is the one in a position to
-//     judge whether that's the right thing for their tenant.
+//   - trustProxy=true  → leftmost X-Forwarded-For (fall back to TCP
+//     peer if XFF is absent). Use when an upstream layer rewrites or
+//     authoritatively writes XFF on every request — nginx-ingress's
+//     default (no `use-forwarded-headers` override) does exactly
+//     that, so in this deployment XFF is the real client IP.
 //
-// Default in DefaultRateLimits is `false` (matches Supabase's published
-// safe default). A project running purely behind nginx-ingress should
-// set it to true once they understand the trade-off; the runbook in
-// #230 explains the decision.
+//   - trustProxy=false → TCP peer only; XFF is ignored entirely.
+//     Use when the gateway is reached without a trusted hop in front
+//     of it and you can't trust caller-supplied headers.
+//
+// ── Why true is the Eurobase default (Supabase ships false) ──
+//
+// In our nginx-ingress deployment, RemoteAddr is the nginx pod IP for
+// every single request. Picking trustProxy=false would key every
+// project's per-IP counter on that one IP — every end user of the
+// project would share one counter, so the documented per-IP budget
+// becomes a total project budget. With the SignupSigninPer5MinPerIP
+// default of 8, a 9-person office team can't all sign up in the same
+// 5 minutes.
+//
+// With trustProxy=true, XFF is the real client IP (nginx wrote it,
+// nothing upstream can forge it through), and each end-user IP gets
+// its own counter — which is what the published "per-IP" knob is
+// meant to mean. So flipping the default to true is what matches the
+// numbers a project owner sees on the Rate Limits page.
+//
+// Projects whose traffic comes through a non-standard path (a
+// customer-side proxy that adds an extra hop the ingress then appends
+// to, a private route that bypasses ingress) can flip this knob to
+// false explicitly; the console will surface the trade-off.
 func ClientIPForProject(r *http.Request, trustProxy bool) string {
 	if trustProxy {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {

--- a/internal/ratelimit/auth.go
+++ b/internal/ratelimit/auth.go
@@ -123,6 +123,11 @@ func CheckAuthRateForProject(limiter *RateLimiter, w http.ResponseWriter, ctx co
 const FiveMinutes = 5 * time.Minute
 
 // ClientIP extracts the client IP from a request, preferring X-Forwarded-For.
+//
+// This is the legacy / platform-wide helper — it ALWAYS trusts the
+// leftmost X-Forwarded-For entry. Per-project gates should use
+// ClientIPForProject instead, which honours the project's `trust_proxy`
+// knob (#228).
 func ClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		// First IP in the chain is the client.
@@ -133,7 +138,50 @@ func ClientIP(r *http.Request) string {
 		}
 		return xff
 	}
-	// Strip port from RemoteAddr.
+	return remoteAddrNoPort(r)
+}
+
+// ClientIPForProject is the per-project sibling that honours
+// auth_config.rate_limits.trust_proxy (#228):
+//
+//   - trustProxy=true  → behaves like ClientIP (read leftmost
+//     X-Forwarded-For; fall back to TCP peer if XFF is absent).
+//     Use this when the platform sits behind an edge or ingress that
+//     OVERWRITES XFF on every request (the prod nginx-ingress default
+//     in this deployment), or when the project is willing to trust the
+//     full XFF chain.
+//
+//   - trustProxy=false → use the TCP peer only, ignoring any
+//     X-Forwarded-For header. Defends against XFF rotation by a caller
+//     when the gateway is reached without a controlled intermediate
+//     hop. The trade-off is that in deployments where every request
+//     IS pre-aggregated through one hop (nginx-ingress, a CDN), the
+//     TCP peer is the hop's IP for every request — every caller shares
+//     one counter. The project owner is the one in a position to
+//     judge whether that's the right thing for their tenant.
+//
+// Default in DefaultRateLimits is `false` (matches Supabase's published
+// safe default). A project running purely behind nginx-ingress should
+// set it to true once they understand the trade-off; the runbook in
+// #230 explains the decision.
+func ClientIPForProject(r *http.Request, trustProxy bool) string {
+	if trustProxy {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			for i := 0; i < len(xff); i++ {
+				if xff[i] == ',' {
+					return xff[:i]
+				}
+			}
+			return xff
+		}
+	}
+	return remoteAddrNoPort(r)
+}
+
+// remoteAddrNoPort returns r.RemoteAddr with any trailing ":port" stripped.
+// Stable across both helpers so changes to address parsing (e.g. IPv6
+// brackets) land in one place.
+func remoteAddrNoPort(r *http.Request) string {
 	addr := r.RemoteAddr
 	for i := len(addr) - 1; i >= 0; i-- {
 		if addr[i] == ':' {

--- a/internal/ratelimit/client_ip_test.go
+++ b/internal/ratelimit/client_ip_test.go
@@ -73,6 +73,35 @@ func TestClientIPForProject_SingleXFFEntry(t *testing.T) {
 	}
 }
 
+// Leftmost-XFF must come back without the leading whitespace a
+// comma-and-space separator would have introduced. A "203.0.113.7,
+// 10.0.0.5" header read with no trim would key on " 203.0.113.7" and
+// "203.0.113.7" as separate counters; the trim collapses them. #237
+// review minor.
+func TestClientIPForProject_LeftmostXFFTrimsSpace(t *testing.T) {
+	cases := []struct {
+		name string
+		xff  string
+		want string
+	}{
+		{"no space, multiple entries", "203.0.113.7,10.0.0.5", "203.0.113.7"},
+		{"comma + space, multiple entries", "203.0.113.7, 10.0.0.5", "203.0.113.7"},
+		{"leading space single entry", "  198.51.100.1", "198.51.100.1"},
+		{"trailing space single entry", "198.51.100.1  ", "198.51.100.1"},
+		{"comma + tab", "203.0.113.7,\t10.0.0.5", "203.0.113.7"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", "/", nil)
+			r.RemoteAddr = "10.0.0.5:54321"
+			r.Header.Set("X-Forwarded-For", c.xff)
+			if got := ClientIPForProject(r, true); got != c.want {
+				t.Errorf("XFF %q → got %q, want %q", c.xff, got, c.want)
+			}
+		})
+	}
+}
+
 // Snapshot the legacy ClientIP behaviour — confirms #228 doesn't
 // regress the platform-wide helper (still used in router.go for the
 // audit log's client IP and for legacy auth helpers).

--- a/internal/ratelimit/client_ip_test.go
+++ b/internal/ratelimit/client_ip_test.go
@@ -1,0 +1,92 @@
+package ratelimit
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// #228: ClientIPForProject is the trust-proxy-aware sibling of ClientIP.
+// Three load-bearing properties the per-project gates depend on:
+//
+//   1. trustProxy=true  → leftmost X-Forwarded-For wins when present.
+//   2. trustProxy=false → X-Forwarded-For is IGNORED entirely (even
+//      when present), and the TCP peer is returned. This is the
+//      anti-XFF-forgery side of the knob.
+//   3. Either way, when there's no X-Forwarded-For header, the TCP
+//      peer is returned (so the helper has a meaningful answer in
+//      direct-connection scenarios).
+
+func TestClientIPForProject_TrustsXFFWhenEnabled(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.5")
+
+	got := ClientIPForProject(r, true)
+	if got != "203.0.113.7" {
+		t.Errorf("trustProxy=true must return leftmost XFF, got %q", got)
+	}
+}
+
+func TestClientIPForProject_IgnoresXFFWhenDisabled(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.5")
+
+	got := ClientIPForProject(r, false)
+	if got != "10.0.0.5" {
+		t.Errorf("trustProxy=false must use TCP peer (no XFF), got %q", got)
+	}
+}
+
+func TestClientIPForProject_NoXFFFallsBackToTCPPeer(t *testing.T) {
+	cases := []struct {
+		name       string
+		trustProxy bool
+	}{
+		{"trustProxy=true", true},
+		{"trustProxy=false", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", "/", nil)
+			r.RemoteAddr = "192.0.2.42:9999"
+			// no XFF header
+			got := ClientIPForProject(r, c.trustProxy)
+			if got != "192.0.2.42" {
+				t.Errorf("no XFF + %s: expected TCP peer 192.0.2.42, got %q", c.name, got)
+			}
+		})
+	}
+}
+
+func TestClientIPForProject_SingleXFFEntry(t *testing.T) {
+	// nginx-ingress default writes a single XFF entry (overwrites,
+	// doesn't append). The leftmost-extract path must work without a
+	// comma being present.
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("X-Forwarded-For", "198.51.100.1")
+
+	got := ClientIPForProject(r, true)
+	if got != "198.51.100.1" {
+		t.Errorf("single XFF entry should be returned verbatim, got %q", got)
+	}
+}
+
+// Snapshot the legacy ClientIP behaviour — confirms #228 doesn't
+// regress the platform-wide helper (still used in router.go for the
+// audit log's client IP and for legacy auth helpers).
+func TestClientIP_LegacyBehaviorUnchanged(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.5")
+	if got := ClientIP(r); got != "203.0.113.7" {
+		t.Errorf("legacy ClientIP must still trust leftmost XFF, got %q", got)
+	}
+
+	r2 := httptest.NewRequest("POST", "/", nil)
+	r2.RemoteAddr = "192.0.2.42:9999"
+	if got := ClientIP(r2); got != "192.0.2.42" {
+		t.Errorf("legacy ClientIP with no XFF must fall back to TCP peer, got %q", got)
+	}
+}

--- a/internal/tenant/auth_config.go
+++ b/internal/tenant/auth_config.go
@@ -94,44 +94,105 @@ type RateLimits struct {
 	SMSPerHour int `json:"sms_per_hour,omitempty"`
 
 	// TrustProxy controls whether the per-project rate limiter keys off
-	// the leftmost X-Forwarded-For entry (true) or the TCP peer (false,
-	// default — XFF can be forged when not behind a controlled hop).
-	// Enforced by ratelimit.ClientIPForProject (#228). The deployment
-	// trade-off: a project running purely behind a controlled ingress
-	// (nginx-ingress in Eurobase prod) gets per-end-user accuracy by
-	// opting in; a project reached without a trusted intermediate hop
-	// stays safe at the default.
-	TrustProxy bool `json:"trust_proxy,omitempty"`
+	// the leftmost X-Forwarded-For entry (true) or the TCP peer (false).
+	// Enforced by ratelimit.ClientIPForProject (#228).
+	//
+	// *bool, not bool, so we can tell "user explicitly set false" apart
+	// from "field absent → use platform default". With a plain bool,
+	// any project that ever saved a RateLimits sub-object without a
+	// trust_proxy field would lock in `false` regardless of what the
+	// platform default later said. The pointer keeps the override
+	// honest — nil means "I haven't decided; pick the platform's
+	// answer". EffectiveRateLimits guarantees the pointer is non-nil
+	// in its return value, so callers can dereference safely.
+	//
+	// ── Why the Eurobase default is true (and Supabase ships false) ──
+	//
+	// The same word "trust_proxy" means different things in different
+	// deployments. The relevant question for any rate limiter is:
+	// "where does the identifier you're keying on actually come from?"
+	//
+	// In Eurobase prod, every request lands on the gateway via
+	// nginx-ingress. nginx-ingress's default policy (which we ship — no
+	// `use-forwarded-headers` override in deploy/k8s/ingress.yaml)
+	// **overwrites X-Forwarded-For on every request** with the IP of
+	// the previous TCP hop. So:
+	//   * XFF, as the gateway sees it, is the *real client IP* (browser
+	//     or customer backend), written by an infrastructure layer the
+	//     attacker cannot forge through.
+	//   * The Go TCP peer (`r.RemoteAddr`) is the *nginx pod IP* — the
+	//     same value for every single request in the cluster.
+	//
+	// Set TrustProxy=true → key on the real client IP. Project A's
+	// 100 worldwide users each get their own counter; the
+	// `signup_signin_per_5min_per_ip: 8` default reads as "any one
+	// end-user can attempt 8 signups per 5 min", which is the
+	// number's intended meaning.
+	//
+	// Set TrustProxy=false → key on the TCP peer = nginx pod IP. All
+	// 100 of Project A's users share one counter, because Go sees the
+	// same RemoteAddr for all of them. The same 8-per-5min budget
+	// now means "Project A, combined across every user on Earth, gets
+	// 8 signups per 5 minutes". A small office trying to onboard a
+	// team would self-DoS in 30 seconds.
+	//
+	// Supabase ships `false` as their default because their architecture
+	// has clients that may set forged XFF that the platform never
+	// rewrites — there, trusting XFF would let an attacker rotate it
+	// and bypass the limiter. The same default in Eurobase is the
+	// opposite of safe: it discards the only IP signal that exists
+	// (the ingress-rewritten XFF) and falls back to a value (nginx pod
+	// IP) that's identical for everyone. We use `true` because we
+	// trust nginx-ingress's XFF rewrite, which we configured.
+	//
+	// A project whose traffic does NOT come via the platform ingress
+	// (an unusual setup — a pre-prod tenant on a non-standard route, a
+	// customer-side proxy that adds an extra forwarded hop the ingress
+	// then appends to) can flip this knob to false explicitly. The
+	// console UI in #229 will surface the choice with the same
+	// trade-off written out, so opting out is informed.
+	TrustProxy *bool `json:"trust_proxy,omitempty"`
 }
 
 // DefaultRateLimits returns the platform-wide defaults applied when a
 // project hasn't overridden a knob.
 //
-// Most numbers mirror Supabase's published defaults. The exception is
-// SignupSigninPer5MinPerIP: Supabase ships 30 (≈360/hour), but in
-// Eurobase that ceiling is only safe once the compensating EmailsPerHour
-// cap is actually enforced — and email/SMS enforcement is scheduled for
-// #227, not this PR. An interim default of 8 (≈96/hour) is the
-// middle ground: ~20× more usable than the legacy 5/hour gate (a shared
-// NAT'd office IP no longer trips on the second user), but ~3.6× tighter
-// blast radius than 360/hour until the email cap closes the
-// amplification path. Bump to 30 in #227 when EmailsPerHour starts
-// rejecting over-quota sends.
+// Most numbers mirror Supabase's published defaults. Two deliberate
+// divergences:
+//
+//   * SignupSigninPer5MinPerIP = 8 (not 30): held at the interim
+//     ~96/h floor while EmailsPerHour enforcement is parked behind
+//     the BYO-SMTP feature in #235. Bumps to 30 when that lands.
+//
+//   * TrustProxy = true (Supabase ships false): in Eurobase's
+//     nginx-ingress deployment the IP source is upside-down compared
+//     to Supabase's architecture. See the TrustProxy field comment
+//     for the full mechanics; the short version is that `false`
+//     here makes every project share one counter across all its
+//     end users (nginx pod IP) while `true` keys on the real
+//     client IP that ingress writes. The shipped default matches
+//     the deployment.
 func DefaultRateLimits() RateLimits {
+	trueVal := true
 	return RateLimits{
 		SignupSigninPer5MinPerIP:      8,
 		TokenRefreshPer5MinPerIP:      150,
 		TokenVerificationPer5MinPerIP: 30,
 		EmailsPerHour:                 2,
 		SMSPerHour:                    30,
-		TrustProxy:                    false,
+		TrustProxy:                    &trueVal,
 	}
 }
 
 // EffectiveRateLimits returns the merged knobs: each zero-valued override
 // in the project's stored config is filled from DefaultRateLimits. Safe to
-// call on a config whose RateLimits field is nil. The result is a value
-// (not a pointer) so callers can read fields without nil-checking.
+// call on a config whose RateLimits field is nil.
+//
+// The returned value is guaranteed to have all int fields non-zero AND
+// TrustProxy non-nil, so callers can read every field without nil checks.
+// (TrustProxy is *bool in the storage shape so we can distinguish
+// "explicit false" from "field absent"; the merge below collapses that
+// distinction so the consumer never has to.)
 func (c *AuthConfig) EffectiveRateLimits() RateLimits {
 	defaults := DefaultRateLimits()
 	if c == nil || c.RateLimits == nil {
@@ -153,8 +214,9 @@ func (c *AuthConfig) EffectiveRateLimits() RateLimits {
 	if out.SMSPerHour == 0 {
 		out.SMSPerHour = defaults.SMSPerHour
 	}
-	// TrustProxy is a deliberate-set-only knob: an absent / false value
-	// means "do not trust forwarded headers". No default merge.
+	if out.TrustProxy == nil {
+		out.TrustProxy = defaults.TrustProxy
+	}
 	return out
 }
 

--- a/internal/tenant/auth_config.go
+++ b/internal/tenant/auth_config.go
@@ -106,81 +106,91 @@ type RateLimits struct {
 	// answer". EffectiveRateLimits guarantees the pointer is non-nil
 	// in its return value, so callers can dereference safely.
 	//
-	// ── Why the Eurobase default is true (and Supabase ships false) ──
+	// ── The two-direction trade-off ──
 	//
-	// The same word "trust_proxy" means different things in different
-	// deployments. The relevant question for any rate limiter is:
-	// "where does the identifier you're keying on actually come from?"
+	// The choice between `true` and `false` here trades one failure
+	// mode for the opposite one — the right answer depends on the
+	// deployment, and "safe by default" depends on which side you're
+	// most worried about.
 	//
-	// In Eurobase prod, every request lands on the gateway via
-	// nginx-ingress. nginx-ingress's default policy (which we ship — no
-	// `use-forwarded-headers` override in deploy/k8s/ingress.yaml)
-	// **overwrites X-Forwarded-For on every request** with the IP of
-	// the previous TCP hop. So:
-	//   * XFF, as the gateway sees it, is the *real client IP* (browser
-	//     or customer backend), written by an infrastructure layer the
-	//     attacker cannot forge through.
-	//   * The Go TCP peer (`r.RemoteAddr`) is the *nginx pod IP* — the
-	//     same value for every single request in the cluster.
+	// TrustProxy = true (key on leftmost XFF):
+	//   * Correct only if **exactly one trusted hop authoritatively
+	//     overwrites XFF with the real client IP**. nginx-ingress with
+	//     `use-forwarded-headers: false` does exactly that.
+	//   * Gives true per-end-user keying — the published
+	//     "per-IP" knob means what the UI says.
+	//   * Failure mode: if the chain APPENDS to XFF (typical with
+	//     `use-forwarded-headers: true`, sometimes needed to recover
+	//     the client IP through a load balancer), leftmost-XFF is
+	//     client-controlled. An attacker rotating the header bypasses
+	//     every per-IP gate.
 	//
-	// Set TrustProxy=true → key on the real client IP. Project A's
-	// 100 worldwide users each get their own counter; the
-	// `signup_signin_per_5min_per_ip: 8` default reads as "any one
-	// end-user can attempt 8 signups per 5 min", which is the
-	// number's intended meaning.
+	// TrustProxy = false (key on TCP peer):
+	//   * Safe under any XFF configuration — no infra assumption.
+	//   * Failure mode: in deployments that pre-aggregate behind a
+	//     controlled hop (every Eurobase prod request comes through
+	//     one nginx pod), `r.RemoteAddr` is the same value for every
+	//     request. The "per-IP" gate effectively becomes per-project
+	//     total — a 9-person office team can't all sign up in the
+	//     same hour.
 	//
-	// Set TrustProxy=false → key on the TCP peer = nginx pod IP. All
-	// 100 of Project A's users share one counter, because Go sees the
-	// same RemoteAddr for all of them. The same 8-per-5min budget
-	// now means "Project A, combined across every user on Earth, gets
-	// 8 signups per 5 minutes". A small office trying to onboard a
-	// team would self-DoS in 30 seconds.
+	// ── Why the Eurobase default is false (for now) ──
 	//
-	// Supabase ships `false` as their default because their architecture
-	// has clients that may set forged XFF that the platform never
-	// rewrites — there, trusting XFF would let an attacker rotate it
-	// and bypass the limiter. The same default in Eurobase is the
-	// opposite of safe: it discards the only IP signal that exists
-	// (the ingress-rewritten XFF) and falls back to a value (nginx pod
-	// IP) that's identical for everyone. We use `true` because we
-	// trust nginx-ingress's XFF rewrite, which we configured.
+	// The default-true correctness depends on the Scaleway LB ↔
+	// nginx-ingress XFF behavior — none of which is declared in this
+	// repo (the Ingress YAML only sets ssl-redirect and proxy-body-
+	// size; there's no controller ConfigMap or LB-side proxy-protocol
+	// annotation). Until that's verified empirically in prod, shipping
+	// `true` as the default would lean on an assumption we haven't
+	// confirmed: if a future operator (or a never-noticed current
+	// config) flips `use-forwarded-headers: true`, every per-IP gate
+	// becomes a header-rotation bypass without anything in code
+	// changing.
 	//
-	// A project whose traffic does NOT come via the platform ingress
-	// (an unusual setup — a pre-prod tenant on a non-standard route, a
-	// customer-side proxy that adds an extra forwarded hop the ingress
-	// then appends to) can flip this knob to false explicitly. The
-	// console UI in #229 will surface the choice with the same
-	// trade-off written out, so opting out is informed.
+	// So we ship `false`, accept the per-project-total degradation,
+	// and track the proper flip in a follow-up: verify what XFF the
+	// gateway actually receives, document the required ingress + LB
+	// config as a hard precondition, then re-default to true. The
+	// long-term hardening is a trusted-hop-count / known-proxy-CIDR
+	// strategy that's robust to both extra hops and header forgery;
+	// the same follow-up covers that.
+	//
+	// Projects that know their deployment trusts XFF can opt in today
+	// by setting `"trust_proxy": true` in auth_config; the console UI
+	// in #229 will surface this choice with the same trade-off
+	// written out.
 	TrustProxy *bool `json:"trust_proxy,omitempty"`
 }
 
 // DefaultRateLimits returns the platform-wide defaults applied when a
 // project hasn't overridden a knob.
 //
-// Most numbers mirror Supabase's published defaults. Two deliberate
-// divergences:
+// Most numbers mirror Supabase's published defaults. One deliberate
+// divergence:
 //
 //   * SignupSigninPer5MinPerIP = 8 (not 30): held at the interim
 //     ~96/h floor while EmailsPerHour enforcement is parked behind
 //     the BYO-SMTP feature in #235. Bumps to 30 when that lands.
 //
-//   * TrustProxy = true (Supabase ships false): in Eurobase's
-//     nginx-ingress deployment the IP source is upside-down compared
-//     to Supabase's architecture. See the TrustProxy field comment
-//     for the full mechanics; the short version is that `false`
-//     here makes every project share one counter across all its
-//     end users (nginx pod IP) while `true` keys on the real
-//     client IP that ingress writes. The shipped default matches
-//     the deployment.
+// TrustProxy ships as false (Supabase parity, safe-by-default). In
+// Eurobase's deployment a true default would key off the nginx-ingress
+// XFF rewrite — and *if* `use-forwarded-headers: true` is set anywhere
+// in the Scaleway-LB → nginx chain, leftmost XFF becomes
+// client-controlled and every per-IP gate becomes header-rotation-
+// bypassable. A separate follow-up issue tracks empirically verifying
+// the chain's XFF behavior in prod; once confirmed safe, the default
+// can flip via the console (or this constant). Project owners who know
+// their deployment trusts XFF can opt in today — see the TrustProxy
+// field comment for the precondition.
 func DefaultRateLimits() RateLimits {
-	trueVal := true
+	falseVal := false
 	return RateLimits{
 		SignupSigninPer5MinPerIP:      8,
 		TokenRefreshPer5MinPerIP:      150,
 		TokenVerificationPer5MinPerIP: 30,
 		EmailsPerHour:                 2,
 		SMSPerHour:                    30,
-		TrustProxy:                    &trueVal,
+		TrustProxy:                    &falseVal,
 	}
 }
 

--- a/internal/tenant/auth_config.go
+++ b/internal/tenant/auth_config.go
@@ -96,9 +96,11 @@ type RateLimits struct {
 	// TrustProxy controls whether the per-project rate limiter keys off
 	// the leftmost X-Forwarded-For entry (true) or the TCP peer (false,
 	// default — XFF can be forged when not behind a controlled hop).
-	// Wired in #228. Pointer-equivalent semantics on a bool are clunky
-	// in JSON, so we treat `false` as the safe default — a project that
-	// wants to flip it sets it to `true` explicitly.
+	// Enforced by ratelimit.ClientIPForProject (#228). The deployment
+	// trade-off: a project running purely behind a controlled ingress
+	// (nginx-ingress in Eurobase prod) gets per-end-user accuracy by
+	// opting in; a project reached without a trusted intermediate hop
+	// stays safe at the default.
 	TrustProxy bool `json:"trust_proxy,omitempty"`
 }
 

--- a/internal/tenant/rate_limits_test.go
+++ b/internal/tenant/rate_limits_test.go
@@ -94,28 +94,31 @@ func TestEffectiveRateLimits_ZeroMeansDefault(t *testing.T) {
 
 func TestEffectiveRateLimits_TrustProxyDefaultsAndOverrides(t *testing.T) {
 	// TrustProxy is *bool so we can distinguish "absent" from
-	// "explicit false". Three behaviours the per-project gates rely on:
+	// "explicit false". Four behaviours the per-project gates rely on:
 	//
-	//   1. Nil RateLimits → default true (Eurobase ingress-aware
-	//      default; see the field doc for why we diverge from Supabase).
-	//   2. Explicit false in storage → false (project opted out).
-	//   3. Explicit true in storage → true.
+	//   1. Nil RateLimits → default false (safe-by-default Supabase
+	//      parity; the verification-pending follow-up tracks flipping
+	//      this once the Scaleway LB ↔ nginx XFF chain is confirmed).
+	//   2. Empty RateLimits, no trust_proxy field → same default.
+	//   3. Explicit false in storage → false (no surprise).
+	//   4. Explicit true in storage → true (project opted in after
+	//      confirming the ingress trusts XFF).
 	falsePtr := false
 	truePtr := true
 
 	cNil := &AuthConfig{}
-	if got := cNil.EffectiveRateLimits().TrustProxy; got == nil || !*got {
-		t.Errorf("TrustProxy must default to true on nil RateLimits, got %v", got)
+	if got := cNil.EffectiveRateLimits().TrustProxy; got == nil || *got {
+		t.Errorf("TrustProxy must default to false on nil RateLimits, got %v", got)
 	}
 
 	cAbsentField := &AuthConfig{RateLimits: &RateLimits{}}
-	if got := cAbsentField.EffectiveRateLimits().TrustProxy; got == nil || !*got {
-		t.Errorf("TrustProxy must default to true when the field is absent, got %v", got)
+	if got := cAbsentField.EffectiveRateLimits().TrustProxy; got == nil || *got {
+		t.Errorf("TrustProxy must default to false when the field is absent, got %v", got)
 	}
 
 	cExplicitFalse := &AuthConfig{RateLimits: &RateLimits{TrustProxy: &falsePtr}}
 	if got := cExplicitFalse.EffectiveRateLimits().TrustProxy; got == nil || *got {
-		t.Errorf("explicit TrustProxy=false must stay false (override), got %v", got)
+		t.Errorf("explicit TrustProxy=false must stay false, got %v", got)
 	}
 
 	cExplicitTrue := &AuthConfig{RateLimits: &RateLimits{TrustProxy: &truePtr}}
@@ -150,8 +153,8 @@ func TestDefaultRateLimits_Numbers(t *testing.T) {
 			t.Errorf("default %s: got %d, want %d", k, got[k], want)
 		}
 	}
-	if d.TrustProxy == nil || !*d.TrustProxy {
-		t.Errorf("default TrustProxy must be true (Eurobase ingress-aware default), got %v", d.TrustProxy)
+	if d.TrustProxy == nil || *d.TrustProxy {
+		t.Errorf("default TrustProxy must be false (Supabase parity, safe-by-default), got %v", d.TrustProxy)
 	}
 }
 

--- a/internal/tenant/rate_limits_test.go
+++ b/internal/tenant/rate_limits_test.go
@@ -14,11 +14,32 @@ import "testing"
 //     "back to default", not "block everything".
 //   * trust_proxy is deliberate-set-only: false stays false, never
 //     promoted to a default
+// rateLimitsEqual compares two RateLimits values field-by-field. Direct
+// `==` doesn't work since `TrustProxy *bool` is now a pointer; two
+// equal-valued pointers from separate DefaultRateLimits() calls have
+// different addresses.
+func rateLimitsEqual(a, b RateLimits) bool {
+	if a.SignupSigninPer5MinPerIP != b.SignupSigninPer5MinPerIP ||
+		a.TokenRefreshPer5MinPerIP != b.TokenRefreshPer5MinPerIP ||
+		a.TokenVerificationPer5MinPerIP != b.TokenVerificationPer5MinPerIP ||
+		a.EmailsPerHour != b.EmailsPerHour ||
+		a.SMSPerHour != b.SMSPerHour {
+		return false
+	}
+	if (a.TrustProxy == nil) != (b.TrustProxy == nil) {
+		return false
+	}
+	if a.TrustProxy != nil && *a.TrustProxy != *b.TrustProxy {
+		return false
+	}
+	return true
+}
+
 func TestEffectiveRateLimits_NilConfig(t *testing.T) {
 	var c *AuthConfig
 	got := c.EffectiveRateLimits()
 	want := DefaultRateLimits()
-	if got != want {
+	if !rateLimitsEqual(got, want) {
 		t.Fatalf("nil receiver should give DefaultRateLimits, got %+v want %+v", got, want)
 	}
 }
@@ -27,7 +48,7 @@ func TestEffectiveRateLimits_NilRateLimits(t *testing.T) {
 	c := &AuthConfig{}
 	got := c.EffectiveRateLimits()
 	want := DefaultRateLimits()
-	if got != want {
+	if !rateLimitsEqual(got, want) {
 		t.Fatalf("nil RateLimits should give defaults, got %+v want %+v", got, want)
 	}
 }
@@ -71,21 +92,35 @@ func TestEffectiveRateLimits_ZeroMeansDefault(t *testing.T) {
 	}
 }
 
-func TestEffectiveRateLimits_TrustProxyStaysOptIn(t *testing.T) {
-	// TrustProxy is NOT default-merged: an absent / false value means
-	// "do not trust X-Forwarded-For". Promoting it to a default would
-	// be a privacy/security regression for projects without an edge.
+func TestEffectiveRateLimits_TrustProxyDefaultsAndOverrides(t *testing.T) {
+	// TrustProxy is *bool so we can distinguish "absent" from
+	// "explicit false". Three behaviours the per-project gates rely on:
+	//
+	//   1. Nil RateLimits → default true (Eurobase ingress-aware
+	//      default; see the field doc for why we diverge from Supabase).
+	//   2. Explicit false in storage → false (project opted out).
+	//   3. Explicit true in storage → true.
+	falsePtr := false
+	truePtr := true
+
 	cNil := &AuthConfig{}
-	if cNil.EffectiveRateLimits().TrustProxy {
-		t.Error("TrustProxy must default to false on nil RateLimits")
+	if got := cNil.EffectiveRateLimits().TrustProxy; got == nil || !*got {
+		t.Errorf("TrustProxy must default to true on nil RateLimits, got %v", got)
 	}
-	cExplicitFalse := &AuthConfig{RateLimits: &RateLimits{TrustProxy: false}}
-	if cExplicitFalse.EffectiveRateLimits().TrustProxy {
-		t.Error("explicit TrustProxy=false must stay false (not promoted)")
+
+	cAbsentField := &AuthConfig{RateLimits: &RateLimits{}}
+	if got := cAbsentField.EffectiveRateLimits().TrustProxy; got == nil || !*got {
+		t.Errorf("TrustProxy must default to true when the field is absent, got %v", got)
 	}
-	cTrue := &AuthConfig{RateLimits: &RateLimits{TrustProxy: true}}
-	if !cTrue.EffectiveRateLimits().TrustProxy {
-		t.Error("explicit TrustProxy=true must pass through")
+
+	cExplicitFalse := &AuthConfig{RateLimits: &RateLimits{TrustProxy: &falsePtr}}
+	if got := cExplicitFalse.EffectiveRateLimits().TrustProxy; got == nil || *got {
+		t.Errorf("explicit TrustProxy=false must stay false (override), got %v", got)
+	}
+
+	cExplicitTrue := &AuthConfig{RateLimits: &RateLimits{TrustProxy: &truePtr}}
+	if got := cExplicitTrue.EffectiveRateLimits().TrustProxy; got == nil || !*got {
+		t.Errorf("explicit TrustProxy=true must pass through, got %v", got)
 	}
 }
 
@@ -115,8 +150,8 @@ func TestDefaultRateLimits_Numbers(t *testing.T) {
 			t.Errorf("default %s: got %d, want %d", k, got[k], want)
 		}
 	}
-	if d.TrustProxy {
-		t.Error("default TrustProxy must be false (safe default)")
+	if d.TrustProxy == nil || !*d.TrustProxy {
+		t.Errorf("default TrustProxy must be true (Eurobase ingress-aware default), got %v", d.TrustProxy)
 	}
 }
 
@@ -146,8 +181,8 @@ func TestParseAuthConfig_RateLimitsRoundTrip(t *testing.T) {
 	if eff.EmailsPerHour != 3 {
 		t.Errorf("EmailsPerHour: got %d, want 3", eff.EmailsPerHour)
 	}
-	if !eff.TrustProxy {
-		t.Error("TrustProxy: got false, want true")
+	if eff.TrustProxy == nil || !*eff.TrustProxy {
+		t.Errorf("TrustProxy: want true (explicit override), got %v", eff.TrustProxy)
 	}
 	// Unspecified knob falls back to default.
 	if eff.SMSPerHour != DefaultRateLimits().SMSPerHour {


### PR DESCRIPTION
Closes #228 (umbrella #224). Per-project IP-source switch + flips the default to true (Supabase divergence) because Eurobase nginx-ingress rewrites XFF — false would collapse every projects per-IP counter to per-project-total. Detailed deployment rationale lives in three doc blocks (RateLimits.TrustProxy field, DefaultRateLimits, ClientIPForProject helper). See commit body for the full story.