### PR TITLE
fix #230: rate-limits docs + at-the-limit integration tests

### DIFF
--- a/docs/compliance/rate-limits.md
+++ b/docs/compliance/rate-limits.md
@@ -1,0 +1,224 @@
+# Per-Project Rate Limits
+
+> Umbrella issue [#224](https://github.com/STGime/euroback/issues/224). Mirrors
+> Supabase's published Rate Limits page so the UX is familiar; the numbers
+> and the enforcement architecture are described below. Console UI:
+> **Auth → Rate Limits** tab on `/p/{id}/auth`.
+
+## What it is
+
+A small set of per-project knobs that decide how much load any one IP (or
+the whole project) can put on the platform's auth and notification
+pipelines. They exist to safeguard:
+
+1. **The platform**, against burst abuse from one project tanking
+   shared infrastructure (Scaleway TEM sender reputation, GatewayAPI
+   spend, the auth pool's RPS budget).
+2. **The project owner**, against runaway costs from a
+   misconfigured client or a leaked anon key.
+3. **End users**, against brute-force on signup, sign-in, token
+   refresh, and OTP verify.
+
+The numbers are tuned to give legitimate apps room to breathe and
+hostile traffic a wall to hit. Project owners can tighten or loosen
+each knob from the console; the underlying limiter uses the per-tenant
+shape so two projects on the same Redis can never collide.
+
+## Defaults
+
+These are the values returned by `DefaultRateLimits()` in
+`internal/tenant/auth_config.go`. Empty fields in the console form
+fall back to these. If you change one in code, update this table.
+
+| Knob | Default | Unit | Notes |
+|---|---|---|---|
+| `signup_signin_per_5min_per_ip` | **8** | requests / 5 min / IP | Held below Supabase's 30 until `emails_per_hour` enforcement lands (#235); the lower interim caps the verification-email amplification path. Bumps to 30 then. |
+| `token_refresh_per_5min_per_ip` | **150** | requests / 5 min / IP | High because legitimate SDK clients refresh proactively. |
+| `token_verification_per_5min_per_ip` | **30** | requests / 5 min / IP | Covers OTP, magic-link verify, email verify, reset. 6-digit OTP brute-force defence sits on top of (and depends on) #233. |
+| `emails_per_hour` | **2** | sends / hour / project | **Defined but not yet enforced.** Parked behind BYO-SMTP (#235) — the platform's single-shared-SMTP model would silently break confirmation flows under the 2/h floor. The field in `auth_config.rate_limits` saves but no code path consumes it today. |
+| `sms_per_hour` | **30** | sends / hour / project | Enforced. Over-quota sends are silently skipped with a `slog.Warn` operator signal; the phone-OTP handler still returns 200 so a 429 can't reveal phone-membership. |
+| `trust_proxy` | **false** | bool | Whether the limiter trusts the leftmost `X-Forwarded-For`. See [IP source — `trust_proxy`](#ip-source--trust_proxy) for the trade-off. |
+
+## How limits are enforced
+
+The same `RateLimiter.Allow` primitive (Redis INCR + EXPIRE via a Lua
+script, `internal/ratelimit/limiter.go`) is used everywhere. The
+difference between knobs is the **key shape** and the **window**.
+
+### Per-IP auth gates (signup/signin, token refresh, token verify)
+
+Key shape:
+
+```
+auth:{action}:project:{projectID}:{identifier}
+```
+
+Where `action` is one of `signup_signin`, `token_refresh`,
+`token_verify`, and `identifier` is the value returned by
+`ratelimit.ClientIPForProject(r, trustProxy)`. Counter resets at the
+end of its 5-minute window.
+
+Distinct from the legacy / platform-wide
+
+```
+auth:{action}:{identifier}
+```
+
+key still used by per-email anti-brute-force gates (signin failures,
+forgot-password, magic-link, resend-verify, phone OTP). Those gates
+are NOT exposed on the Rate Limits page — they're security floors,
+not knobs — and they stay at platform defaults regardless of what a
+project sets here.
+
+### Per-project hourly quotas (email, SMS)
+
+Key shape:
+
+```
+quota:{email|sms}:project:{projectID}
+```
+
+Window: 1 hour, TTL-managed by Redis. One counter per project per
+action; checked **before** the underlying provider call so an
+over-quota send never reaches TEM / GatewayAPI.
+
+Email enforcement is dormant today (see [`emails_per_hour`](#defaults))
+but the key is reserved.
+
+### Fail-open behaviour
+
+When Redis is unreachable (dev without Redis, transient outage), every
+rate-limit check returns "allowed" with no error. The rationale: a
+quota outage shouldn't take auth offline platform-wide, and the
+upstream provider quotas (TEM, GatewayAPI, the gateway pool) are a
+hard backstop. The Discord `#alerts` channel pages on Redis
+unreachability via the cluster health monitor; rate-limit decisions
+just stop applying until the limiter recovers.
+
+## IP source — `trust_proxy`
+
+The most consequential knob. Same word means different things in
+different deployments and the right answer depends on the chain
+between the client and the gateway.
+
+### Mechanics
+
+- **`trust_proxy = true`** — read leftmost `X-Forwarded-For`; fall
+  back to the TCP peer if XFF is absent.
+- **`trust_proxy = false`** — read TCP peer (`r.RemoteAddr`); XFF is
+  ignored entirely.
+
+### The two failure modes
+
+Picking the wrong value breaks the limiter in one of two ways.
+
+**`true` under header forgery — security-critical.** If anything in
+the chain *appends* to XFF instead of overwriting it (typical with
+nginx-ingress `use-forwarded-headers: true`, sometimes needed to
+recover the client IP through a load balancer), the leftmost entry
+is **client-controlled**. An attacker rotating the header bypasses
+every per-IP gate — signup spam, OTP brute-force, token-refresh
+flooding.
+
+**`false` behind one shared hop — limiter collapse.** In a deployment
+where every request hits the gateway through one nginx pod (Eurobase
+prod), `r.RemoteAddr` is the same value for every request. With
+`SignupSigninPer5MinPerIP=8`, a 9-person office team can't all sign
+up in the same 5 minutes — the "per-IP" gate becomes a "per-project
+total" gate.
+
+### Eurobase default: `false` (pending #238 verification)
+
+`#238` tracks the empirical verification of what XFF the gateway
+actually receives in prod (`curl -H 'X-Forwarded-For: 1.2.3.4'`
+against the gateway, then check `data_access_log` for the recorded
+IP). Until that's confirmed, the default is the safe side: `false`
+keeps the limiter resistant to header forgery at the cost of the
+per-IP discrimination collapsing to per-project total. Project owners
+who know their deployment trusts XFF can flip the toggle in the
+console today; the precondition `#238` will document for the default
+to flip is roughly:
+
+1. nginx-ingress `use-forwarded-headers: false` (the default; we
+   ship no override).
+2. Scaleway LB delivering the real client IP via PROXY protocol OR
+   `externalTrafficPolicy: Local` on the nginx-ingress Service.
+
+If both hold, leftmost XFF is the real client IP and the safe default
+is `true`. The long-term hardening is a trusted-hop-count / known-proxy-
+CIDR strategy that's robust to either failure mode — that's also
+tracked in `#238`.
+
+## Debugging — Redis snippets
+
+All commands assume a `redis-cli` connection scoped to the prod
+limiter Redis. Replace `<projectID>` with the tenant UUID.
+
+### "Is this IP currently capped?"
+
+```sh
+# Counter for the signup/signin per-IP gate
+redis-cli get "auth:signup_signin:project:<projectID>:1.2.3.4"
+# TTL (seconds until the window resets)
+redis-cli ttl "auth:signup_signin:project:<projectID>:1.2.3.4"
+```
+
+If the value is at or above the configured limit and the TTL is > 0,
+the next request from `1.2.3.4` to this project's signup or signin
+will return 429.
+
+### "Where did the project's hourly SMS budget go?"
+
+```sh
+# Current hour's count
+redis-cli get "quota:sms:project:<projectID>"
+# When does the bucket reset
+redis-cli ttl "quota:sms:project:<projectID>"
+```
+
+If the value equals `auth_config.rate_limits.sms_per_hour` (or the
+default 30) and the TTL is > 0, the next OTP send for the project
+silently skips with a `slog.Warn` line.
+
+### "Force a counter reset"
+
+```sh
+# Burn the per-IP signup counter for this project + IP
+redis-cli del "auth:signup_signin:project:<projectID>:1.2.3.4"
+```
+
+Resets the budget immediately. Use during incident response when a
+legitimate caller is collateral damage from a misset cap.
+
+## Override precedence
+
+1. **Explicit project override** — the value persisted in
+   `auth_config.rate_limits.{knob}` via the console / API.
+2. **Platform default** — `DefaultRateLimits()` in
+   `internal/tenant/auth_config.go`, the values in this doc's
+   defaults table.
+
+`EffectiveRateLimits()` (`internal/tenant/auth_config.go`) does the
+merge: zero / absent numeric fields fall through to the platform
+default; `trust_proxy *bool` distinguishes "explicit `false`" from
+"absent" so a project that explicitly opted out stays opted out
+even if the platform default flips.
+
+There is **no per-plan tier** today — the same defaults apply to
+Free and Pro projects. Once the Pro tier ships (Mollie billing,
+#163), this doc gets a third precedence column.
+
+## Related
+
+- `#224` — umbrella issue.
+- `#225` foundation: schema, helper, signup+signin gates.
+- `#226` token refresh + token verification gates.
+- `#227` / PR #234: SMS hourly quota; email half deferred behind
+  `#235`.
+- `#228`: `trust_proxy` enforcement.
+- `#229`: console UI (Auth → Rate Limits tab).
+- `#233`: phone-OTP code-only verify SQL fix (the gates here narrow
+  but don't close the underlying issue).
+- `#235`: BYO-SMTP + paid TEM (unblocks email quotas).
+- `#238`: XFF chain verification + trusted-hop-count hardening
+  (unblocks the `trust_proxy` default flip).

--- a/internal/ratelimit/project_test.go
+++ b/internal/ratelimit/project_test.go
@@ -1,0 +1,214 @@
+package ratelimit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// #230: at-the-limit + below-the-limit integration tests covering each
+// per-project knob end-to-end against a real Redis (skipped when one
+// isn't available). Existing unit tests cover the helper contracts
+// (project_auth_test.go + quota_test.go + client_ip_test.go); these
+// tests verify the *behaviour* the docs page promises: a knob saved to
+// the config takes effect on the next request, the window expires, and
+// the trust-proxy switch changes the counter identifier so the right
+// counter takes the hit.
+
+// helperRequest builds a minimal *http.Request with the given RemoteAddr
+// and X-Forwarded-For header — just enough surface for ClientIPForProject
+// to make its decision. We reuse this from each table-driven case.
+func helperRequest(remoteAddr, xff string) *http.Request {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = remoteAddr
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	return r
+}
+
+// TestKnobs_AtTheLimit walks the four per-IP knob shapes (signup_signin,
+// token_refresh, token_verify, and a representative per-project hourly
+// quota via CheckProjectHourlyQuota) past their cap. For each:
+//
+//   - N requests pass (below limit)
+//   - the (N+1)th returns 429 with Retry-After set
+//   - per-project isolation holds: a second project on the same Redis
+//     and same identifier still gets through
+//
+// One table-driven test so a future knob (anonymous sign-ups, Web3,
+// whatever lands) is one row away.
+func TestKnobs_AtTheLimit(t *testing.T) {
+	rl := setupAuthTestLimiter(t)
+	defer rl.Close()
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	cases := []struct {
+		name       string
+		action     string
+		identifier string
+		limit      int
+		window     time.Duration
+	}{
+		{"signup_signin per IP per 5min", "signup_signin", "203.0.113.7", 3, 10 * time.Second},
+		{"token_refresh per IP per 5min", "token_refresh", "203.0.113.7", 3, 10 * time.Second},
+		{"token_verify per IP per 5min", "token_verify", "203.0.113.7", 3, 10 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			projA := "projA-" + tc.name + "-" + suffix
+			projB := "projB-" + tc.name + "-" + suffix
+
+			// N requests must pass on projA.
+			for i := 0; i < tc.limit; i++ {
+				w := httptest.NewRecorder()
+				if CheckAuthRateForProject(rl, w, context.Background(), tc.action, projA, tc.identifier, tc.limit, tc.window) {
+					t.Fatalf("request %d/%d unexpectedly blocked", i+1, tc.limit)
+				}
+			}
+
+			// (N+1)th must 429 with Retry-After.
+			w := httptest.NewRecorder()
+			blocked := CheckAuthRateForProject(rl, w, context.Background(), tc.action, projA, tc.identifier, tc.limit, tc.window)
+			if !blocked {
+				t.Fatal("over-cap request was allowed")
+			}
+			if w.Code != http.StatusTooManyRequests {
+				t.Errorf("over-cap status: got %d, want 429", w.Code)
+			}
+			if w.Header().Get("Retry-After") == "" {
+				t.Error("over-cap response must set Retry-After header")
+			}
+
+			// projB on the same identifier must pass — counter isolation.
+			wB := httptest.NewRecorder()
+			if CheckAuthRateForProject(rl, wB, context.Background(), tc.action, projB, tc.identifier, tc.limit, tc.window) {
+				t.Fatal("projB blocked because projA was capped — counter isolation broken")
+			}
+		})
+	}
+}
+
+// Note: the hourly-quota path coverage (CheckProjectHourlyQuota +
+// ErrQuotaExceeded for the email/SMS keyspace) lives with PR #234's
+// project_quota_test.go — those symbols don't exist on main until #234
+// merges, so the at-the-limit + below-the-limit coverage for that
+// surface ships alongside the code itself.
+
+// TestKnob_WindowExpiry verifies that an at-cap counter unblocks once the
+// limiter's window elapses. We use a tight 1-second window so the test
+// stays fast.
+func TestKnob_WindowExpiry(t *testing.T) {
+	rl := setupAuthTestLimiter(t)
+	defer rl.Close()
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	proj := "proj-expiry-" + suffix
+	const limit = 1
+	const window = 1100 * time.Millisecond // > 1s so the underlying TTL rounds correctly
+
+	// Hit the cap.
+	for i := 0; i < limit; i++ {
+		w := httptest.NewRecorder()
+		if CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, "ip", limit, window) {
+			t.Fatalf("first request unexpectedly blocked")
+		}
+	}
+	w := httptest.NewRecorder()
+	if !CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, "ip", limit, window) {
+		t.Fatal("second request should be blocked")
+	}
+
+	// Wait past the window, then verify the budget refilled.
+	time.Sleep(window + 200*time.Millisecond)
+
+	w2 := httptest.NewRecorder()
+	if CheckAuthRateForProject(rl, w2, context.Background(), "signup_signin", proj, "ip", limit, window) {
+		t.Fatal("after window expiry the next request must pass — counter did not reset")
+	}
+}
+
+// TestKnob_PerProjectOverrideTakesEffect: tightening the limit mid-flight
+// (the console save behaviour the docs page promises) is reflected on
+// the next call without waiting for the window to expire. We model this
+// by hitting one project at limit=N, then a second one at limit=N-1
+// from request 1 — the override took effect immediately.
+//
+// (We can't actually mutate the persisted limit mid-window because the
+// limit is a parameter to Allow, not stored state. But the contract the
+// caller depends on is: "the next CheckAuthRateForProject reads the
+// caller's limit verbatim." That's what we test here.)
+func TestKnob_PerProjectOverrideTakesEffect(t *testing.T) {
+	rl := setupAuthTestLimiter(t)
+	defer rl.Close()
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	proj := "proj-override-" + suffix
+	ip := "ip"
+
+	// At limit=5, 3 requests pass.
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		if CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, ip, 5, 10*time.Second) {
+			t.Fatalf("request %d/5 unexpectedly blocked", i+1)
+		}
+	}
+
+	// Operator tightens the limit to 3 via the console. The very next
+	// request (the 4th overall, but the first at limit=3) sees
+	// "current count 3 ≥ limit 3" and is blocked.
+	w := httptest.NewRecorder()
+	if !CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, ip, 3, 10*time.Second) {
+		t.Fatal("tightened limit should block the next request — saw allowed")
+	}
+}
+
+// TestTrustProxy_ChangesCounterIdentifier — when the trust_proxy knob
+// flips, the counter that takes the hit changes from "TCP peer" to
+// "leftmost XFF" (and vice versa). That has a visible effect: a request
+// at the cap under one mode must not block the next request under the
+// other (different counter).
+func TestTrustProxy_ChangesCounterIdentifier(t *testing.T) {
+	rl := setupAuthTestLimiter(t)
+	defer rl.Close()
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	proj := "proj-tp-" + suffix
+	const limit = 2
+	const window = 10 * time.Second
+
+	// Two requests with TCP peer "10.0.0.5" and XFF "1.2.3.4". With
+	// trust_proxy=false, both key on "10.0.0.5" (the TCP peer).
+	r := helperRequest("10.0.0.5:54321", "1.2.3.4")
+	for i := 0; i < limit; i++ {
+		w := httptest.NewRecorder()
+		id := ClientIPForProject(r, false)
+		if id != "10.0.0.5" {
+			t.Fatalf("trust_proxy=false identifier: got %q, want 10.0.0.5", id)
+		}
+		if CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, id, limit, window) {
+			t.Fatalf("trust_proxy=false: request %d/%d blocked unexpectedly", i+1, limit)
+		}
+	}
+	// Cap reached against the TCP peer.
+	w := httptest.NewRecorder()
+	if !CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, ClientIPForProject(r, false), limit, window) {
+		t.Fatal("trust_proxy=false: over-cap request should be blocked")
+	}
+
+	// Now flip the project's trust_proxy. The identifier switches to
+	// the leftmost XFF (1.2.3.4) — a different counter — so the next
+	// request must pass even though the project + TCP-peer counter is
+	// at cap.
+	id := ClientIPForProject(r, true)
+	if id != "1.2.3.4" {
+		t.Fatalf("trust_proxy=true identifier: got %q, want 1.2.3.4", id)
+	}
+	w2 := httptest.NewRecorder()
+	if CheckAuthRateForProject(rl, w2, context.Background(), "signup_signin", proj, id, limit, window) {
+		t.Fatal("trust_proxy flip should switch to a fresh counter (different identifier) — saw blocked")
+	}
+}

--- a/internal/ratelimit/project_test.go
+++ b/internal/ratelimit/project_test.go
@@ -63,7 +63,7 @@ func TestKnobs_AtTheLimit(t *testing.T) {
 			projB := "projB-" + tc.name + "-" + suffix
 
 			// N requests must pass on projA.
-			for i := 0; i < tc.limit; i++ {
+			for i := range tc.limit {
 				w := httptest.NewRecorder()
 				if CheckAuthRateForProject(rl, w, context.Background(), tc.action, projA, tc.identifier, tc.limit, tc.window) {
 					t.Fatalf("request %d/%d unexpectedly blocked", i+1, tc.limit)
@@ -111,7 +111,7 @@ func TestKnob_WindowExpiry(t *testing.T) {
 	const window = 1100 * time.Millisecond // > 1s so the underlying TTL rounds correctly
 
 	// Hit the cap.
-	for i := 0; i < limit; i++ {
+	for range limit {
 		w := httptest.NewRecorder()
 		if CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, "ip", limit, window) {
 			t.Fatalf("first request unexpectedly blocked")
@@ -150,7 +150,7 @@ func TestKnob_PerProjectOverrideTakesEffect(t *testing.T) {
 	ip := "ip"
 
 	// At limit=5, 3 requests pass.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		w := httptest.NewRecorder()
 		if CheckAuthRateForProject(rl, w, context.Background(), "signup_signin", proj, ip, 5, 10*time.Second) {
 			t.Fatalf("request %d/5 unexpectedly blocked", i+1)
@@ -183,7 +183,7 @@ func TestTrustProxy_ChangesCounterIdentifier(t *testing.T) {
 	// Two requests with TCP peer "10.0.0.5" and XFF "1.2.3.4". With
 	// trust_proxy=false, both key on "10.0.0.5" (the TCP peer).
 	r := helperRequest("10.0.0.5:54321", "1.2.3.4")
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		w := httptest.NewRecorder()
 		id := ClientIPForProject(r, false)
 		if id != "10.0.0.5" {


### PR DESCRIPTION
Closes #230 (umbrella #224).

## What lands

- **`docs/compliance/rate-limits.md`** — operator-facing reference. Defaults table (single source of truth, calls out the EmailsPerHour parked-pending-#235 reality), key-shape doc for both the auth keyspace and the quota keyspace, fail-open contract, IP-source / `trust_proxy` walkthrough with both failure modes spelled out (forgery vs collapse), Eurobase default rationale, precondition for the future flip (#238). `redis-cli` snippets for the three common questions: "is this IP currently capped?", "where did this project's hourly SMS budget go?", "force a counter reset". Override precedence at the bottom; related-issues at the end so the doc points outwards.
- **`internal/ratelimit/project_test.go`** — integration tests against a real Redis (skipped via setupAuthTestLimiter when one isn't available). Four cases:
  - `TestKnobs_AtTheLimit` (table-driven): for each per-IP knob (signup_signin, token_refresh, token_verify), N below-cap requests pass, (N+1)th returns 429 with Retry-After, and a second project on the same Redis + same identifier still gets through.
  - `TestKnob_WindowExpiry`: an at-cap counter unblocks once the limiter's window elapses.
  - `TestKnob_PerProjectOverrideTakesEffect`: tightening the limit mid-flight is reflected on the very next call without waiting for the window. Models the console-save UX.
  - `TestTrustProxy_ChangesCounterIdentifier`: at-cap-under-false + flip-to-true → next request passes because the identifier switched from TCP peer to leftmost XFF (different counter). The visible behaviour for the #228 knob.

The hourly-quota path coverage (CheckProjectHourlyQuota + ErrQuotaExceeded) ships with PR #234's own test file since those symbols don't exist on main until #234 merges.

`go test ./internal/ratelimit/... -count=1` green; all four new tests pass.