### PR TITLE
Tier-1 #3 follow-on (#171): audit retention + WORM bucket policy

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -166,6 +166,13 @@ func main() {
 	}()
 	slog.Info("cron executor started (60s interval)")
 
+	// ── Audit retention worker (#171) ──
+	// Daily housekeeping: roll forward data_access_log monthly
+	// partitions, drop ones past the retention horizon, optionally
+	// prune audit_log row tails. Tuned via env vars; see
+	// internal/workers/audit_retention.go.
+	workers.StartAuditRetention(ctx, pool)
+
 	// ── Graceful shutdown ──
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/docs/compliance/audit-log.md
+++ b/docs/compliance/audit-log.md
@@ -124,11 +124,11 @@ linkage-break paths.
 Two streams, two strategies — picked to match each stream's volume and the
 GDPR Art. 30 baseline ("≥1 year").
 
-| Stream                | Default | Mechanism                                        |
-| --------------------- | ------- | ------------------------------------------------ |
-| `audit_log`           | never   | Per-project row prune, leaves chain checkpoint   |
-| `data_access_log`     | 13 mo   | Drop whole monthly partitions past the horizon   |
-| Future partitions     | 12 mo   | Rolling pre-create so writes never hit `DEFAULT` |
+| Task                          | Default     | Mechanism                                        |
+| ----------------------------- | ----------- | ------------------------------------------------ |
+| `audit_log` row prune         | never       | Per-project row prune, leaves chain checkpoint   |
+| `data_access_log` partitions  | drop > 13 mo| Drop whole monthly partitions past the horizon   |
+| Forward partition pre-create  | 12 mo ahead | Rolling pre-create so writes never hit `DEFAULT` |
 
 The retention worker (`internal/workers/audit_retention.go`) runs **once at
 startup + every 24 h**. Each tick calls three migrator-owned `SECURITY
@@ -183,12 +183,15 @@ Scaleway Object Storage (fr-par):
 ```
 Bucket:        eurobase-audit-archive
 Region:        fr-par
+Versioning:    enabled       ← MUST be enabled BEFORE Object Lock
 Object Lock:   enabled (Compliance mode)
 Retention:     7 years per object (GDPR Art. 30 + national rules)
-Versioning:    enabled
 Lifecycle:     no Expiration rule (compliance mode would block it anyway)
 ACL:           private, no public access
 ```
+
+> Order matters: Scaleway requires bucket Versioning to be enabled
+> **before** Object Lock can be turned on. Provision in that order.
 
 `Compliance mode` is the strict variant: no role — including the bucket
 owner — can shorten a retained object's lock before its retention date.

--- a/docs/compliance/audit-log.md
+++ b/docs/compliance/audit-log.md
@@ -102,6 +102,16 @@ chain verifies as OK.
 > a multi-year log this is a heavy interactive call; a bounded/streaming or
 > checkpointed variant is a likely future addition.
 
+### Verify after retention pruning
+
+When retention pruning is enabled (see below), the oldest rows of a project's
+chain are deleted. Verify reads
+`public.audit_log_chain_checkpoints.last_row_hash` for the project and seeds
+its initial `prev` from that value, so the first **surviving** row's
+`prev_hash` still links correctly. Operationally this means: in-DB Verify
+keeps working without false positives across pruning events, and the full
+pre-prune history is still verifiable against the off-box WORM dump (#170).
+
 ## Testing
 
 `internal/audit/verifier_test.go` (integration, runs in CI `test-go`):
@@ -109,7 +119,85 @@ appends entries, verifies clean, then mutates and deletes rows directly in the
 DB and asserts `Verify` flags both — the content-tamper and the
 linkage-break paths.
 
-## Retention & export
-1-year retention and the vendor-neutral SIEM export (webhook / syslog / signed
-object dump) are documented in
-[`audit-export.md`](./audit-export.md) once those PRs land (#170, #171).
+## Retention (#171)
+
+Two streams, two strategies — picked to match each stream's volume and the
+GDPR Art. 30 baseline ("≥1 year").
+
+| Stream                | Default | Mechanism                                        |
+| --------------------- | ------- | ------------------------------------------------ |
+| `audit_log`           | never   | Per-project row prune, leaves chain checkpoint   |
+| `data_access_log`     | 13 mo   | Drop whole monthly partitions past the horizon   |
+| Future partitions     | 12 mo   | Rolling pre-create so writes never hit `DEFAULT` |
+
+The retention worker (`internal/workers/audit_retention.go`) runs **once at
+startup + every 24 h**. Each tick calls three migrator-owned `SECURITY
+DEFINER` helpers added in migration 000070:
+
+- `public.ensure_future_data_access_log_partitions(months_ahead)` —
+  idempotent rolling pre-create.
+- `public.drop_old_data_access_log_partitions(cutoff_months)` —
+  detaches + drops monthly partitions whose covered month ends on or before
+  `today - cutoff_months`. Returns the list of dropped names.
+- `public.prune_audit_log(cutoff_days)` — per project, deletes rows older
+  than the cutoff, **never the chain head** (always preserves the
+  highest-`seq` row), and upserts the chain checkpoint.
+
+### Config
+
+Environment variables read once at worker startup
+(`internal/workers/audit_retention.go`):
+
+```
+AUDIT_LOG_RETENTION_DAYS            default 0   (never prune in DB)
+DATA_ACCESS_LOG_RETENTION_MONTHS    default 13  (1 year + 1 buffer month)
+DATA_ACCESS_LOG_FUTURE_MONTHS_AHEAD default 12  (rolling pre-create)
+```
+
+`AUDIT_LOG_RETENTION_DAYS=0` is the safe default — `audit_log` is
+low-volume and the WORM dump is the long-term archive, so there's no
+operational reason to prune in DB unless a specific data-minimisation rule
+applies. Operators can flip to any positive number; chain integrity is
+preserved by the checkpoint.
+
+### Why partition-drop, not row-DELETE, for `data_access_log`
+
+`data_access_log` is high-volume and partitioned by month (000066). Dropping
+a partition is a single metadata operation; a giant `DELETE FROM ... WHERE
+created_at < ...` would generate bloat and pressure autovacuum. The
+worker's job is therefore "detach + drop" old partitions, not row delete.
+
+## WORM object archive (long-term)
+
+The in-DB tables hold the **hot** window (above). For long-term, off-box
+retention — the Art. 30 records-of-processing baseline plus the
+tamper-evidence defence against a migrator-level actor described above —
+the canonical store is the **signed object dump** in PR #170 (SIEM export):
+a regularly-emitted, signed `.jsonl` per project / per day pushed to an
+object-store bucket configured for immutability.
+
+The bucket policy is owned by ops, not the application code. When the
+bucket is provisioned (#170), it must be configured as follows on
+Scaleway Object Storage (fr-par):
+
+```
+Bucket:        eurobase-audit-archive
+Region:        fr-par
+Object Lock:   enabled (Compliance mode)
+Retention:     7 years per object (GDPR Art. 30 + national rules)
+Versioning:    enabled
+Lifecycle:     no Expiration rule (compliance mode would block it anyway)
+ACL:           private, no public access
+```
+
+`Compliance mode` is the strict variant: no role — including the bucket
+owner — can shorten a retained object's lock before its retention date.
+That is the property that makes the dump count as the off-box
+tamper-evident copy referred to above and in the migration-058 / 070
+headers.
+
+The application path that emits the dump is intentionally separated from
+the bucket policy: the worker only writes; the lifecycle/lock guarantees
+sit with Scaleway. A reviewer of an in-DB chain break can fetch the
+matching day's dump from the bucket and walk the same hash chain
+externally to identify the divergence point.

--- a/docs/compliance/data-access-log.md
+++ b/docs/compliance/data-access-log.md
@@ -83,14 +83,24 @@ expensive.
 
 `data_access_log` is **range-partitioned by month** on `created_at`:
 
-- The retention job (#171) can **drop an old month's partition** instead of a
-  giant `DELETE` — cheap, lock-light data minimisation.
+- The retention worker (#171, migration 000070, runs daily in
+  `cmd/worker`) **drops an old month's partition** via
+  `public.drop_old_data_access_log_partitions(cutoff_months)` — single
+  metadata operation, no `DELETE`/autovacuum churn.
 - Queries that filter on `created_at` prune to a few partitions.
 - `public.ensure_data_access_log_partition(month)` creates a month's partition
-  idempotently (used by the pre-create loop and the rolling job in #171).
-- A **`DEFAULT` partition** guarantees inserts never fail on a missing month;
-  rows simply land in default and can be redistributed later.
-- The migration pre-creates the current month + the next 11.
+  idempotently. The retention worker calls
+  `public.ensure_future_data_access_log_partitions(months_ahead)` each
+  tick to keep the next 12 months pre-created — writes never land in
+  `DEFAULT` once the worker has run.
+- A **`DEFAULT` partition** is the safety net for the small window between
+  worker ticks (or while the worker is down) — rows still get a home and
+  can be redistributed later.
+- The migration pre-creates the current month + the next 11; the worker
+  takes over from there.
+- Default retention: **13 months** (= 1 year + 1 buffer month), tunable via
+  `DATA_ACCESS_LOG_RETENTION_MONTHS`. The off-box signed object dump (#170)
+  is the long-term archive past this horizon.
 
 ## Append-only (defence-in-depth)
 

--- a/internal/audit/retention.go
+++ b/internal/audit/retention.go
@@ -1,0 +1,112 @@
+package audit
+
+// Tier-1 GDPR #3 follow-up (#171): retention helpers for the two audit
+// streams (`public.audit_log`, `public.data_access_log`). The actual SQL —
+// pruning, partition drop, and rolling pre-create — lives in migrator-owned
+// SECURITY DEFINER functions added in migration 000070. This file is the
+// Go-side wrapper called by the periodic worker so the call sites read
+// cleanly and the test surface is mockable.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// RetentionConfig tunes the retention worker. Zero values mean "skip this
+// task" — operators can disable individual streams without touching code.
+type RetentionConfig struct {
+	// AuditLogRetentionDays: rows in `public.audit_log` older than this
+	// are deleted, per project, leaving a chain checkpoint behind so
+	// Verify still walks cleanly. 0 = never prune in DB (the off-box
+	// WORM dump in #170 is the long-term store).
+	AuditLogRetentionDays int
+
+	// DataAccessLogRetentionMonths: monthly partitions of
+	// `public.data_access_log` whose covered month ends on or before
+	// (today - this many months) are detached and dropped. 0 = never
+	// drop partitions. Default 13 keeps ~1 year + 1 buffer month hot.
+	DataAccessLogRetentionMonths int
+
+	// FuturePartitionsMonthsAhead: how many future monthly partitions
+	// to keep pre-created on every tick. 0 = don't pre-create (rows
+	// would fall back to the DEFAULT partition). Default 12.
+	FuturePartitionsMonthsAhead int
+}
+
+// DefaultRetentionConfig returns the shipped defaults. See the field
+// comments above for the reasoning; the migration's header repeats the
+// numbers so a future change shows up in both places.
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{
+		AuditLogRetentionDays:        0,  // never prune audit_log in DB by default
+		DataAccessLogRetentionMonths: 13, // 1 year + 1 buffer month
+		FuturePartitionsMonthsAhead:  12, // keep a year of forward partitions
+	}
+}
+
+// RetentionResult summarizes one pass of the retention worker. Useful for
+// log lines and for the test suite to assert.
+type RetentionResult struct {
+	AuditLogRowsDeleted          int64
+	DataAccessPartitionsDropped  []string
+	DataAccessPartitionsEnsured  int
+}
+
+// RetentionService is the Go wrapper around the SQL helpers added in
+// migration 000070. Holds a pool so the worker can construct it once.
+type RetentionService struct {
+	pool *pgxpool.Pool
+}
+
+// NewRetentionService constructs the service.
+func NewRetentionService(pool *pgxpool.Pool) *RetentionService {
+	return &RetentionService{pool: pool}
+}
+
+// Run executes one full retention pass. The order matters:
+//
+//  1. Pre-create forward partitions BEFORE dropping old ones — if both
+//     fail in some pathological way, we'd rather have extra partitions
+//     than miss the next month's writes (they'd hit DEFAULT, recoverable).
+//  2. Drop old partitions — pure delete; lock-light because each partition
+//     is its own physical table.
+//  3. Prune audit_log — heaviest, per-project; deferred to last so an
+//     earlier failure doesn't block the cheaper housekeeping.
+//
+// Errors from any single step are returned wrapped; the worker logs and
+// continues — retention is best-effort and idempotent, the next tick
+// will catch up.
+func (s *RetentionService) Run(ctx context.Context, cfg RetentionConfig) (*RetentionResult, error) {
+	res := &RetentionResult{}
+
+	if cfg.FuturePartitionsMonthsAhead > 0 {
+		if err := s.pool.QueryRow(ctx,
+			`SELECT public.ensure_future_data_access_log_partitions($1)`,
+			cfg.FuturePartitionsMonthsAhead,
+		).Scan(&res.DataAccessPartitionsEnsured); err != nil {
+			return res, fmt.Errorf("ensure future partitions: %w", err)
+		}
+	}
+
+	if cfg.DataAccessLogRetentionMonths > 0 {
+		if err := s.pool.QueryRow(ctx,
+			`SELECT public.drop_old_data_access_log_partitions($1)`,
+			cfg.DataAccessLogRetentionMonths,
+		).Scan(&res.DataAccessPartitionsDropped); err != nil {
+			return res, fmt.Errorf("drop old partitions: %w", err)
+		}
+	}
+
+	if cfg.AuditLogRetentionDays > 0 {
+		if err := s.pool.QueryRow(ctx,
+			`SELECT public.prune_audit_log($1)`,
+			cfg.AuditLogRetentionDays,
+		).Scan(&res.AuditLogRowsDeleted); err != nil {
+			return res, fmt.Errorf("prune audit_log: %w", err)
+		}
+	}
+
+	return res, nil
+}

--- a/internal/audit/retention_test.go
+++ b/internal/audit/retention_test.go
@@ -1,5 +1,14 @@
 package audit
 
+// Skip-pattern note: several tests below back-date rows via direct UPDATE
+// to exercise the cutoff path. The runtime gateway role has UPDATE
+// revoked on `public.audit_log` (migration 000058), so under that role
+// the UPDATE fails and the test t.Skipf's out — by design. CI's `test-go`
+// stage connects as `eurobase_api` (test role) which retains UPDATE, so
+// the assertions run. If the test role ever loses UPDATE, the tests
+// silently skip and the assertions stop running — flag this in the CI
+// runbook so a green test-go matrix can't hide a regression.
+
 import (
 	"context"
 	"testing"

--- a/internal/audit/retention_test.go
+++ b/internal/audit/retention_test.go
@@ -1,0 +1,194 @@
+package audit
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRetention_PruneKeepsChainHeadAndVerifies appends a handful of rows,
+// runs prune with a 0-day cutoff (everything-older-than-now), and asserts:
+//   * The chain head (the newest row) is preserved.
+//   * The pruned rows are gone.
+//   * A checkpoint row was written for this project.
+//   * Verify() walks cleanly using the checkpoint to seed prev_hash.
+//
+// 0-day cutoff is a useful test idiom: now() - 0 days = now(), so every
+// row whose created_at is strictly before now() is prunable. Since INSERT
+// happens "in the past" relative to the prune call, all but the head get
+// pruned in a single pass.
+func TestRetention_PruneKeepsChainHeadAndVerifies(t *testing.T) {
+	svc, projectID, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "ret.one")
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "ret.two")
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "ret.three")
+
+	// Clean baseline.
+	if res, err := svc.Verify(ctx, projectID); err != nil {
+		t.Fatalf("Verify (pre-prune): %v", err)
+	} else if !res.OK || res.Checked != 3 {
+		t.Fatalf("baseline verify: %+v", res)
+	}
+
+	var deleted int64
+	if err := pool.QueryRow(ctx, `SELECT public.prune_audit_log(0)`).Scan(&deleted); err != nil {
+		// 0 short-circuits to "do nothing" by contract — sanity check the
+		// guard branch.
+		t.Fatalf("prune_audit_log(0): %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("prune(0) should be a no-op, deleted %d", deleted)
+	}
+
+	// Now prune with cutoff_days=0 logically blocked by the guard. Use a
+	// SQL helper that mirrors the worker's "everything < now()" intent by
+	// passing cutoff_days=1 and back-dating two of three rows by a day.
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.audit_log SET created_at = created_at - interval '2 days'
+		 WHERE project_id = $1 AND action IN ('ret.one','ret.two')`,
+		projectID); err != nil {
+		t.Skipf("cannot back-date rows (UPDATE denied): %v", err)
+	}
+
+	if err := pool.QueryRow(ctx, `SELECT public.prune_audit_log(1)`).Scan(&deleted); err != nil {
+		t.Fatalf("prune_audit_log(1): %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("expected to prune 2 rows, got %d", deleted)
+	}
+
+	// Verify the head survived.
+	var remaining int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_log WHERE project_id = $1`,
+		projectID).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("expected 1 head row remaining, got %d", remaining)
+	}
+
+	// Checkpoint exists for this project.
+	var ckExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(
+		   SELECT 1 FROM public.audit_log_chain_checkpoints WHERE project_id = $1::uuid)`,
+		projectID).Scan(&ckExists); err != nil {
+		t.Fatalf("check checkpoint: %v", err)
+	}
+	if !ckExists {
+		t.Fatal("checkpoint row was not written after prune")
+	}
+
+	// Verify still passes — seeded from checkpoint.
+	res, err := svc.Verify(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Verify (post-prune): %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("post-prune verify broken at %s: %s", res.BrokenAtID, res.Reason)
+	}
+	if res.Checked != 1 {
+		t.Errorf("Checked = %d, want 1 (only head remains)", res.Checked)
+	}
+}
+
+// TestRetention_PruneNeverDeletesHead — even with an absurdly large
+// retention window (everything older than 1 day), if the head row itself
+// is older than cutoff, we MUST NOT prune it. Tests the "keep at least
+// the head" invariant the SQL function guarantees with `seq < head_seq`.
+func TestRetention_PruneNeverDeletesHead(t *testing.T) {
+	svc, projectID, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	svc.Log(ctx, projectID, "", "admin@eurobase.app", "head.only")
+
+	// Back-date the single row so cutoff catches it.
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.audit_log SET created_at = created_at - interval '10 days'
+		 WHERE project_id = $1`,
+		projectID); err != nil {
+		t.Skipf("cannot back-date head row: %v", err)
+	}
+
+	var deleted int64
+	if err := pool.QueryRow(ctx, `SELECT public.prune_audit_log(1)`).Scan(&deleted); err != nil {
+		t.Fatalf("prune_audit_log: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("prune must preserve the head row, but deleted %d", deleted)
+	}
+
+	var remaining int
+	_ = pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_log WHERE project_id = $1`,
+		projectID).Scan(&remaining)
+	if remaining != 1 {
+		t.Errorf("head row missing after prune; remaining = %d", remaining)
+	}
+}
+
+// TestRetention_EnsureFuturePartitionsIdempotent confirms the rolling
+// pre-create is safe to call repeatedly. Migration 000066 already pre-
+// creates 12 months, so a fresh DB has at least that many — calling the
+// helper again should not throw and should not produce duplicates.
+func TestRetention_EnsureFuturePartitionsIdempotent(t *testing.T) {
+	_, _, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	countPartitions := func() int {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_inherits i
+			   JOIN pg_class c ON c.oid = i.inhrelid
+			   JOIN pg_class p ON p.oid = i.inhparent
+			  WHERE p.relname = 'data_access_log'
+			    AND c.relname ~ '^data_access_log_[0-9]{6}$'`).Scan(&n); err != nil {
+			t.Fatalf("count partitions: %v", err)
+		}
+		return n
+	}
+
+	before := countPartitions()
+
+	// First call — adds up to 12 months ahead (most may already exist).
+	var ensured int
+	if err := pool.QueryRow(ctx,
+		`SELECT public.ensure_future_data_access_log_partitions(12)`).Scan(&ensured); err != nil {
+		t.Fatalf("ensure (first): %v", err)
+	}
+	mid := countPartitions()
+
+	// Second call — must be a no-op.
+	if err := pool.QueryRow(ctx,
+		`SELECT public.ensure_future_data_access_log_partitions(12)`).Scan(&ensured); err != nil {
+		t.Fatalf("ensure (second): %v", err)
+	}
+	after := countPartitions()
+
+	if after != mid {
+		t.Errorf("ensure not idempotent: %d → %d → %d", before, mid, after)
+	}
+}
+
+// TestRetention_RunDefaults runs the Go wrapper with the shipped
+// defaults and asserts the call shape: ensure runs (positive), drop is
+// safe (no partitions are old enough to drop on a fresh DB), and audit
+// prune is skipped (defaults disable it).
+func TestRetention_RunDefaults(t *testing.T) {
+	_, _, pool := setupAuditTest(t)
+	ctx := context.Background()
+
+	svc := NewRetentionService(pool)
+	res, err := svc.Run(ctx, DefaultRetentionConfig())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.DataAccessPartitionsEnsured == 0 {
+		t.Error("ensure step did not run with defaults")
+	}
+	if res.AuditLogRowsDeleted != 0 {
+		t.Errorf("default config should not prune audit_log, got %d deleted", res.AuditLogRowsDeleted)
+	}
+}

--- a/internal/audit/verifier.go
+++ b/internal/audit/verifier.go
@@ -3,8 +3,17 @@ package audit
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/jackc/pgx/v5"
 )
+
+// isNoRows is a tiny helper so the Verify path doesn't drag pgx symbols
+// into every error-shape check site.
+func isNoRows(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows)
+}
 
 // VerifyResult is the outcome of walking a project's audit-log hash chain.
 type VerifyResult struct {
@@ -26,7 +35,33 @@ type VerifyResult struct {
 // Either failure is reported with the offending row id. An empty chain (no
 // rows) verifies as OK. The recompute happens in SQL via the same
 // public.audit_row_hash function used on insert, so the comparison is exact.
+//
+// Retention pruning (#171): if the retention worker has pruned the oldest
+// rows for this project, a checkpoint row in `audit_log_chain_checkpoints`
+// records the row_hash of the last pruned row. Verify seeds its initial
+// `prev` from that hash so the first surviving row's `prev_hash` still
+// links correctly. Without the checkpoint we'd flag the surviving prefix
+// as a chain break — but it's the off-box WORM dump (#170) that holds the
+// pruned prefix, so the in-DB chain stays continuous from the checkpoint
+// forward.
 func (s *Service) Verify(ctx context.Context, projectID string) (*VerifyResult, error) {
+	// Seed prev from the retention checkpoint if one exists. NULL-project
+	// chains use the all-zero UUID by convention (see migration 000070).
+	var prev []byte
+	var ckErr error
+	if projectID == "" {
+		ckErr = s.pool.QueryRow(ctx,
+			`SELECT last_row_hash FROM public.audit_log_chain_checkpoints
+			 WHERE project_id = '00000000-0000-0000-0000-000000000000'::uuid`).Scan(&prev)
+	} else {
+		ckErr = s.pool.QueryRow(ctx,
+			`SELECT last_row_hash FROM public.audit_log_chain_checkpoints
+			 WHERE project_id = NULLIF($1,'')::uuid`, projectID).Scan(&prev)
+	}
+	if ckErr != nil && !isNoRows(ckErr) {
+		return nil, fmt.Errorf("read retention checkpoint: %w", ckErr)
+	}
+
 	rows, err := s.pool.Query(ctx,
 		`SELECT id, prev_hash, row_hash,
 		        public.audit_row_hash(prev_hash, project_id, actor_id, actor_email, action,
@@ -41,7 +76,6 @@ func (s *Service) Verify(ctx context.Context, projectID string) (*VerifyResult, 
 	}
 	defer rows.Close()
 
-	var prev []byte // previous row's row_hash; nil before the first row
 	checked := 0
 	for rows.Next() {
 		var id string

--- a/internal/workers/audit_retention.go
+++ b/internal/workers/audit_retention.go
@@ -1,0 +1,94 @@
+package workers
+
+// Periodic retention task for the two audit streams. Closes #171.
+//
+// Not a River job: River is great for one-shot work triggered by an HTTP
+// handler or another job. Retention is fixed-cadence housekeeping with no
+// upstream trigger, and the worker process already runs a 60-second cron
+// ticker for the same reason (cmd/worker/main.go). We add a separate,
+// slower ticker for retention rather than coupling it to cron — cron fires
+// every minute; retention runs daily.
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/eurobase/euroback/internal/audit"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// auditRetentionInterval is how often Run is invoked. Daily is plenty —
+// neither partition drops nor row pruning are time-sensitive at finer
+// resolution, and a slower cadence lets ad-hoc operator runs (the SQL
+// helpers are idempotent) drive the system when needed.
+const auditRetentionInterval = 24 * time.Hour
+
+// StartAuditRetention launches the daily retention loop in a goroutine.
+// It returns immediately; the loop exits when ctx is cancelled. Errors
+// from a single tick are logged but never propagated — retention is
+// best-effort, idempotent, and the next tick reconciles.
+//
+// Config is read from environment variables once at startup:
+//   - AUDIT_LOG_RETENTION_DAYS              (default 0 = never)
+//   - DATA_ACCESS_LOG_RETENTION_MONTHS      (default 13)
+//   - DATA_ACCESS_LOG_FUTURE_MONTHS_AHEAD   (default 12)
+func StartAuditRetention(ctx context.Context, pool *pgxpool.Pool) {
+	cfg := audit.DefaultRetentionConfig()
+	if v := os.Getenv("AUDIT_LOG_RETENTION_DAYS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.AuditLogRetentionDays = n
+		}
+	}
+	if v := os.Getenv("DATA_ACCESS_LOG_RETENTION_MONTHS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.DataAccessLogRetentionMonths = n
+		}
+	}
+	if v := os.Getenv("DATA_ACCESS_LOG_FUTURE_MONTHS_AHEAD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.FuturePartitionsMonthsAhead = n
+		}
+	}
+
+	svc := audit.NewRetentionService(pool)
+
+	slog.Info("audit retention worker started",
+		"interval", auditRetentionInterval.String(),
+		"audit_log_retention_days", cfg.AuditLogRetentionDays,
+		"data_access_log_retention_months", cfg.DataAccessLogRetentionMonths,
+		"future_partitions_months_ahead", cfg.FuturePartitionsMonthsAhead,
+	)
+
+	go func() {
+		// Run once at startup so a freshly-deployed pod doesn't wait a
+		// full day before reconciling forward partitions.
+		runOnce(ctx, svc, cfg)
+
+		ticker := time.NewTicker(auditRetentionInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runOnce(ctx, svc, cfg)
+			}
+		}
+	}()
+}
+
+func runOnce(ctx context.Context, svc *audit.RetentionService, cfg audit.RetentionConfig) {
+	res, err := svc.Run(ctx, cfg)
+	if err != nil {
+		slog.Error("audit retention run failed", "error", err)
+		return
+	}
+	slog.Info("audit retention run complete",
+		"audit_log_rows_deleted", res.AuditLogRowsDeleted,
+		"data_access_partitions_ensured", res.DataAccessPartitionsEnsured,
+		"data_access_partitions_dropped", res.DataAccessPartitionsDropped,
+	)
+}

--- a/migrations/000070_audit_retention.down.sql
+++ b/migrations/000070_audit_retention.down.sql
@@ -1,0 +1,6 @@
+-- 000070_audit_retention.down.sql
+
+DROP FUNCTION IF EXISTS public.ensure_future_data_access_log_partitions(int);
+DROP FUNCTION IF EXISTS public.drop_old_data_access_log_partitions(int);
+DROP FUNCTION IF EXISTS public.prune_audit_log(int);
+DROP TABLE    IF EXISTS public.audit_log_chain_checkpoints;

--- a/migrations/000070_audit_retention.up.sql
+++ b/migrations/000070_audit_retention.up.sql
@@ -1,0 +1,254 @@
+-- 000070_audit_retention.up.sql
+--
+-- Tier-1 GDPR #3 follow-up (#171): retention worker for the two append-only
+-- audit streams.
+--
+-- What this migration adds
+-- ========================
+--   1. `public.audit_log_chain_checkpoints` — per-project bookmark recording
+--      the last pruned `seq` + `row_hash`. Lets `Verify()` start from a
+--      non-genesis prev_hash so pruning the oldest rows does NOT show up as a
+--      chain break.
+--   2. `public.prune_audit_log(retention_days)` — SECURITY DEFINER helper
+--      owned by the migrator that DELETEs audit_log rows older than the
+--      retention horizon, per project, and UPSERTs the checkpoint. Returns
+--      total rows deleted. Gateway has EXECUTE so the worker (which connects
+--      as `eurobase_gateway`) can call it; runtime roles still lack direct
+--      DELETE on `public.audit_log` (000058).
+--   3. `public.drop_old_data_access_log_partitions(retention_months)` —
+--      detaches + drops monthly partitions whose end < cutoff. Returns the
+--      list of dropped partition names (for log lines / observability).
+--   4. `public.ensure_future_data_access_log_partitions(months_ahead)` —
+--      idempotent rolling pre-create. Loops over current month + N months
+--      ahead and calls the existing `ensure_data_access_log_partition`
+--      helper so writes never land in `DEFAULT`.
+--
+-- Tamper-evidence and pruning
+-- ===========================
+-- The in-DB hash chain (000058) catches modification, deletion, and
+-- reordering of *existing* rows. Pruning the OLDEST rows for retention
+-- inevitably "deletes" rows — naïvely, that would break `Verify`'s linkage
+-- check at the first surviving row (its `prev_hash` no longer matches the
+-- nil starting state). The checkpoint table fixes this: when Verify starts
+-- a chain it loads `last_pruned_row_hash` as its initial `prev`. The chain
+-- is still cryptographically continuous, just with a recorded prefix that
+-- lives in the off-box WORM dump (#170).
+--
+-- The chain head (most recent row of each project) is never pruned, so
+-- ongoing appends keep linking against fresh prev_hashes — they don't even
+-- know pruning happened.
+--
+-- Default retention
+-- =================
+-- Both helpers take retention as a parameter; defaults live in the Go
+-- caller. The shipped defaults (see `internal/workers/audit_retention.go`)
+-- are:
+--   * audit_log:        0 days  → "never prune in DB" (off-box WORM is the
+--                                 long-term store). Operators can flip to a
+--                                 positive number to enable in-DB pruning.
+--   * data_access_log: 395 days → ~13 months of monthly partitions kept hot,
+--                                 1 buffer month so the rolling pre-create
+--                                 has slack. The signed object dump in #170
+--                                 retains beyond this.
+--
+-- Convention (CLAUDE.md): every new SECURITY DEFINER function in `public`
+-- REVOKEs EXECUTE from PUBLIC and GRANTs only to the runtime role that
+-- needs it. Enforced manually here per function.
+--
+-- No explicit BEGIN/COMMIT: golang-migrate wraps each .up.sql in its own tx.
+
+-- ── 1. Per-project chain checkpoint ────────────────────────────────────
+-- Stores the (seq, row_hash) of the last row PRUNED from each project's
+-- chain. Verify() seeds its initial `prev` from `last_row_hash` when a
+-- checkpoint exists, so the first surviving row's `prev_hash` still links
+-- correctly. NULL-project rows share the `__global__` chain in the writer;
+-- their checkpoint key is the all-zero UUID by convention so the table can
+-- have a UUID PK without nullable column gymnastics.
+CREATE TABLE public.audit_log_chain_checkpoints (
+    project_id      uuid PRIMARY KEY,
+    last_pruned_seq bigint      NOT NULL,
+    last_row_hash   bytea       NOT NULL,
+    updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.audit_log_chain_checkpoints IS
+  'Tier-1 GDPR #3 retention bookmark (#171): per-project last-pruned (seq, row_hash). Used by audit.Verify to start from a non-genesis prev_hash after retention pruning.';
+
+GRANT SELECT ON public.audit_log_chain_checkpoints TO eurobase_gateway;
+
+-- ── 2. audit_log prune helper ──────────────────────────────────────────
+-- Deletes rows older than `cutoff_days` per project, capturing the (seq,
+-- row_hash) of the newest row that was deleted into the checkpoint table.
+-- The chain head (newest row) is preserved by definition — we never
+-- delete rows newer than cutoff. Per-project advisory lock prevents
+-- racing with audit appends on the same project (Service.Log uses
+-- `pg_advisory_xact_lock(hashtext(project_id))` on the same key shape).
+--
+-- Returns total rows deleted across all projects.
+CREATE OR REPLACE FUNCTION public.prune_audit_log(cutoff_days int)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_cutoff   timestamptz;
+    v_total    bigint := 0;
+    v_deleted  bigint;
+    r          RECORD;
+    v_last_seq bigint;
+    v_last_h   bytea;
+    v_chainkey text;
+BEGIN
+    IF cutoff_days IS NULL OR cutoff_days <= 0 THEN
+        RETURN 0;
+    END IF;
+    v_cutoff := now() - make_interval(days => cutoff_days);
+
+    -- Group by project (NULL → __global__) and prune each chain
+    -- independently. Order matters: we always preserve the chain HEAD
+    -- (newest seq) of each project, and only ever delete rows with
+    -- seq < the head's seq. A chain whose head itself is older than
+    -- cutoff is left alone — the chain never gets pruned entirely.
+    FOR r IN
+        SELECT
+            COALESCE(project_id::text, '__global__') AS chain_key,
+            project_id,
+            (SELECT max(seq) FROM public.audit_log
+             WHERE project_id IS NOT DISTINCT FROM a.project_id) AS head_seq
+        FROM public.audit_log a
+        GROUP BY project_id
+    LOOP
+        v_chainkey := r.chain_key;
+        -- Serialize against concurrent appends on the same chain.
+        PERFORM pg_advisory_xact_lock(hashtext(v_chainkey));
+
+        -- Find the newest row we're about to delete (highest seq < head
+        -- with created_at < cutoff). That row becomes the checkpoint.
+        SELECT seq, row_hash
+          INTO v_last_seq, v_last_h
+          FROM public.audit_log
+         WHERE project_id IS NOT DISTINCT FROM r.project_id
+           AND created_at < v_cutoff
+           AND seq < r.head_seq
+         ORDER BY seq DESC
+         LIMIT 1;
+
+        IF v_last_seq IS NULL THEN
+            -- Nothing prunable on this project.
+            CONTINUE;
+        END IF;
+
+        DELETE FROM public.audit_log
+         WHERE project_id IS NOT DISTINCT FROM r.project_id
+           AND seq <= v_last_seq;
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+        v_total := v_total + v_deleted;
+
+        -- UPSERT checkpoint. Key uses NULL UUID for the global chain.
+        INSERT INTO public.audit_log_chain_checkpoints
+            (project_id, last_pruned_seq, last_row_hash, updated_at)
+        VALUES
+            (COALESCE(r.project_id, '00000000-0000-0000-0000-000000000000'::uuid),
+             v_last_seq, v_last_h, now())
+        ON CONFLICT (project_id) DO UPDATE
+           SET last_pruned_seq = EXCLUDED.last_pruned_seq,
+               last_row_hash   = EXCLUDED.last_row_hash,
+               updated_at      = EXCLUDED.updated_at;
+    END LOOP;
+
+    RETURN v_total;
+END$$;
+
+ALTER FUNCTION public.prune_audit_log(int) OWNER TO eurobase_migrator;
+REVOKE EXECUTE ON FUNCTION public.prune_audit_log(int) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.prune_audit_log(int) TO eurobase_gateway;
+
+-- ── 3. data_access_log partition drop helper ──────────────────────────
+-- Detaches and DROPs monthly partitions whose UPPER bound is on or before
+-- the retention cutoff. Returns the list of dropped partition names so the
+-- worker can log them. Never touches DEFAULT or the current month.
+--
+-- pg_class.relname holds the partition name; pg_get_expr decodes the
+-- bound expression. We don't parse pg_get_expr — instead we go through
+-- pg_inherits + pg_partition_tree to read the actual bound via
+-- pg_get_partition_constraintdef, but that's expensive on PG14+. Simpler:
+-- the helper `ensure_data_access_log_partition` names partitions
+-- `data_access_log_YYYYMM`; we walk pg_class for that pattern and parse
+-- the month out of the name. That's deterministic since every partition
+-- we create goes through that helper.
+CREATE OR REPLACE FUNCTION public.drop_old_data_access_log_partitions(cutoff_months int)
+RETURNS text[]
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_cutoff_month date;
+    v_dropped      text[] := ARRAY[]::text[];
+    r              RECORD;
+    v_part_month   date;
+BEGIN
+    IF cutoff_months IS NULL OR cutoff_months <= 0 THEN
+        RETURN v_dropped;
+    END IF;
+    -- Drop partitions whose covered month ends on or before the cutoff.
+    -- Example: cutoff_months=13 + today=2027-03-15 → cutoff_month=2026-02-01;
+    -- partitions for 2026-01 or earlier are dropped.
+    v_cutoff_month := (date_trunc('month', now()) - make_interval(months => cutoff_months))::date;
+
+    FOR r IN
+        SELECT c.relname AS name
+        FROM   pg_inherits i
+        JOIN   pg_class c    ON c.oid = i.inhrelid
+        JOIN   pg_class pc   ON pc.oid = i.inhparent
+        WHERE  pc.relname = 'data_access_log'
+          AND  c.relname  ~ '^data_access_log_[0-9]{6}$'
+        ORDER BY c.relname
+    LOOP
+        -- Name format: data_access_log_YYYYMM
+        v_part_month := to_date(substring(r.name from 17 for 6), 'YYYYMM');
+        IF v_part_month <= v_cutoff_month THEN
+            EXECUTE format('ALTER TABLE public.data_access_log DETACH PARTITION public.%I', r.name);
+            EXECUTE format('DROP TABLE public.%I', r.name);
+            v_dropped := array_append(v_dropped, r.name);
+        END IF;
+    END LOOP;
+
+    RETURN v_dropped;
+END$$;
+
+ALTER FUNCTION public.drop_old_data_access_log_partitions(int) OWNER TO eurobase_migrator;
+REVOKE EXECUTE ON FUNCTION public.drop_old_data_access_log_partitions(int) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.drop_old_data_access_log_partitions(int) TO eurobase_gateway;
+
+-- ── 4. data_access_log future-partition pre-create ────────────────────
+-- Idempotent rolling pre-create. The migration 000066 pre-creates the
+-- current month + 11; this helper extends that horizon on every worker
+-- tick so the rolling window never closes. months_ahead=12 keeps a
+-- year of forward partitions ready at all times.
+CREATE OR REPLACE FUNCTION public.ensure_future_data_access_log_partitions(months_ahead int)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    m date;
+    i int;
+    n int := 0;
+BEGIN
+    IF months_ahead IS NULL OR months_ahead < 0 THEN
+        RETURN 0;
+    END IF;
+    m := date_trunc('month', now())::date;
+    FOR i IN 0..months_ahead LOOP
+        PERFORM public.ensure_data_access_log_partition((m + make_interval(months => i))::date);
+        n := n + 1;
+    END LOOP;
+    RETURN n;
+END$$;
+
+ALTER FUNCTION public.ensure_future_data_access_log_partitions(int) OWNER TO eurobase_migrator;
+REVOKE EXECUTE ON FUNCTION public.ensure_future_data_access_log_partitions(int) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.ensure_future_data_access_log_partitions(int) TO eurobase_gateway;

--- a/migrations/000070_audit_retention.up.sql
+++ b/migrations/000070_audit_retention.up.sql
@@ -85,6 +85,14 @@ GRANT SELECT ON public.audit_log_chain_checkpoints TO eurobase_gateway;
 -- `pg_advisory_xact_lock(hashtext(project_id))` on the same key shape).
 --
 -- Returns total rows deleted across all projects.
+--
+-- Multi-pod safety. Two worker pods that enter this function at the same
+-- time DO race on the head-snapshot SELECT below — but the per-chain
+-- advisory lock taken inside the loop body serializes them, AND we re-do
+-- the "find newest prunable row" probe under the lock, so pod 2 just sees
+-- v_last_seq IS NULL after pod 1 finished and CONTINUEs. Safe today and
+-- under HPA. The cross-project `drop_old_data_access_log_partitions` is
+-- not similarly safe — see its header comment.
 CREATE OR REPLACE FUNCTION public.prune_audit_log(cutoff_days int)
 RETURNS bigint
 LANGUAGE plpgsql
@@ -110,6 +118,15 @@ BEGIN
     -- (newest seq) of each project, and only ever delete rows with
     -- seq < the head's seq. A chain whose head itself is older than
     -- cutoff is left alone — the chain never gets pruned entirely.
+    --
+    -- NOTE on the head_seq subselect: r.head_seq is sampled BEFORE the
+    -- advisory lock is acquired, so it may be stale by the time the loop
+    -- body runs (a writer could have appended a newer head). That is
+    -- safe: a stale (older) head_seq only causes us to UNDER-prune
+    -- (`seq < stale_head` excludes more rows than `seq < real_head`),
+    -- never to delete the actual current head. Do NOT hoist the lock to
+    -- cover the outer SELECT — that would serialize prune across all
+    -- chains and is unnecessary.
     FOR r IN
         SELECT
             COALESCE(project_id::text, '__global__') AS chain_key,
@@ -120,7 +137,8 @@ BEGIN
         GROUP BY project_id
     LOOP
         v_chainkey := r.chain_key;
-        -- Serialize against concurrent appends on the same chain.
+        -- Serialize against concurrent appends on the same chain AND
+        -- against another worker pod also pruning the same chain.
         PERFORM pg_advisory_xact_lock(hashtext(v_chainkey));
 
         -- Find the newest row we're about to delete (highest seq < head
@@ -177,6 +195,22 @@ GRANT  EXECUTE ON FUNCTION public.prune_audit_log(int) TO eurobase_gateway;
 -- `data_access_log_YYYYMM`; we walk pg_class for that pattern and parse
 -- the month out of the name. That's deterministic since every partition
 -- we create goes through that helper.
+--
+-- Multi-pod safety. Without coordination, two pods could enumerate
+-- pg_inherits, both attempt DETACH on the same partition name, and the
+-- loser's error aborts the whole function (the per-iteration EXECUTE has
+-- no savepoint, so subsequent drops in the same call are skipped and
+-- v_dropped is lost). We acquire a single advisory xact lock at function
+-- entry to serialize cross-pod calls — pod 2 blocks behind pod 1, runs
+-- against post-drop state, finds nothing to drop, returns empty. The
+-- lock is held for the duration of the tx (the function's caller commit),
+-- which is fine because retention is a daily housekeeping pass — there
+-- is no hot path waiting on this.
+--
+-- Mis-named partitions (operator created `data_access_log_2026_q1` etc.)
+-- don't match the regex and are silently skipped. Surface that as a
+-- WARNING so an operator notices in logs rather than discovering at the
+-- 13-month horizon that nothing was ever pruned.
 CREATE OR REPLACE FUNCTION public.drop_old_data_access_log_partitions(cutoff_months int)
 RETURNS text[]
 LANGUAGE plpgsql
@@ -184,18 +218,38 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 DECLARE
-    v_cutoff_month date;
-    v_dropped      text[] := ARRAY[]::text[];
-    r              RECORD;
-    v_part_month   date;
+    v_cutoff_month  date;
+    v_dropped       text[] := ARRAY[]::text[];
+    r               RECORD;
+    v_part_month    date;
+    v_unrecognized  int := 0;
 BEGIN
     IF cutoff_months IS NULL OR cutoff_months <= 0 THEN
         RETURN v_dropped;
     END IF;
+
+    -- Cross-pod serialization (see header). hashtext() of a fixed string
+    -- gives a stable int4 lock key.
+    PERFORM pg_advisory_xact_lock(hashtext('data_access_log_retention'));
+
     -- Drop partitions whose covered month ends on or before the cutoff.
     -- Example: cutoff_months=13 + today=2027-03-15 → cutoff_month=2026-02-01;
     -- partitions for 2026-01 or earlier are dropped.
     v_cutoff_month := (date_trunc('month', now()) - make_interval(months => cutoff_months))::date;
+
+    -- Count partitions that DON'T match the YYYYMM convention so an
+    -- operator notices manual partitions accumulating outside the
+    -- retention sweep.
+    SELECT count(*) INTO v_unrecognized
+    FROM   pg_inherits i
+    JOIN   pg_class c    ON c.oid = i.inhrelid
+    JOIN   pg_class pc   ON pc.oid = i.inhparent
+    WHERE  pc.relname = 'data_access_log'
+      AND  c.relname <> 'data_access_log_default'
+      AND  c.relname !~ '^data_access_log_[0-9]{6}$';
+    IF v_unrecognized > 0 THEN
+        RAISE WARNING 'data_access_log retention: % partition(s) skipped — name not in data_access_log_YYYYMM form', v_unrecognized;
+    END IF;
 
     FOR r IN
         SELECT c.relname AS name


### PR DESCRIPTION
Closes #171.

## Summary

Daily retention pass for the two append-only audit streams.

- **`public.audit_log`** — per-project row prune that always preserves the chain head; off by default (\`AUDIT_LOG_RETENTION_DAYS=0\`). The off-box WORM dump (#170) is the long-term store.
- **`public.data_access_log`** — drop monthly partitions past a 13-month horizon (single metadata op, no \`DELETE\` churn); roll the next 12 months forward each tick.
- **Chain integrity through pruning** — new \`audit_log_chain_checkpoints\` table records the last pruned (\`seq\`, \`row_hash\`) per project; \`Verify()\` seeds initial \`prev\` from it so the surviving chain still links cleanly without false positives.
- **WORM bucket policy** — documented in \`docs/compliance/audit-log.md\` so ops can provision the Scaleway fr-par bucket alongside #170 with Object Lock in **Compliance mode** (no-shorten, 7y).

## Why this shape

- Three migrator-owned SECURITY DEFINER helpers (REVOKE EXECUTE FROM PUBLIC, GRANT to \`eurobase_gateway\`) per the CLAUDE.md convention — the worker connects as gateway, which still has no direct DELETE on \`audit_log\` (000058).
- Pruner re-uses the writer's \`pg_advisory_xact_lock(hashtext(chain_key))\` key shape, so retention and appends serialize per-project without a separate lock surface.
- \`prune_audit_log\` selects \`seq < head_seq\` first, then \`DELETE WHERE seq <= v_last_seq\` — the head is impossible to delete by construction (covered by \`TestRetention_PruneNeverDeletesHead\`).
- Partition drop reads partition names directly from \`pg_inherits\` and parses the \`YYYYMM\` suffix — deterministic because every partition is created via \`ensure_data_access_log_partition\` (000066).

## Files

- \`migrations/000070_audit_retention.{up,down}.sql\` — checkpoint table + 3 helpers
- \`internal/audit/verifier.go\` — checkpoint-seeded Verify
- \`internal/audit/retention.go\` + \`retention_test.go\` — Go wrapper + integration tests
- \`internal/workers/audit_retention.go\` — daily ticker (startup + 24h)
- \`cmd/worker/main.go\` — wires \`StartAuditRetention\`
- \`docs/compliance/audit-log.md\` — retention story + WORM bucket policy
- \`docs/compliance/data-access-log.md\` — points partitions section at the live helper

## Config (env on the worker pod)

| Var | Default | Effect |
|---|---|---|
| \`AUDIT_LOG_RETENTION_DAYS\` | \`0\` | never prune \`audit_log\` in DB |
| \`DATA_ACCESS_LOG_RETENTION_MONTHS\` | \`13\` | drop partitions older than 13 months |
| \`DATA_ACCESS_LOG_FUTURE_MONTHS_AHEAD\` | \`12\` | rolling pre-create horizon |

## Test plan

- [x] \`go build ./...\` clean, \`go vet ./...\` clean
- [x] \`go test -short ./internal/audit/ ./internal/workers/\` green
- [ ] CI \`test-go\` runs the new integration tests against a real DB:
  - \`TestRetention_PruneKeepsChainHeadAndVerifies\` — prune leaves head, checkpoint written, Verify still OK
  - \`TestRetention_PruneNeverDeletesHead\` — head with no peers can never be pruned
  - \`TestRetention_EnsureFuturePartitionsIdempotent\` — second call adds 0 partitions
  - \`TestRetention_RunDefaults\` — default config: ensure runs, prune is skipped
- [ ] Manual: deploy to a project, observe worker log line \`audit retention run complete\` with non-zero \`data_access_partitions_ensured\` on startup.

## Follow-ups not in this PR

- The signed object dump itself ships in **#170** (SIEM export). This PR documents the bucket policy that pairs with it; the actual writer + bucket provisioning land there.
- A bounded / paginated variant of \`Verify\` (mentioned as a "future addition" in the existing docs) is still a future addition — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)