### PR TITLE
Fix: scan nullable env_vars_key_version into *int16 (predwell function-not-found)

### DIFF
--- a/internal/functions/env_vars_test.go
+++ b/internal/functions/env_vars_test.go
@@ -95,6 +95,22 @@ func TestNullIfZero(t *testing.T) {
 	}
 }
 
+// TestDerefInt16 pins the read-side counterpart to nullIfZero. The Get
+// queries scan env_vars_key_version into *int16 because the column is
+// nullable (intentionally, for the legacy + empty-env paths). The
+// previous code used a plain `int16` dest and crashed on every function
+// without sealed env_vars with `cannot scan NULL into *int16` — which
+// the old handler then masked as "function not found" (fixed in #242).
+func TestDerefInt16(t *testing.T) {
+	if derefInt16(nil) != 0 {
+		t.Fatal("nil should map to 0 (matches nullIfZero(0))")
+	}
+	v := int16(3)
+	if got := derefInt16(&v); got != 3 {
+		t.Fatalf("non-nil should pass through, got %d", got)
+	}
+}
+
 // mustNewVaultService constructs a VaultService with a throwaway 32-byte
 // master, enough to exercise the seal/open contract end-to-end inside a
 // test that doesn't touch the DB.

--- a/internal/functions/service.go
+++ b/internal/functions/service.go
@@ -165,11 +165,19 @@ func (s *Service) List(ctx context.Context, projectID string) ([]EdgeFunction, e
 }
 
 // Get returns a single edge function by name, including code.
+//
+// Scan dest note: env_vars_key_version is intentionally NULL for rows
+// that aren't sealed (empty env_vars or legacy plaintext path — see the
+// all-or-nothing CHECK in migration 000067 + the nullIfZero adapter in
+// Update). The dest must be a pointer or a sql.Null* type; a plain
+// `int16` panics with `cannot scan NULL into *int16` for the common
+// "no env vars" case. Surfaced by PR #242 once the handler stopped
+// masking it as 404.
 func (s *Service) Get(ctx context.Context, projectID, name string) (*EdgeFunction, error) {
 	var f EdgeFunction
 	var legacy map[string]string
 	var blob, nonce []byte
-	var version int16
+	var version *int16
 	err := s.pool.QueryRow(ctx,
 		`SELECT id, project_id, name, code, verify_jwt,
 		        env_vars, env_vars_blob, env_vars_nonce, env_vars_key_version,
@@ -182,7 +190,7 @@ func (s *Service) Get(ctx context.Context, projectID, name string) (*EdgeFunctio
 	if err != nil {
 		return nil, fmt.Errorf("get edge function %q: %w", name, err)
 	}
-	f.EnvVars, err = s.resolveEnvVars(ctx, f.ProjectID, blob, nonce, version, legacy)
+	f.EnvVars, err = s.resolveEnvVars(ctx, f.ProjectID, blob, nonce, derefInt16(version), legacy)
 	if err != nil {
 		return nil, err
 	}
@@ -190,11 +198,12 @@ func (s *Service) Get(ctx context.Context, projectID, name string) (*EdgeFunctio
 }
 
 // GetByID returns a single edge function by ID, including code.
+// See Get's docstring for the nullable env_vars_key_version contract.
 func (s *Service) GetByID(ctx context.Context, id string) (*EdgeFunction, error) {
 	var f EdgeFunction
 	var legacy map[string]string
 	var blob, nonce []byte
-	var version int16
+	var version *int16
 	err := s.pool.QueryRow(ctx,
 		`SELECT id, project_id, name, code, verify_jwt,
 		        env_vars, env_vars_blob, env_vars_nonce, env_vars_key_version,
@@ -207,11 +216,21 @@ func (s *Service) GetByID(ctx context.Context, id string) (*EdgeFunction, error)
 	if err != nil {
 		return nil, fmt.Errorf("get edge function by id: %w", err)
 	}
-	f.EnvVars, err = s.resolveEnvVars(ctx, f.ProjectID, blob, nonce, version, legacy)
+	f.EnvVars, err = s.resolveEnvVars(ctx, f.ProjectID, blob, nonce, derefInt16(version), legacy)
 	if err != nil {
 		return nil, err
 	}
 	return &f, nil
+}
+
+// derefInt16 turns a nullable scan dest into the int16 resolveEnvVars
+// expects. NULL → 0, which is the same shape the legacy / empty-env
+// paths produce on write (see env_vars_test.go TestNullIfZero).
+func derefInt16(p *int16) int16 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 // CreateRequest is the payload for creating an edge function.


### PR DESCRIPTION
## Symptom (user report on predwell project)

> Get edge function \"create-checkout\": can't scan into dest[8] (col: env_vars_key_version): cannot scan NULL into *int16

— and the same error for every other function in the project. Surfaced by #242 once \`HandleGet\` stopped masking real errors as 404.

## Root cause

Migration 000067 (sealed env_vars, #206) added \`env_vars_key_version SMALLINT\` as a **nullable** column, with an all-or-nothing CHECK so the trio \`(blob, nonce, key_version)\` is either all populated or all NULL. The legacy plaintext path AND the empty-env-vars path both write NULL — the write side uses \`nullIfZero(version)\` exactly for this.

But the read side in \`Service.Get\` and \`Service.GetByID\` scanned the column into a plain \`int16\` dest:

\`\`\`go
var version int16   // ← can't accept NULL
...
.Scan(..., &version, ...)
\`\`\`

So any function without sealed env_vars (legacy, empty, or pre-#206) failed the entire row scan with \`cannot scan NULL into *int16\`. Predwell's functions are all in that bucket.

## Why it slipped through

The existing \`env_vars_test.go\` tests cover \`sealEnvVars\` / \`resolveEnvVars\` in isolation — not the DB scan boundary. CI test-go runs against a DB that only had sealed-from-creation rows in test fixtures. The asymmetry between \`nullIfZero\` on write and a plain \`int16\` on read had no test coverage.

## Fix

Scan into \`*int16\` and dereference (nil → 0) before passing to \`resolveEnvVars\`. The 0 sentinel matches what the write path produces via \`nullIfZero\`, and \`resolveEnvVars\`'s blob-absent early return ignores \`version\` anyway, so no behavioural change for sealed rows.

\`\`\`go
var version *int16
...
.Scan(..., &version, ...)
f.EnvVars, err = s.resolveEnvVars(ctx, f.ProjectID, blob, nonce, derefInt16(version), legacy)
\`\`\`

Both \`Get\` and \`GetByID\` are fixed. New \`TestDerefInt16\` mirrors the existing \`TestNullIfZero\` so the read/write asymmetry can't reappear.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -short ./internal/functions/\` green (\`TestDerefInt16\` + \`TestNullIfZero\` + \`TestResolveEnvVars_Fallback\` all pass)
- [ ] CI test-go green
- [ ] Manual after deploy: predwell Functions tab, click every function → editor loads, no error banner

## Follow-up

Worth adding a CI integration test that creates a function with empty \`env_vars\` then reads it back, to catch this whole class of nullable-column-scan bugs. Not in this PR — small enough as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)