### PR TITLE
Fix: surface real errors instead of "function not found" lie

### DIFF
--- a/internal/functions/handler.go
+++ b/internal/functions/handler.go
@@ -2,18 +2,41 @@ package functions
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/eurobase/euroback/internal/plans"
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 )
 
 func jsonError(w http.ResponseWriter, msg string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// writeGetError maps a Service.Get error to the right HTTP shape. Before
+// this, every error was masked as 404 "function not found" — which hid
+// real failures (vault decryption errors after the #206 sealed env_vars
+// migration, schema lookup failures, transient pool errors) behind a
+// lie. The user-visible symptom was: "Function not found" appearing on
+// every function in the console even though they all existed in the DB.
+//
+// Strategy: a true row-miss is a 404 with the original short message;
+// anything else surfaces as 500 with the underlying error string so the
+// operator can see what's actually wrong (e.g. "decrypt env_vars
+// (key_version 1): …"). The original error is also slog'd for ops.
+func writeGetError(w http.ResponseWriter, projectID, name string, err error) {
+	if errors.Is(err, pgx.ErrNoRows) {
+		slog.Info("get edge function: not found", "project_id", projectID, "name", name)
+		jsonError(w, "function not found", http.StatusNotFound)
+		return
+	}
+	slog.Error("get edge function failed", "project_id", projectID, "name", name, "error", err)
+	jsonError(w, err.Error(), http.StatusInternalServerError)
 }
 
 // HandleList returns all edge functions for a project.
@@ -40,8 +63,7 @@ func HandleGet(svc *Service) http.HandlerFunc {
 
 		fn, err := svc.Get(r.Context(), projectID, name)
 		if err != nil {
-			slog.Error("get edge function failed", "project_id", projectID, "name", name, "error", err)
-			jsonError(w, "function not found", http.StatusNotFound)
+			writeGetError(w, projectID, name, err)
 			return
 		}
 
@@ -135,7 +157,7 @@ func HandleListTriggers(svc *Service, trigSvc *TriggerService) http.HandlerFunc 
 
 		fn, err := svc.Get(r.Context(), projectID, name)
 		if err != nil {
-			jsonError(w, "function not found", http.StatusNotFound)
+			writeGetError(w, projectID, name, err)
 			return
 		}
 
@@ -159,7 +181,7 @@ func HandleCreateTrigger(svc *Service, trigSvc *TriggerService) http.HandlerFunc
 
 		fn, err := svc.Get(r.Context(), projectID, name)
 		if err != nil {
-			jsonError(w, "function not found", http.StatusNotFound)
+			writeGetError(w, projectID, name, err)
 			return
 		}
 

--- a/internal/functions/handler_test.go
+++ b/internal/functions/handler_test.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// writeGetError used to be `jsonError(w, "function not found", 404)` for
+// every error path from Service.Get — which masked vault decryption
+// failures (#206 sealed env_vars) and any other real failure behind a
+// 404 lie. The console then displayed "Function not found" on every
+// function the user clicked, because the JS layer takes the backend
+// error message verbatim.
+//
+// These two tests pin the new contract:
+//   * pgx.ErrNoRows  →  404 "function not found"   (real not-found)
+//   * anything else  →  500 with the err.Error()    (real reason surfaced)
+
+func TestWriteGetError_RealNotFoundIs404(t *testing.T) {
+	w := httptest.NewRecorder()
+	wrapped := fmt.Errorf("get edge function %q: %w", "hello", pgx.ErrNoRows)
+	writeGetError(w, "proj-1", "hello", wrapped)
+
+	if w.Code != 404 {
+		t.Errorf("expected 404 for ErrNoRows, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "function not found") {
+		t.Errorf("expected 'function not found' message, got %q", w.Body.String())
+	}
+}
+
+func TestWriteGetError_OtherErrorSurfacesAs500(t *testing.T) {
+	w := httptest.NewRecorder()
+	// Simulate the post-#206 decryption-failure path: an opaque internal
+	// error that has NOTHING to do with the row being missing. The user
+	// must see the real reason or they cannot diagnose.
+	wrapped := errors.New("decrypt env_vars (key_version 1): cipher: message authentication failed")
+	writeGetError(w, "proj-1", "hello", wrapped)
+
+	if w.Code != 500 {
+		t.Errorf("expected 500 for non-not-found error, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "function not found") {
+		t.Errorf("must not mask non-not-found error as 'function not found', body=%q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "decrypt env_vars") {
+		t.Errorf("real error reason missing from response body: %q", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Symptom

Console **Functions** tab shows red banner "Function not found" on every function the user clicks, even though all the functions exist in the DB and the list endpoint returns them correctly.

Reported by user with screenshot of the predwell project's Functions tab — 7 functions visible in the left list, "Function not found" banner above, "Select a function to edit" placeholder in the right pane (because `selectedFn` never gets populated when GET fails).

## Root cause

`internal/functions/handler.go` had three call-sites that collapsed every error from `Service.Get` into a 404 "function not found":

```go
fn, err := svc.Get(...)
if err != nil {
    jsonError(w, "function not found", 404)   // ← the lie
    return
}
```

After the #206 sealed env_vars migration, `Service.Get` calls `resolveEnvVars` which can fail on vault decryption (key version mismatch, missing `VAULT_ENCRYPTION_KEY`, schema lookup error). All of those failure modes were being masked as "function not found" — so the user couldn't tell whether the function was missing or whether something else was broken. The console takes the backend error message verbatim, so the lie appeared in the UI as-is.

## Fix

New `writeGetError` helper:

- `errors.Is(err, pgx.ErrNoRows)` → **404** "function not found" (real not-found, original short message preserved)
- everything else → **500** with `err.Error()` (real reason surfaces; user can act, ops can correlate via slog at `error` level)

Applied to all three masking sites: `HandleGet`, `HandleListTriggers`, `HandleCreateTrigger`.

`handler_test.go` pins both contracts so a future change can't silently re-mask internal failures as 404 again.

## What the user will see next

Once deployed, clicking a predwell function should show the **real** underlying error in the red banner, e.g.

> decrypt env_vars (key_version 1): cipher: message authentication failed

— which we'll then be able to fix at the source (likely a vault key/version mismatch on that project, not a bug in this handler).

## Test plan

- [x] `go build ./...` clean
- [x] `go test -short ./internal/functions/` green (incl. new `TestWriteGetError_RealNotFoundIs404` + `TestWriteGetError_OtherErrorSurfacesAs500`)
- [ ] CI test-go green
- [ ] Manual after deploy: load `/p/{predwell}/auth` → Functions tab → click any function → confirm banner now shows the real reason instead of "Function not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)